### PR TITLE
fix #89 : crash if there is no source in events leading to overflow

### DIFF
--- a/pkg/outputs/ouputs.go
+++ b/pkg/outputs/ouputs.go
@@ -45,6 +45,11 @@ func OvflwToOrder(sig types.SignalOccurence, prof types.Profile) (*types.BanOrde
 		/*if the profil has no remediation, no order */
 		return nil, nil, fmt.Errorf("no remediation")
 	}
+
+	if sig.Source == nil {
+		return nil, nil, fmt.Errorf("no 'source' in event (Meta.source_ip empty?)")
+	}
+
 	ordr.MeasureSource = "local"
 	ordr.Reason = sig.Scenario
 	//Identify scope


### PR DESCRIPTION
SignalOccurence can't lead to BanApplication if there is no source in the Event