### PR TITLE
fix #73 : `cscli metrics` error with atoi

### DIFF
--- a/cmd/crowdsec-cli/metrics.go
+++ b/cmd/crowdsec-cli/metrics.go
@@ -62,10 +62,11 @@ func ShowPrometheus(url string) {
 				log.Debugf("no source in Metric")
 			}
 			value := m.(prom2json.Metric).Value
-			ival, err := strconv.Atoi(value)
+			fval, err := strconv.ParseFloat(value, 32)
 			if err != nil {
 				log.Errorf("Unexpected int value %s : %s", value, err)
 			}
+			ival := int(fval)
 			switch fam.Name {
 			/*buckets*/
 			case "cs_bucket_create":


### PR DESCRIPTION
When prometheus's metrics are in scientific notation `XXe+0XX`, atoi will lead to error, treat it as float instead.
