### PR TITLE
Sqlite : Support automatic db flushing

### DIFF
--- a/cmd/crowdsec-cli/api.go
+++ b/cmd/crowdsec-cli/api.go
@@ -152,8 +152,9 @@ cscli api credentials   # Display your API credentials
 
 			outputConfig := outputs.OutputFactory{
 				BackendFolder: config.BackendPluginFolder,
+				Flush:         false,
 			}
-			outputCTX, err = outputs.NewOutput(&outputConfig, false)
+			outputCTX, err = outputs.NewOutput(&outputConfig)
 			if err != nil {
 				return err
 			}

--- a/cmd/crowdsec-cli/backup-restore.go
+++ b/cmd/crowdsec-cli/backup-restore.go
@@ -412,8 +412,9 @@ cscli backup restore ./my-backup`,
 
 			outputConfig := outputs.OutputFactory{
 				BackendFolder: config.BackendPluginFolder,
+				Flush:         false,
 			}
-			outputCTX, err = outputs.NewOutput(&outputConfig, false)
+			outputCTX, err = outputs.NewOutput(&outputConfig)
 			if err != nil {
 				log.Fatalf("Failed to load output plugins")
 			}
@@ -453,8 +454,9 @@ cscli backup restore ./my-backup`,
 
 			outputConfig := outputs.OutputFactory{
 				BackendFolder: config.BackendPluginFolder,
+				Flush:         false,
 			}
-			outputCTX, err = outputs.NewOutput(&outputConfig, false)
+			outputCTX, err = outputs.NewOutput(&outputConfig)
 			if err != nil {
 				log.Fatalf("Failed to load output plugins")
 			}

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -183,9 +183,10 @@ You can add/delete/list or flush current bans in your local ban DB.`,
 
 			outputConfig := outputs.OutputFactory{
 				BackendFolder: config.BackendPluginFolder,
+				Flush:         false,
 			}
 
-			outputCTX, err = outputs.NewOutput(&outputConfig, false)
+			outputCTX, err = outputs.NewOutput(&outputConfig)
 			if err != nil {
 				return fmt.Errorf(err.Error())
 			}

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -162,7 +162,7 @@ func BanAdd(target string, duration string, reason string, action string) error 
 	if err != nil {
 		return err
 	}
-	log.Infof("Wrote ban to database.")
+	log.Infof("%s %s for %s (%s)", action, target, duration, reason)
 	return nil
 }
 

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -216,9 +216,10 @@ cscli ban add range 1.2.3.0/24 24h "the whole range"`,
 		Short:   "Adds the specific ip to the ban db",
 		Long:    `Duration must be [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration), expressed in s/m/h.`,
 		Example: `cscli ban add ip 1.2.3.4 12h "the scan"`,
-		Args:    cobra.ExactArgs(3),
+		Args:    cobra.MinimumNArgs(3),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := BanAdd(args[0], args[1], args[2], remediationType); err != nil {
+			reason := strings.Join(args[2:], " ")
+			if err := BanAdd(args[0], args[1], reason, remediationType); err != nil {
 				log.Fatalf("failed to add ban to sqlite : %v", err)
 			}
 		},
@@ -229,9 +230,10 @@ cscli ban add range 1.2.3.0/24 24h "the whole range"`,
 		Short:   "Adds the specific ip to the ban db",
 		Long:    `Duration must be [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) compatible, expressed in s/m/h.`,
 		Example: `cscli ban add range 1.2.3.0/24 12h "the whole range"`,
-		Args:    cobra.ExactArgs(3),
+		Args:    cobra.MinimumNArgs(3),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := BanAdd(args[0], args[1], args[2], remediationType); err != nil {
+			reason := strings.Join(args[2:], " ")
+			if err := BanAdd(args[0], args[1], reason, remediationType); err != nil {
 				log.Fatalf("failed to add ban to sqlite : %v", err)
 			}
 		},

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -155,6 +155,8 @@ func LoadOutputs(cConfig *csconfig.CrowdSec) error {
 	if cConfig.SingleFile != "" {
 		log.Infof("forensic mode, disable flush")
 		cConfig.OutputConfig.Flush = false
+	} else {
+		cConfig.OutputConfig.Flush = true
 	}
 	OutputRunner, err = outputs.NewOutput(cConfig.OutputConfig)
 	if err != nil {

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -151,7 +151,12 @@ func LoadOutputs(cConfig *csconfig.CrowdSec) error {
 		return fmt.Errorf("Failed to load output profiles : %v", err)
 	}
 
-	OutputRunner, err = outputs.NewOutput(cConfig.OutputConfig, cConfig.Daemonize)
+	//If the user is providing a single file (ie forensic mode), don't flush expired records
+	if cConfig.SingleFile != "" {
+		log.Infof("forensic mode, disable flush")
+		cConfig.OutputConfig.Flush = false
+	}
+	OutputRunner, err = outputs.NewOutput(cConfig.OutputConfig)
 	if err != nil {
 		return fmt.Errorf("output plugins initialization error : %s", err.Error())
 	}
@@ -280,7 +285,6 @@ func main() {
 
 	if err := LoadBuckets(cConfig); err != nil {
 		log.Fatalf("Failed to load scenarios: %s", err)
-
 	}
 
 	if err := LoadOutputs(cConfig); err != nil {

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/outputs"
 	"github.com/crowdsecurity/crowdsec/pkg/parser"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
+	"github.com/pkg/errors"
 	"github.com/sevlyar/go-daemon"
 
 	log "github.com/sirupsen/logrus"
@@ -161,6 +162,10 @@ func LoadOutputs(cConfig *csconfig.CrowdSec) error {
 	OutputRunner, err = outputs.NewOutput(cConfig.OutputConfig)
 	if err != nil {
 		return fmt.Errorf("output plugins initialization error : %s", err.Error())
+	}
+
+	if err := OutputRunner.StartAutoCommit(); err != nil {
+		return errors.Wrap(err, "failed to start autocommit")
 	}
 
 	/* Init the API connector */

--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -129,8 +129,6 @@ func termHandler(sig os.Signal) error {
 }
 
 func serveOneTimeRun(outputRunner outputs.Output) error {
-	log.Infof("waiting for acquisition to finish")
-
 	if err := acquisTomb.Wait(); err != nil {
 		log.Warningf("acquisition returned error : %s", err)
 	}

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -6,6 +6,7 @@ cscli_dir: "./config/crowdsec-cli"
 log_dir: "./logs"
 log_mode: "stdout"
 log_level: info
+prometheus: true
 profiling: false
 apimode: false
 plugin:

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -7,7 +7,9 @@ log_dir: "./logs"
 log_mode: "stdout"
 log_level: info
 profiling: false
-sqlite_path: "./test.db"
 apimode: false
 plugin:
   backend: "./config/plugins/backend"
+  max_records: 10000
+  max_records_age: 60d
+  

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -11,5 +11,6 @@ apimode: false
 plugin:
   backend: "./config/plugins/backend"
   max_records: 10000
-  max_records_age: 60d
+  #30 days = 720 hours
+  max_records_age: 720h
   

--- a/config/plugins/backend/sqlite.yaml
+++ b/config/plugins/backend/sqlite.yaml
@@ -2,4 +2,3 @@ name: sqlite
 path: /usr/local/lib/crowdsec/plugins/backend/sqlite.so
 config:
   db_path: /var/lib/crowdsec/data/crowdsec.db
-  flush: true

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -14,3 +14,4 @@ prometheus: true
 http_listen: 127.0.0.1:6060
 plugin:
   backend: "/etc/crowdsec/plugins/backend"
+  max_records_age: 30d

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -7,7 +7,6 @@ cscli_dir: ${CFG}/cscli
 log_mode: file
 log_level: info
 profiling: false
-sqlite_path: ${DATA}/crowdsec.db
 apimode: true
 daemon: true
 prometheus: true

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -14,4 +14,4 @@ prometheus: true
 http_listen: 127.0.0.1:6060
 plugin:
   backend: "/etc/crowdsec/plugins/backend"
-  max_records_age: 30d
+  max_records_age: 720h

--- a/config/user.yaml
+++ b/config/user.yaml
@@ -7,7 +7,6 @@ cscli_dir: ${CFG}/cscli
 log_mode: stdout
 log_level: info
 profiling: false
-sqlite_path: ${DATA}/crowdsec.db
 apimode: false
 daemon: false
 prometheus: false

--- a/pkg/csconfig/config.go
+++ b/pkg/csconfig/config.go
@@ -25,14 +25,13 @@ type CrowdSec struct {
 	SingleFileLabel string    //for forensic mode
 	PIDFolder       string    `yaml:"pid_dir,omitempty"`
 	LogFolder       string    `yaml:"log_dir,omitempty"`
-	LogMode         string    `yaml:"log_mode,omitempty"`    //like file, syslog or stdout ?
-	LogLevel        log.Level `yaml:"log_level,omitempty"`   //trace,debug,info,warning,error
-	Daemonize       bool      `yaml:"daemon,omitempty"`      //true -> go background
-	Profiling       bool      `yaml:"profiling,omitempty"`   //true -> enable runtime profiling
-	SQLiteFile      string    `yaml:"sqlite_path,omitempty"` //path to sqlite output
-	APIMode         bool      `yaml:"apimode,omitempty"`     //true -> enable api push
-	CsCliFolder     string    `yaml:"cscli_dir"`             //cscli folder
-	NbParsers       int       `yaml:"parser_routines"`       //the number of go routines to start for parsing
+	LogMode         string    `yaml:"log_mode,omitempty"`  //like file, syslog or stdout ?
+	LogLevel        log.Level `yaml:"log_level,omitempty"` //trace,debug,info,warning,error
+	Daemonize       bool      `yaml:"daemon,omitempty"`    //true -> go background
+	Profiling       bool      `yaml:"profiling,omitempty"` //true -> enable runtime profiling
+	APIMode         bool      `yaml:"apimode,omitempty"`   //true -> enable api push
+	CsCliFolder     string    `yaml:"cscli_dir"`           //cscli folder
+	NbParsers       int       `yaml:"parser_routines"`     //the number of go routines to start for parsing
 	Linter          bool
 	Prometheus      bool
 	HTTPListen      string `yaml:"http_listen,omitempty"`
@@ -53,7 +52,6 @@ func NewCrowdSecConfig() *CrowdSec {
 		PIDFolder:     "/var/run/",
 		LogFolder:     "/var/log/",
 		LogMode:       "stdout",
-		SQLiteFile:    "/var/lib/crowdsec/data/crowdsec.db",
 		APIMode:       false,
 		NbParsers:     1,
 		Prometheus:    false,
@@ -89,7 +87,6 @@ func (c *CrowdSec) GetOPT() error {
 	printInfo := flag.Bool("info", false, "print info-level on stdout")
 	printVersion := flag.Bool("version", false, "display version")
 	APIMode := flag.Bool("api", false, "perform pushes to api")
-	SQLiteMode := flag.Bool("sqlite", true, "write overflows to sqlite")
 	profileMode := flag.Bool("profile", false, "Enable performance profiling")
 	catFile := flag.String("file", "", "Process a single file in time-machine")
 	catFileType := flag.String("type", "", "Labels.type for file in time-machine")
@@ -155,9 +152,6 @@ func (c *CrowdSec) GetOPT() error {
 	}
 	if *printTrace {
 		c.LogLevel = log.TraceLevel
-	}
-	if !*SQLiteMode {
-		c.SQLiteFile = ""
 	}
 	if *APIMode {
 		c.APIMode = true

--- a/pkg/cwplugin/backend.go
+++ b/pkg/cwplugin/backend.go
@@ -99,6 +99,13 @@ func NewBackendPlugin(outputConfig map[string]string) (*BackendManager, error) {
 		// Add the interface and Init()
 		newPlugin.funcs = bInterface
 		// Merge backend config from main config file
+		// Merge backend config from main config file
+		if v, ok := outputConfig["debug"]; ok {
+			newPlugin.Config["debug"] = v
+		} else {
+			newPlugin.Config["debug"] = "false"
+		}
+
 		if v, ok := outputConfig["max_records"]; ok {
 			newPlugin.Config["max_records"] = v
 		} else {

--- a/pkg/cwplugin/backend.go
+++ b/pkg/cwplugin/backend.go
@@ -39,6 +39,10 @@ type BackendManager struct {
 	backendPlugins map[string]BackendPlugin
 }
 
+var defaultMaxRecords = "1000"
+var defaultMaxRecordsAge = "30d"
+var defaultDbDebug = "false"
+
 func NewBackendPlugin(outputConfig map[string]string) (*BackendManager, error) {
 	var files []string
 	var backendManager = &BackendManager{}
@@ -98,25 +102,21 @@ func NewBackendPlugin(outputConfig map[string]string) (*BackendManager, error) {
 
 		// Add the interface and Init()
 		newPlugin.funcs = bInterface
+		newPlugin.Config["debug"] = defaultDbDebug
+		newPlugin.Config["max_records"] = defaultMaxRecords
+		newPlugin.Config["max_records_age"] = defaultMaxRecordsAge
+
 		// Merge backend config from main config file
 		if v, ok := outputConfig["debug"]; ok {
 			newPlugin.Config["debug"] = v
-		} else {
-			newPlugin.Config["debug"] = "false"
 		}
 
 		if v, ok := outputConfig["max_records"]; ok {
 			newPlugin.Config["max_records"] = v
-		} else {
-			log.Warningf("missing 'max_records' parameters, setting to default (1000)")
-			newPlugin.Config["max_records"] = "1000"
 		}
 
 		if v, ok := outputConfig["max_records_age"]; ok {
 			newPlugin.Config["max_records_age"] = v
-		} else {
-			log.Warningf("missing 'max_records_age' parameters, setting to default (30d)")
-			newPlugin.Config["max_records_age"] = "30d"
 		}
 
 		err = newPlugin.funcs.Init(newPlugin.Config)

--- a/pkg/cwplugin/backend.go
+++ b/pkg/cwplugin/backend.go
@@ -99,7 +99,6 @@ func NewBackendPlugin(outputConfig map[string]string) (*BackendManager, error) {
 		// Add the interface and Init()
 		newPlugin.funcs = bInterface
 		// Merge backend config from main config file
-		// Merge backend config from main config file
 		if v, ok := outputConfig["debug"]; ok {
 			newPlugin.Config["debug"] = v
 		} else {

--- a/pkg/cwplugin/backend.go
+++ b/pkg/cwplugin/backend.go
@@ -22,6 +22,7 @@ type Backend interface {
 	Flush() error
 	Shutdown() error
 	DeleteAll() error
+	StartAutoCommit() error
 }
 
 type BackendPlugin struct {
@@ -194,6 +195,17 @@ func (b *BackendManager) IsBackendPlugin(plugin string) bool {
 		return true
 	}
 	return false
+}
+
+func (b *BackendManager) StartAutoCommit() error {
+	var err error
+	for _, plugin := range b.backendPlugins {
+		err = plugin.funcs.StartAutoCommit()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (b *BackendManager) ReadAT(timeAT time.Time) ([]map[string]string, error) {

--- a/pkg/cwplugin/backend.go
+++ b/pkg/cwplugin/backend.go
@@ -119,7 +119,7 @@ func NewBackendPlugin(outputConfig map[string]string) (*BackendManager, error) {
 		if err != nil {
 			return nil, fmt.Errorf("plugin '%s' init error : %s", newPlugin.Name, err)
 		}
-		log.Infof("backend plugin '%s' loaded", newPlugin.Name)
+		log.Debugf("backend plugin '%s' loaded", newPlugin.Name)
 		backendManager.backendPlugins[newPlugin.Name] = newPlugin
 
 	}

--- a/pkg/cwplugin/backend.go
+++ b/pkg/cwplugin/backend.go
@@ -39,10 +39,6 @@ type BackendManager struct {
 	backendPlugins map[string]BackendPlugin
 }
 
-var defaultMaxRecords = "1000"
-var defaultMaxRecordsAge = "30d"
-var defaultDbDebug = "false"
-
 func NewBackendPlugin(outputConfig map[string]string) (*BackendManager, error) {
 	var files []string
 	var backendManager = &BackendManager{}
@@ -102,10 +98,6 @@ func NewBackendPlugin(outputConfig map[string]string) (*BackendManager, error) {
 
 		// Add the interface and Init()
 		newPlugin.funcs = bInterface
-		newPlugin.Config["debug"] = defaultDbDebug
-		newPlugin.Config["max_records"] = defaultMaxRecords
-		newPlugin.Config["max_records_age"] = defaultMaxRecordsAge
-
 		// Merge backend config from main config file
 		if v, ok := outputConfig["debug"]; ok {
 			newPlugin.Config["debug"] = v
@@ -117,6 +109,10 @@ func NewBackendPlugin(outputConfig map[string]string) (*BackendManager, error) {
 
 		if v, ok := outputConfig["max_records_age"]; ok {
 			newPlugin.Config["max_records_age"] = v
+		}
+
+		if v, ok := outputConfig["flush"]; ok {
+			newPlugin.Config["flush"] = v
 		}
 
 		err = newPlugin.funcs.Init(newPlugin.Config)

--- a/pkg/exprhelpers/exprlib.go
+++ b/pkg/exprhelpers/exprlib.go
@@ -44,7 +44,6 @@ func GetExprEnv(ctx map[string]interface{}) map[string]interface{} {
 }
 
 func Init() error {
-	log.Infof("Expr helper initiated")
 	dataFile = make(map[string][]string)
 	dataFileRegex = make(map[string][]*regexp.Regexp)
 	return nil

--- a/pkg/outputs/ouputs.go
+++ b/pkg/outputs/ouputs.go
@@ -27,7 +27,8 @@ type OutputFactory struct {
 	//For the db GC what is the oldest records we tolerate
 	MaxRecordsAge string `yaml:"max_records_age"`
 	//Should we automatically flush expired bans
-	Flush bool `yaml:"flush"`
+	Flush bool
+	Debug bool `yaml:"debug"`
 }
 
 //Output holds the runtime objects of backend
@@ -329,7 +330,8 @@ func NewOutput(config *OutputFactory) (*Output, error) {
 		"backend":         config.BackendFolder,
 		"max_records":     config.MaxRecords,
 		"max_records_age": config.MaxRecordsAge,
-		"flush":           strconv.FormatBool(config.Flush)}
+		"flush":           strconv.FormatBool(config.Flush),
+		"debug":           strconv.FormatBool(config.Debug)}
 	output.bManager, err = cwplugin.NewBackendPlugin(backendConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load backend plugin")

--- a/pkg/outputs/ouputs.go
+++ b/pkg/outputs/ouputs.go
@@ -91,6 +91,10 @@ func OvflwToOrder(sig types.SignalOccurence, prof types.Profile) (*types.BanOrde
 	return &ordr, nil, warn
 }
 
+func (o *Output) StartAutoCommit() error {
+	return o.bManager.StartAutoCommit()
+}
+
 func (o *Output) Shutdown() error {
 	var reterr error
 	if o.API != nil {

--- a/pkg/outputs/ouputs.go
+++ b/pkg/outputs/ouputs.go
@@ -21,11 +21,11 @@ import (
 
 //OutputFactory is part of the main yaml configuration file, and holds generic backend config
 type OutputFactory struct {
-	BackendFolder string `yaml:"backend"`
+	BackendFolder string `yaml:"backend,omitempty"`
 	//For the db GC : how many records can we keep at most
-	MaxRecords string `yaml:"max_records"`
+	MaxRecords string `yaml:"max_records,omitempty"`
 	//For the db GC what is the oldest records we tolerate
-	MaxRecordsAge string `yaml:"max_records_age"`
+	MaxRecordsAge string `yaml:"max_records_age,omitempty"`
 	//Should we automatically flush expired bans
 	Flush bool
 	Debug bool `yaml:"debug"`

--- a/pkg/outputs/ouputs.go
+++ b/pkg/outputs/ouputs.go
@@ -328,10 +328,16 @@ func NewOutput(config *OutputFactory) (*Output, error) {
 	//turn the *OutputFactory into a map[string]string for less constraint
 	backendConfig := map[string]string{
 		"backend":         config.BackendFolder,
-		"max_records":     config.MaxRecords,
-		"max_records_age": config.MaxRecordsAge,
 		"flush":           strconv.FormatBool(config.Flush),
 		"debug":           strconv.FormatBool(config.Debug)}
+
+	if config.MaxRecords != "" {
+		backendConfig["max_records"] = config.MaxRecords,
+	}
+	if config.MaxRecordsAge != "" {
+		backendConfig["max_records_age"] = config.MaxRecordsAge,
+	}
+	
 	output.bManager, err = cwplugin.NewBackendPlugin(backendConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load backend plugin")

--- a/pkg/outputs/ouputs.go
+++ b/pkg/outputs/ouputs.go
@@ -327,17 +327,17 @@ func NewOutput(config *OutputFactory) (*Output, error) {
 	log.Debugf("loading backend plugins ...")
 	//turn the *OutputFactory into a map[string]string for less constraint
 	backendConfig := map[string]string{
-		"backend":         config.BackendFolder,
-		"flush":           strconv.FormatBool(config.Flush),
-		"debug":           strconv.FormatBool(config.Debug)}
+		"backend": config.BackendFolder,
+		"flush":   strconv.FormatBool(config.Flush),
+		"debug":   strconv.FormatBool(config.Debug)}
 
 	if config.MaxRecords != "" {
-		backendConfig["max_records"] = config.MaxRecords,
+		backendConfig["max_records"] = config.MaxRecords
 	}
 	if config.MaxRecordsAge != "" {
-		backendConfig["max_records_age"] = config.MaxRecordsAge,
+		backendConfig["max_records_age"] = config.MaxRecordsAge
 	}
-	
+
 	output.bManager, err = cwplugin.NewBackendPlugin(backendConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load backend plugin")

--- a/pkg/parser/stage.go
+++ b/pkg/parser/stage.go
@@ -133,7 +133,8 @@ func LoadStages(stageFiles []Stagefile, pctx *UnixParserCtx) ([]Node, error) {
 		pctx.Stages = append(pctx.Stages, k)
 	}
 	sort.Strings(pctx.Stages)
-	log.Infof("Stages loaded: %+v", pctx.Stages)
+	log.Infof("Loaded %d nodes, %d stages", len(nodes), len(pctx.Stages))
+
 	return nodes, nil
 }
 

--- a/pkg/sqlite/commit.go
+++ b/pkg/sqlite/commit.go
@@ -17,8 +17,6 @@ func (c *Context) DeleteExpired() error {
 		if retx.RowsAffected > 0 {
 			log.Infof("Flushed %d expired entries from Ban Application", retx.RowsAffected)
 		}
-	} else {
-		log.Infof("flush is disabled")
 	}
 	return nil
 }
@@ -136,6 +134,9 @@ func (c *Context) AutoCommit() {
 	ticker := time.NewTicker(200 * time.Millisecond)
 	cleanUpTicker := time.NewTicker(1 * time.Minute)
 	expireTicker := time.NewTicker(1 * time.Second)
+	if !c.flush {
+		log.Infof("flush is disabled")
+	}
 	for {
 		select {
 		case <-c.PusherTomb.Dying():

--- a/pkg/sqlite/commit.go
+++ b/pkg/sqlite/commit.go
@@ -46,7 +46,7 @@ func (c *Context) CleanUpRecordsByAge() error {
 
 	//look for soft-deleted events that are OLDER than maxDurationRetention
 	ret := c.Db.Unscoped().Table("ban_applications").Where("deleted_at is not NULL").
-		Where(fmt.Sprintf("deleted_at > data('now','-%d minutes')", int(c.maxDurationRetention.Minutes()))).
+		Where(fmt.Sprintf("deleted_at > date('now','-%d minutes')", int(c.maxDurationRetention.Minutes()))).
 		Order("updated_at desc").Find(&sos)
 
 	if ret.Error != nil {

--- a/pkg/sqlite/commit.go
+++ b/pkg/sqlite/commit.go
@@ -55,7 +55,7 @@ func (c *Context) CleanUpRecordsByAge() error {
 
 	//no events elligible
 	if len(sos) == 0 || ret.RowsAffected == 0 {
-		log.Infof("no event older than %s", c.maxDurationRetention.String())
+		log.Debugf("no event older than %s", c.maxDurationRetention.String())
 		return nil
 	}
 	//let's do it in a single transaction
@@ -91,7 +91,7 @@ func (c *Context) CleanUpRecordsByCount() error {
 		return errors.Wrap(ret.Error, "failed to get bans count")
 	}
 	if count < c.maxEventRetention {
-		log.Infof("%d < %d, don't cleanup", count, c.maxEventRetention)
+		log.Debugf("%d < %d, don't cleanup", count, c.maxEventRetention)
 		return nil
 	}
 
@@ -130,12 +130,12 @@ func (c *Context) CleanUpRecordsByCount() error {
 }
 
 func (c *Context) AutoCommit() {
-	log.Warningf("starting autocommit")
+	log.Infof("starting autocommit")
 	ticker := time.NewTicker(200 * time.Millisecond)
 	cleanUpTicker := time.NewTicker(1 * time.Minute)
 	expireTicker := time.NewTicker(1 * time.Second)
 	if !c.flush {
-		log.Infof("flush is disabled")
+		log.Debugf("flush is disabled")
 	}
 	for {
 		select {

--- a/pkg/sqlite/commit.go
+++ b/pkg/sqlite/commit.go
@@ -6,8 +6,22 @@ import (
 	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/types"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
+
+func (c *Context) DeleteExpired() error {
+	//Delete the expired records
+	if c.flush {
+		retx := c.Db.Where(`strftime("%s", until) < strftime("%s", "now")`).Delete(types.BanApplication{})
+		if retx.RowsAffected > 0 {
+			log.Infof("Flushed %d expired entries from Ban Application", retx.RowsAffected)
+		}
+	} else {
+		log.Infof("flush is disabled")
+	}
+	return nil
+}
 
 func (c *Context) Flush() error {
 	c.lock.Lock()
@@ -21,17 +35,64 @@ func (c *Context) Flush() error {
 	}
 	c.tx = c.Db.Begin()
 	c.lastCommit = time.Now()
-	//Delete the expired records
-	if c.flush {
-		retx := c.Db.Where(`strftime("%s", until) < strftime("%s", "now")`).Delete(types.BanApplication{})
-		if retx.RowsAffected > 0 {
-			log.Infof("Flushed %d expired entries from Ban Application", retx.RowsAffected)
+	c.DeleteExpired()
+
+	return nil
+}
+
+func (c *Context) CleanUpRecordsByCount() error {
+	var count int
+
+	if c.maxEventRetention <= 0 {
+		return nil
+	}
+
+	ret := c.Db.Unscoped().Table("ban_applications").Order("updated_at desc").Count(&count)
+
+	if ret.Error != nil {
+		return errors.Wrap(ret.Error, "failed to get bans count")
+	}
+	if count < c.maxEventRetention {
+		log.Infof("%d < %d, don't cleanup", count, c.maxEventRetention)
+		return nil
+	}
+
+	sos := []types.BanApplication{}
+	/*get soft deleted records oldest to youngest*/
+	records := c.Db.Unscoped().Table("ban_applications").Where("deleted_at is not NULL").Where(`strftime("%s", deleted_at) < strftime("%s", "now")`).Find(&sos)
+	if records.Error != nil {
+		return errors.Wrap(records.Error, "failed to list expired bans for flush")
+	}
+
+	//let's do it in a single transaction
+	delTx := c.Db.Unscoped().Begin()
+	delRecords := 0
+	for _, ld := range sos {
+		copy := ld
+		delTx.Unscoped().Table("signal_occurences").Where("ID = ?", copy.SignalOccurenceID).Delete(&types.SignalOccurence{})
+		delTx.Unscoped().Table("event_sequences").Where("signal_occurence_id = ?", copy.SignalOccurenceID).Delete(&types.EventSequence{})
+		delTx.Unscoped().Table("ban_applications").Delete(&copy)
+		//we need to delete associations : event_sequences, signal_occurences
+		delRecords++
+		//let's delete as well the associated event_sequence
+		if count-delRecords <= c.maxEventRetention {
+			break
 		}
+	}
+	if len(sos) > 0 {
+		log.Printf("Deleting %d soft-deleted results out of %d total events (%d soft-deleted)", delRecords, count, len(sos))
+		ret = delTx.Unscoped().Commit()
+		if ret.Error != nil {
+			return errors.Wrap(ret.Error, "failed to delete records")
+		}
+	} else {
+		log.Debugf("didn't find any record to clean")
 	}
 	return nil
 }
 
 func (c *Context) AutoCommit() {
+	log.Infof("starting autocommit")
 	ticker := time.NewTicker(200 * time.Millisecond)
 	for {
 		select {
@@ -54,10 +115,16 @@ func (c *Context) AutoCommit() {
 		case <-ticker.C:
 			if atomic.LoadInt32(&c.count) != 0 &&
 				(atomic.LoadInt32(&c.count)%100 == 0 || time.Since(c.lastCommit) >= 500*time.Millisecond) {
+				//log.Warningf("flush time")
 				if err := c.Flush(); err != nil {
 					log.Errorf("failed to flush : %s", err)
 				}
+				//log.Printf("starting auto-cleanup")
+				if err := c.CleanUpRecordsByCount(); err != nil {
+					log.Errorf("error in auto-cleanup : %s", err)
+				}
 			}
+
 		}
 	}
 }

--- a/pkg/sqlite/commit.go
+++ b/pkg/sqlite/commit.go
@@ -57,6 +57,7 @@ func (c *Context) CleanUpRecordsByAge() error {
 
 	//no events elligible
 	if len(sos) == 0 || ret.RowsAffected == 0 {
+		log.Infof("no event older than %s", c.maxDurationRetention.String())
 		return nil
 	}
 	//let's do it in a single transaction

--- a/pkg/sqlite/sqlite.go
+++ b/pkg/sqlite/sqlite.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/types"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/jinzhu/gorm"
@@ -63,7 +64,10 @@ func NewSQLite(cfg map[string]string) (*Context, error) {
 		c.Db.LogMode(true)
 	}
 
-	c.flush, _ = strconv.ParseBool(cfg["flush"])
+	c.flush, err = strconv.ParseBool(cfg["flush"])
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to parse 'flush' flag")
+	}
 	// Migrate the schema
 	c.Db.AutoMigrate(&types.EventSequence{}, &types.SignalOccurence{}, &types.BanApplication{})
 	c.Db.Model(&types.SignalOccurence{}).Related(&types.EventSequence{})

--- a/pkg/sqlite/sqlite.go
+++ b/pkg/sqlite/sqlite.go
@@ -38,13 +38,12 @@ func NewSQLite(cfg map[string]string) (*Context, error) {
 			log.Errorf("Ignoring invalid max_records '%s' : %s", v, err)
 		}
 	}
-	if v, ok := cfg["max_records_duration"]; ok {
+	if v, ok := cfg["max_records_age"]; ok {
 		c.maxDurationRetention, err = time.ParseDuration(v)
 		if err != nil {
 			log.Errorf("Ignoring invalid duration '%s' : %s", v, err)
 		}
 	}
-	log.Warningf("NEW SQLITE : %+v", cfg)
 	if _, ok := cfg["db_path"]; !ok {
 		return nil, fmt.Errorf("please specify a 'db_path' to SQLite db in the configuration")
 	}
@@ -52,6 +51,7 @@ func NewSQLite(cfg map[string]string) (*Context, error) {
 	if cfg["db_path"] == "" {
 		return nil, fmt.Errorf("please specify a 'db_path' to SQLite db in the configuration")
 	}
+	log.Warningf("Starting SQLite backend, path:%s", cfg["db_path"])
 
 	c.Db, err = gorm.Open("sqlite3", cfg["db_path"]+"?_busy_timeout=1000")
 	if err != nil {

--- a/pkg/sqlite/sqlite.go
+++ b/pkg/sqlite/sqlite.go
@@ -84,10 +84,5 @@ func NewSQLite(cfg map[string]string) (*Context, error) {
 	if c.tx == nil {
 		return nil, fmt.Errorf("failed to begin sqlite transac : %s", err)
 	}
-	//TBD : we shouldn't start auto-commit if we are in cli mode ?
-	c.PusherTomb.Go(func() error {
-		c.AutoCommit()
-		return nil
-	})
 	return c, nil
 }

--- a/pkg/sqlite/sqlite.go
+++ b/pkg/sqlite/sqlite.go
@@ -63,8 +63,6 @@ func NewSQLite(cfg map[string]string) (*Context, error) {
 		c.Db.LogMode(true)
 	}
 
-	c.Db.LogMode(true)
-
 	c.flush, _ = strconv.ParseBool(cfg["flush"])
 	// Migrate the schema
 	c.Db.AutoMigrate(&types.EventSequence{}, &types.SignalOccurence{}, &types.BanApplication{})

--- a/pkg/sqlite/sqlite.go
+++ b/pkg/sqlite/sqlite.go
@@ -52,7 +52,7 @@ func NewSQLite(cfg map[string]string) (*Context, error) {
 	if cfg["db_path"] == "" {
 		return nil, fmt.Errorf("please specify a 'db_path' to SQLite db in the configuration")
 	}
-	log.Infof("Starting SQLite backend, path:%s", cfg["db_path"])
+	log.Debugf("Starting SQLite backend, path:%s", cfg["db_path"])
 
 	c.Db, err = gorm.Open("sqlite3", cfg["db_path"]+"?_busy_timeout=1000")
 	if err != nil {

--- a/pkg/sqlite/sqlite.go
+++ b/pkg/sqlite/sqlite.go
@@ -52,7 +52,7 @@ func NewSQLite(cfg map[string]string) (*Context, error) {
 	if cfg["db_path"] == "" {
 		return nil, fmt.Errorf("please specify a 'db_path' to SQLite db in the configuration")
 	}
-	log.Warningf("Starting SQLite backend, path:%s", cfg["db_path"])
+	log.Infof("Starting SQLite backend, path:%s", cfg["db_path"])
 
 	c.Db, err = gorm.Open("sqlite3", cfg["db_path"]+"?_busy_timeout=1000")
 	if err != nil {
@@ -84,8 +84,7 @@ func NewSQLite(cfg map[string]string) (*Context, error) {
 	if c.tx == nil {
 		return nil, fmt.Errorf("failed to begin sqlite transac : %s", err)
 	}
-	//random attempt
-	//c.maxEventRetention = 100
+	//TBD : we shouldn't start auto-commit if we are in cli mode ?
 	c.PusherTomb.Go(func() error {
 		c.AutoCommit()
 		return nil

--- a/pkg/sqlite/sqlite.go
+++ b/pkg/sqlite/sqlite.go
@@ -32,6 +32,18 @@ func NewSQLite(cfg map[string]string) (*Context, error) {
 	var err error
 	c := &Context{}
 
+	if v, ok := cfg["max_records"]; ok {
+		c.maxEventRetention, err = strconv.Atoi(v)
+		if err != nil {
+			log.Errorf("Ignoring invalid max_records '%s' : %s", v, err)
+		}
+	}
+	if v, ok := cfg["max_records_duration"]; ok {
+		c.maxDurationRetention, err = time.ParseDuration(v)
+		if err != nil {
+			log.Errorf("Ignoring invalid duration '%s' : %s", v, err)
+		}
+	}
 	log.Warningf("NEW SQLITE : %+v", cfg)
 	if _, ok := cfg["db_path"]; !ok {
 		return nil, fmt.Errorf("please specify a 'db_path' to SQLite db in the configuration")
@@ -71,7 +83,7 @@ func NewSQLite(cfg map[string]string) (*Context, error) {
 		return nil, fmt.Errorf("failed to begin sqlite transac : %s", err)
 	}
 	//random attempt
-	c.maxEventRetention = 100
+	//c.maxEventRetention = 100
 	c.PusherTomb.Go(func() error {
 		c.AutoCommit()
 		return nil

--- a/plugins/backend/sqlite.go
+++ b/plugins/backend/sqlite.go
@@ -23,6 +23,10 @@ func (p *pluginDB) Shutdown() error {
 	return nil
 }
 
+func (p *pluginDB) StartAutoCommit() error {
+	return p.CTX.StartAutoCommit()
+}
+
 func (p *pluginDB) Init(config map[string]string) error {
 	var err error
 	log.Debugf("sqlite config : %+v \n", config)


### PR DESCRIPTION
Crowdsec :
 - Support database (sqlite) retention policy via the main yaml file.

Allow to specify "max_records" and/or "max_records_age".
These parameters will trigger (every minute) a check that will cleanup expired records from the SQLite database based on the policy.

 - `AutoCommit` routine in backend is not automatically started when Output is instanciated (so that cscli doesn't start one for ex)

Cscli :

 - Reduce verbosity of cwhub in debug mode

 - Reduce verbosity of output startup (and verbosity of ie `cscli ban add`)

 - Allow 'ban add' to accept reason on more than one arg `cscli ban add ip 1.2.3.4 2h this is a test` 

