### PR TITLE
add output raw for ban list

### DIFF
--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -96,7 +96,12 @@ func BanList() error {
 	if err != nil {
 		return fmt.Errorf("unable to get records from sqlite : %v", err)
 	}
-	if config.output == "json" {
+	if config.output == "raw" {
+		fmt.Printf("source,ip,reason,bans,action,country,as,events_count,expiration\n")
+		for _, rm := range ret {
+			fmt.Printf("%s,%s,%s,%s,%s,%s,%s,%s,%s\n", rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"])
+		}
+	} else if config.output == "json" {
 		x, _ := json.MarshalIndent(ret, "", " ")
 		fmt.Printf("%s", string(x))
 	} else if config.output == "human" {


### PR DESCRIPTION
this MR add the possibility to run `cscli ban list -o raw` . This will output current bans in DB in `csv` format such as :
```bash
$ sudo cscli ban list -o raw   
source,ip,reason,bans,action,country,as,events,expiration
api,1.2.3.4,api: crowdsecurity/ssh-bf_user-enum,1,ban,,0 ,1,23h57m39s
api,1.2.3.5,api: crowdsecurity/ssh-bf,1,ban,FR,16276 ,1,23h57m39s
api,1.2.3.6,api: crowdsecurity/ssh-bf,1,ban,BY,6697 ,1,23h57m39s
```

This should fix #107 