### PR TITLE
add a 'Upper' expr helper

### DIFF
--- a/pkg/exprhelpers/exprlib.go
+++ b/pkg/exprhelpers/exprlib.go
@@ -24,14 +24,6 @@ func Atof(x string) float64 {
 	return ret
 }
 
-func StartsWith(s string, pref string) bool {
-	return strings.HasPrefix(s, pref)
-}
-
-func EndsWith(s string, suff string) bool {
-	return strings.HasSuffix(s, suff)
-}
-
 func Upper(s string) string {
 	return strings.ToUpper(s)
 }
@@ -39,8 +31,6 @@ func Upper(s string) string {
 func GetExprEnv(ctx map[string]interface{}) map[string]interface{} {
 	var ExprLib = map[string]interface{}{
 		"Atof":           Atof,
-		"StartsWith":     StartsWith,
-		"EndsWith":       EndsWith,
 		"JsonExtract":    JsonExtract,
 		"JsonExtractLib": JsonExtractLib,
 		"File":           File,

--- a/pkg/exprhelpers/exprlib.go
+++ b/pkg/exprhelpers/exprlib.go
@@ -32,15 +32,20 @@ func EndsWith(s string, suff string) bool {
 	return strings.HasSuffix(s, suff)
 }
 
+func Upper(s string) string {
+	return strings.ToUpper(s)
+}
+
 func GetExprEnv(ctx map[string]interface{}) map[string]interface{} {
 	var ExprLib = map[string]interface{}{
-		"Atof": Atof,
-		"StartsWith": StartsWith,
-		"EndsWith" : EndsWith,
-		"JsonExtract": JsonExtract,
+		"Atof":           Atof,
+		"StartsWith":     StartsWith,
+		"EndsWith":       EndsWith,
+		"JsonExtract":    JsonExtract,
 		"JsonExtractLib": JsonExtractLib,
-		"File": File,
-		"RegexpInFile": RegexpInFile,
+		"File":           File,
+		"RegexpInFile":   RegexpInFile,
+		"Upper":          Upper,
 	}
 	for k, v := range ctx {
 		ExprLib[k] = v


### PR DESCRIPTION
- add a 'Upper' expr helper. It is useful for various string matches (at least for the SQLi probing scenario)
 - remove startsWith and endsWith overlapping with operators