### PR TITLE
wizard: fix unattended mode

### DIFF
--- a/wizard.sh
+++ b/wizard.sh
@@ -457,9 +457,8 @@ main() {
 
         if [[ ${SILENT} == "false" ]]; then
             (systemctl start crowdsec && log_info "crowdsec started") || log_err "unable to start crowdsec. exiting"
+            ${CSCLI_BIN_INSTALLED} api pull
         fi;
-
-        ${CSCLI_BIN_INSTALLED} api pull
         # Set the cscli api pull cronjob 
         setup_cron_pull
 

--- a/wizard.sh
+++ b/wizard.sh
@@ -455,8 +455,9 @@ main() {
         ${CSCLI_BIN_INSTALLED} api register >> /etc/crowdsec/config/api.yaml || ${CSCLI_BIN_INSTALLED} api reset >> /etc/crowdsec/config/api.yaml || log_err "unable to register, skipping crowdsec api registration"
         log_info "Crowdsec api registered"
 
-
-        (systemctl start crowdsec && log_info "crowdsec started") || log_err "unable to start crowdsec. exiting"
+        if [[ ${SILENT} == "false" ]]; then
+            (systemctl start crowdsec && log_info "crowdsec started") || log_err "unable to start crowdsec. exiting"
+        fi;
 
         ${CSCLI_BIN_INSTALLED} api pull
         # Set the cscli api pull cronjob 


### PR DESCRIPTION
When unattended mode is set, don't :
* start crowdsec service 
* pull API data

Because there is no scenarios/parsers installed yet and the api configuration isn't done.