### PR TITLE
fix #47 #35

### DIFF
--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -53,6 +53,9 @@ func initConfig() {
 	/*read config*/
 	config.InstallFolder = filepath.Clean(csConfig.ConfigFolder)
 	config.HubFolder = filepath.Clean(config.configFolder + "/hub/")
+	if csConfig.OutputConfig == nil {
+		log.Fatalf("Missing backend plugin configuration in %s", config.ConfigFilePath)
+	}
 	config.BackendPluginFolder = filepath.Clean(csConfig.OutputConfig.BackendFolder)
 	config.DataFolder = filepath.Clean(csConfig.DataFolder)
 	//

--- a/pkg/leakybucket/manager.go
+++ b/pkg/leakybucket/manager.go
@@ -168,8 +168,8 @@ func LoadBuckets(files []string, dataFolder string) ([]BucketFactory, chan types
 			g.ret = response
 			err = LoadBucket(&g, dataFolder)
 			if err != nil {
-				log.Errorf("Failed to load bucket : %v", err)
-				return nil, nil, fmt.Errorf("loadBucket failed : %v", err)
+				log.Errorf("Failed to load bucket %s : %v", g.Name, err)
+				return nil, nil, fmt.Errorf("loading of %s failed : %v", g.Name, err)
 			}
 			ret = append(ret, g)
 		}


### PR DESCRIPTION
 - fix #47 : Properly display the invalid scenario name when we can't load it
 - fix #35 : Don't stacktrace if the config is empty
