### PR TITLE
Logging cleanup and fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ else
 	@echo "Required golang version is $(REQUIRE_GOVERSION). The current one is $(CURRENT_GOVERSION). Exiting.."
 	@exit 1;
 endif
+	@bash ./scripts/build_plugins.sh
 
 
 cscli_static:

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 
 	"io/ioutil"
@@ -19,7 +18,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"gopkg.in/natefinch/lumberjack.v2"
 	"gopkg.in/tomb.v2"
 	"gopkg.in/yaml.v2"
 )
@@ -38,33 +36,6 @@ var (
 	/*settings*/
 	lastProcessedItem time.Time /*keep track of last item timestamp in time-machine. it is used to GC buckets when we dump them.*/
 )
-
-func configureLogger(logMode string, logFolder string, logLevel log.Level) error {
-	/*Configure logs*/
-	if logMode == "file" {
-		log.SetOutput(&lumberjack.Logger{
-			Filename:   logFolder + "/crowdsec.log",
-			MaxSize:    500, //megabytes
-			MaxBackups: 3,
-			MaxAge:     28,   //days
-			Compress:   true, //disabled by default
-		})
-		log.SetFormatter(&log.TextFormatter{TimestampFormat: "02-01-2006 15:04:05", FullTimestamp: true})
-	} else if logMode != "stdout" {
-		return fmt.Errorf("log mode '%s' unknown", logMode)
-	}
-
-	log.Printf("setting loglevel to %s", logLevel)
-	log.SetLevel(logLevel)
-	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
-	if logLevel >= log.InfoLevel {
-		log.SetFormatter(&log.TextFormatter{TimestampFormat: "02-01-2006 15:04:05", FullTimestamp: true})
-	}
-	if logLevel >= log.DebugLevel {
-		log.SetReportCaller(true)
-	}
-	return nil
-}
 
 func main() {
 	var (
@@ -92,7 +63,7 @@ func main() {
 		log.Fatalf(err.Error())
 	}
 
-	if err = configureLogger(cConfig.LogMode, cConfig.LogFolder, cConfig.LogLevel); err != nil {
+	if err = types.SetDefaultLoggerConfig(cConfig.LogMode, cConfig.LogFolder, cConfig.LogLevel); err != nil {
 		log.Fatal(err.Error())
 	}
 

--- a/config/user.yaml
+++ b/config/user.yaml
@@ -8,9 +8,9 @@ log_mode: stdout
 log_level: info
 profiling: false
 sqlite_path: ${DATA}/crowdsec.db
-apimode: true
+apimode: false
 daemon: false
-prometheus: true
+prometheus: false
 #for prometheus agent / golang debugging
 http_listen: 127.0.0.1:6060
 plugin:

--- a/pkg/leakybucket/manager.go
+++ b/pkg/leakybucket/manager.go
@@ -191,7 +191,7 @@ func LoadBucket(g *BucketFactory) error {
 	var err error
 	if g.Debug {
 		var clog = logrus.New()
-		if types.ConfigureLogger(clog) != err {
+		if err := types.ConfigureLogger(clog); err != nil {
 			log.Fatalf("While creating bucket-specific logger : %s", err)
 		}
 		clog.SetLevel(log.DebugLevel)

--- a/pkg/leakybucket/manager.go
+++ b/pkg/leakybucket/manager.go
@@ -191,7 +191,9 @@ func LoadBucket(g *BucketFactory) error {
 	var err error
 	if g.Debug {
 		var clog = logrus.New()
-		clog.SetFormatter(&log.TextFormatter{FullTimestamp: true})
+		if types.ConfigureLogger(clog) != err {
+			log.Fatalf("While creating bucket-specific logger : %s", err)
+		}
 		clog.SetLevel(log.DebugLevel)
 		g.logger = clog.WithFields(log.Fields{
 			"cfg":  g.BucketName,

--- a/pkg/leakybucket/manager.go
+++ b/pkg/leakybucket/manager.go
@@ -146,7 +146,7 @@ func LoadBuckets(files []string) ([]BucketFactory, chan types.Event, error) {
 			}
 			//check compat
 			if g.FormatVersion == "" {
-				log.Warningf("no version in %s : %s, assuming '1.0'", g.Name, f)
+				log.Debugf("no version in %s : %s, assuming '1.0'", g.Name, f)
 				g.FormatVersion = "1.0"
 			}
 			ok, err := cwversion.Statisfies(g.FormatVersion, cwversion.Constraint_scenario)

--- a/pkg/parser/node.go
+++ b/pkg/parser/node.go
@@ -341,7 +341,7 @@ func (n *Node) compile(pctx *UnixParserCtx) error {
 	that will be used only for processing this node ;) */
 	if n.Debug {
 		var clog = logrus.New()
-		if types.ConfigureLogger(clog) != err {
+		if err := types.ConfigureLogger(clog); err != nil {
 			log.Fatalf("While creating bucket-specific logger : %s", err)
 		}
 		clog.SetLevel(log.DebugLevel)

--- a/pkg/parser/stage.go
+++ b/pkg/parser/stage.go
@@ -76,7 +76,7 @@ func LoadStages(stageFiles []Stagefile, pctx *UnixParserCtx) ([]Node, error) {
 
 			//check for empty bucket
 			if node.Name == "" && node.Description == "" && node.Author == "" {
-				log.Infof("Node has no name,author or description. Skipping.")
+				log.Infof("Node in %s has no name,author or description. Skipping.", stageFile.Filename)
 				continue
 			}
 			//check compat

--- a/pkg/types/utils.go
+++ b/pkg/types/utils.go
@@ -87,7 +87,9 @@ func ConfigureLogger(clog *log.Logger) error {
 	if logReportCaller {
 		clog.SetReportCaller(true)
 	}
-	clog.SetFormatter(logFormatter)
+	if logFormatter != nil {
+		clog.SetFormatter(logFormatter)
+	}
 	clog.SetLevel(logLevel)
 	return nil
 }


### PR DESCRIPTION
 - Ensure node-specific or bucket-specific loggers get a base config similar to main logger
 - Cleanup logging in various spots to provide context or lower verbostiry
 - `user.yaml` doesn't try to start prometheus or use API
