### PR TITLE
fix #55 : fast service shutdown

### DIFF
--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -26,8 +26,6 @@ func termHandler(sig os.Signal) error {
 		log.Warningf("Acquisition returned error : %s", err)
 	}
 	log.Infof("acquisition is finished, wait for parser/bucket/ouputs.")
-	//let's wait more than enough for in-flight events to be parsed.
-	time.Sleep(5 * time.Second)
 	parsersTomb.Kill(nil)
 	if err := parsersTomb.Wait(); err != nil {
 		log.Warningf("Parsers returned error : %s", err)


### PR DESCRIPTION
now that we have split the code for external shutdown (service) and one-shot, we don't need the 5s sleep anymore (avoid the 5+ seconds of delay)

```bash
# time systemctl  stop crowdsec

real	0m0,031s
user	0m0,004s
```

