### PR TITLE
add support in cscli to switch branches of hub

### DIFF
--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -117,7 +117,8 @@ API interaction:
 	rootCmd.PersistentFlags().BoolVar(&nfo_lvl, "info", false, "Set logging to info.")
 	rootCmd.PersistentFlags().BoolVar(&wrn_lvl, "warning", false, "Set logging to warning.")
 	rootCmd.PersistentFlags().BoolVar(&err_lvl, "error", false, "Set logging to error.")
-
+	rootCmd.PersistentFlags().StringVar(&cwhub.HUB_BRANCH, "branch", "master", "Override hub branch on github")
+	rootCmd.PersistentFlags().MarkHidden("branch")
 	cobra.OnInitialize(initConfig)
 	/*don't sort flags so we can enforce order*/
 	rootCmd.Flags().SortFlags = false

--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -118,7 +118,9 @@ API interaction:
 	rootCmd.PersistentFlags().BoolVar(&wrn_lvl, "warning", false, "Set logging to warning.")
 	rootCmd.PersistentFlags().BoolVar(&err_lvl, "error", false, "Set logging to error.")
 	rootCmd.PersistentFlags().StringVar(&cwhub.HubBranch, "branch", "master", "Override hub branch on github")
-	rootCmd.PersistentFlags().MarkHidden("branch")
+	if err := rootCmd.PersistentFlags().MarkHidden("branch"); err != nil {
+		log.Fatalf("failed to make branch hidden : %s", err)
+	}
 	cobra.OnInitialize(initConfig)
 	/*don't sort flags so we can enforce order*/
 	rootCmd.Flags().SortFlags = false

--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -117,7 +117,7 @@ API interaction:
 	rootCmd.PersistentFlags().BoolVar(&nfo_lvl, "info", false, "Set logging to info.")
 	rootCmd.PersistentFlags().BoolVar(&wrn_lvl, "warning", false, "Set logging to warning.")
 	rootCmd.PersistentFlags().BoolVar(&err_lvl, "error", false, "Set logging to error.")
-	rootCmd.PersistentFlags().StringVar(&cwhub.HUB_BRANCH, "branch", "master", "Override hub branch on github")
+	rootCmd.PersistentFlags().StringVar(&cwhub.HubBranch, "branch", "master", "Override hub branch on github")
 	rootCmd.PersistentFlags().MarkHidden("branch")
 	cobra.OnInitialize(initConfig)
 	/*don't sort flags so we can enforce order*/

--- a/pkg/cwhub/hubMgmt.go
+++ b/pkg/cwhub/hubMgmt.go
@@ -32,8 +32,9 @@ var Installdir = "/etc/crowdsec/"
 var Hubdir = "/etc/crowdsec/cscli/hub/"
 var Cfgdir = "/etc/crowdsec/cscli/"
 
-var RawFileURLTemplate = "https://raw.githubusercontent.com/crowdsecurity/hub/master/%s"
+var RawFileURLTemplate = "https://raw.githubusercontent.com/crowdsecurity/hub/%s/%s"
 var HUB_INDEX_FILE = ".index.json"
+var HUB_BRANCH = "master"
 
 type ItemVersion struct {
 	Digest     string
@@ -406,7 +407,7 @@ func UpdateHubIdx() error {
 }
 
 func DownloadHubIdx() ([]byte, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf(RawFileURLTemplate, HUB_INDEX_FILE), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf(RawFileURLTemplate, HUB_BRANCH, HUB_INDEX_FILE), nil)
 	if err != nil {
 		log.Errorf("failed request : %s", err)
 		return nil, err
@@ -418,7 +419,7 @@ func DownloadHubIdx() ([]byte, error) {
 	}
 	if resp.StatusCode != 200 {
 		log.Errorf("got code %d while requesting %s, abort", resp.StatusCode,
-			fmt.Sprintf(RawFileURLTemplate, HUB_INDEX_FILE))
+			fmt.Sprintf(RawFileURLTemplate, HUB_BRANCH, HUB_INDEX_FILE))
 		return nil, fmt.Errorf("bad http code")
 	}
 	defer resp.Body.Close()
@@ -678,7 +679,7 @@ func DownloadItem(target Item, tdir string, overwrite bool, dataFolder string) (
 	}
 
 	//log.Infof("Downloading %s to %s", target.Name, tdir)
-	req, err := http.NewRequest("GET", fmt.Sprintf(RawFileURLTemplate, target.RemotePath), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf(RawFileURLTemplate, HUB_BRANCH, target.RemotePath), nil)
 	if err != nil {
 		log.Errorf("%s : request creation failed : %s", target.Name, err)
 		return target, err

--- a/pkg/cwhub/hubMgmt.go
+++ b/pkg/cwhub/hubMgmt.go
@@ -33,8 +33,8 @@ var Hubdir = "/etc/crowdsec/cscli/hub/"
 var Cfgdir = "/etc/crowdsec/cscli/"
 
 var RawFileURLTemplate = "https://raw.githubusercontent.com/crowdsecurity/hub/%s/%s"
-var HUB_INDEX_FILE = ".index.json"
-var HUB_BRANCH = "master"
+var HubIndexFile = ".index.json"
+var HubBranch = "master"
 
 type ItemVersion struct {
 	Digest     string
@@ -407,7 +407,7 @@ func UpdateHubIdx() error {
 }
 
 func DownloadHubIdx() ([]byte, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf(RawFileURLTemplate, HUB_BRANCH, HUB_INDEX_FILE), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf(RawFileURLTemplate, HubBranch, HubIndexFile), nil)
 	if err != nil {
 		log.Errorf("failed request : %s", err)
 		return nil, err
@@ -419,7 +419,7 @@ func DownloadHubIdx() ([]byte, error) {
 	}
 	if resp.StatusCode != 200 {
 		log.Errorf("got code %d while requesting %s, abort", resp.StatusCode,
-			fmt.Sprintf(RawFileURLTemplate, HUB_BRANCH, HUB_INDEX_FILE))
+			fmt.Sprintf(RawFileURLTemplate, HubBranch, HubIndexFile))
 		return nil, fmt.Errorf("bad http code")
 	}
 	defer resp.Body.Close()
@@ -679,7 +679,7 @@ func DownloadItem(target Item, tdir string, overwrite bool, dataFolder string) (
 	}
 
 	//log.Infof("Downloading %s to %s", target.Name, tdir)
-	req, err := http.NewRequest("GET", fmt.Sprintf(RawFileURLTemplate, HUB_BRANCH, target.RemotePath), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf(RawFileURLTemplate, HubBranch, target.RemotePath), nil)
 	if err != nil {
 		log.Errorf("%s : request creation failed : %s", target.Name, err)
 		return target, err


### PR DESCRIPTION
Add a global hidden flag `--branch` to `cscli` : this flag sets `cwhub.HUB_BRANCH` variable that is used by `cwhub` to download index or scenarios.

