### PR TITLE
fix #60 - sqlite lock + badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 <p align="center">
 <img src="https://github.com/crowdsecurity/crowdsec/workflows/Go/badge.svg">
 <img src="https://github.com/crowdsecurity/crowdsec/workflows/build-binary-package/badge.svg">
+<img src="https://goreportcard.com/badge/github.com/crowdsecurity/crowdsec">
+<img src="https://img.shields.io/github/license/crowdsecurity/crowdsec">
 </p>
 
 <p align="center">

--- a/pkg/sqlite/commit.go
+++ b/pkg/sqlite/commit.go
@@ -5,8 +5,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	sqlite3 "github.com/mattn/go-sqlite3"
-
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -16,13 +14,8 @@ func (c *Context) Flush() error {
 	defer c.lock.Unlock()
 
 	ret := c.tx.Commit()
+
 	if ret.Error != nil {
-		/*if the database is locked, don't overwrite the current transaction*/
-		if ret.Error == sqlite3.ErrLocked {
-			log.Errorf("sqlite commit : db is locked : %s", ret.Error)
-			return ret.Error
-		}
-		/*if it's another error, create a new transaction to avoid locking ourselves in a bad state ?*/
 		c.tx = c.Db.Begin()
 		return fmt.Errorf("failed to commit records : %v", ret.Error)
 	}


### PR DESCRIPTION
 - fix #60 :

SQLite doesn't support concurrency too well, and in some cases we might try to write on a locked database. It happens in #60 when crowdsec and metabase are concurrently doing things.

This makes it non-fatal, and we'll try to comit later :)

 - add badges : because you know ... badges !

