### PR TITLE
Release builder : Get version from git tag rather than RELEASE.json

### DIFF
--- a/.github/workflows/build-binary-package.yml
+++ b/.github/workflows/build-binary-package.yml
@@ -17,11 +17,6 @@ jobs:
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-    - name: Check tag == json version
-      run: |
-        jsonver=$(cat RELEASE.json | jq -r .Version)
-        lasttag=$(git for-each-ref --sort=-v:refname --count=1 --format '%(refname)'  | cut -d '/' -f3)
-        if [ ${jsonver} != ${lasttag} ] ; then echo "version mismatch : ${jsonver} in json, ${lasttag} in git" ; exit 2 ; else echo "${jsonver} == ${lasttag}" ; fi
     - name: Build the binaries
       run: make release
     - name: Upload to release

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ REQUIRE_GOVERSION="1.13"
 
 
 #Current versioning information from env
-export BUILD_VERSION=$(shell cat RELEASE.json | jq -r .Version)
+export BUILD_VERSION="$(shell git for-each-ref --sort=-v:refname --count=1 --format '%(refname)'  | cut -d '/' -f3)"
 export BUILD_GOVERSION="$(shell go version | cut -d " " -f3 | sed -r 's/[go]+//g')"
 export BUILD_CODENAME=$(shell cat RELEASE.json | jq -r .CodeName)
 export BUILD_TIMESTAMP=$(shell date +%F"_"%T)

--- a/RELEASE.json
+++ b/RELEASE.json
@@ -1,4 +1,3 @@
 {
-    "Version": "v0.1.2",
     "CodeName": "beta"
 }


### PR DESCRIPTION
 - remove requirement for version in RELEASE.json, the version is guessed from the git tag
 - Remove the CI check that RELEASE.json == git tag
