### PR TITLE
Add possibility to filter the size of cscli ban list returned array

### DIFF
--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -428,7 +428,8 @@ cscli ban del range 1.2.3.0/24`,
 		Short: "List local or api bans/remediations",
 		Long: `List the bans, by default only local decisions.
 
-If --all/-a is specified, api-provided bans will be displayed too.
+If --all/-a is specified, bans will be displayed without limit (--limit).
+Default limit is 50.
 
 Time can be specified with --at and support a variety of date formats:  
  - Jan  2 15:04:05  
@@ -451,7 +452,7 @@ Time can be specified with --at and support a variety of date formats:
 		},
 	}
 	cmdBanList.PersistentFlags().StringVar(&atTime, "at", "", "List bans at given time")
-	cmdBanList.PersistentFlags().BoolVarP(&displayALL, "all", "a", false, "List as well bans received from API")
+	cmdBanList.PersistentFlags().BoolVarP(&displayALL, "all", "a", false, "List bans without limit")
 	cmdBanList.PersistentFlags().BoolVarP(&displayAPI, "api", "", false, "List as well bans received from API")
 	cmdBanList.PersistentFlags().StringVar(&ipFilter, "ip", "", "List bans for given IP")
 	cmdBanList.PersistentFlags().StringVar(&rangeFilter, "range", "", "List bans belonging to given range")

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -259,7 +259,7 @@ func BanList() error {
 			}
 			table.Render() // Send output
 			if dispcount > displayLimit && !displayALL {
-				fmt.Printf("Additional records stripped : %d | %d.\n", dispcount, displayLimit)
+				fmt.Printf("Additional records stripped.\n")
 			}
 		} else {
 			fmt.Printf("No local decisions.\n")

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -271,7 +271,7 @@ func BanList() error {
 		} else {
 			fmt.Printf("No local decisions.\n")
 		}
-		if !displayALL && displayAPI {
+		if !displayALL || displayAPI {
 			fmt.Printf("And %d records from API, %d distinct AS, %d distinct countries\n", apicount, len(uniqAS), len(uniqCN))
 		}
 	}

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -220,7 +220,6 @@ func BanList() error {
 		totcount := 0
 		apicount := 0
 		for _, rm := range ret {
-			log.Printf("source : %v", rm["source"])
 			if !displayAPI && rm["source"] == "api" {
 				apicount++
 				if _, ok := uniqAS[rm["as"]]; !ok {
@@ -242,15 +241,16 @@ func BanList() error {
 				if displayAPI {
 					if rm["source"] == "api" {
 						table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
+						dispcount++
 					}
 				} else {
 					if rm["source"] != "api" {
 						table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
+						dispcount++
 					}
 				}
 			}
 			totcount++
-			dispcount++
 
 		}
 		if dispcount > 0 {

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -256,7 +256,7 @@ func BanList() error {
 
 		}
 		if dispcount > 0 {
-			if !displayALL && !displayAPI {
+			if !displayAPI {
 				fmt.Printf("%d local decisions:\n", totcount)
 			}
 			table.Render() // Send output

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -269,7 +269,11 @@ func BanList() error {
 				fmt.Printf("Additional records stripped.\n")
 			}
 		} else {
-			fmt.Printf("No local decisions.\n")
+			if displayAPI {
+				fmt.Printf("No API decisions")
+			} else {
+				fmt.Printf("No local decisions.\n")
+			}
 		}
 		if !displayAPI {
 			fmt.Printf("And %d records from API, %d distinct AS, %d distinct countries\n", apicount, len(uniqAS), len(uniqCN))

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -220,6 +220,7 @@ func BanList() error {
 		totcount := 0
 		apicount := 0
 		for _, rm := range ret {
+			log.Printf("source : %v", rm["source"])
 			if !displayAPI && rm["source"] == "api" {
 				apicount++
 				if _, ok := uniqAS[rm["as"]]; !ok {

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -220,7 +220,7 @@ func BanList() error {
 		totcount := 0
 		apicount := 0
 		for _, rm := range ret {
-			if !displayALL && rm["source"] == "api" {
+			if !displayAPI && rm["source"] == "api" {
 				apicount++
 				if _, ok := uniqAS[rm["as"]]; !ok {
 					uniqAS[rm["as"]] = true
@@ -228,7 +228,6 @@ func BanList() error {
 				if _, ok := uniqCN[rm["cn"]]; !ok {
 					uniqCN[rm["cn"]] = true
 				}
-				continue
 			}
 			if displayALL {
 				if rm["source"] == "api" {
@@ -239,7 +238,6 @@ func BanList() error {
 					table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
 				}
 			} else if dispcount < displayLimit {
-				log.Printf("Displaying API ?? : %v  | source event : %s", displayAPI, rm["source"])
 				if displayAPI {
 					if rm["source"] == "api" {
 						table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -217,9 +217,7 @@ func BanList() error {
 		table.SetHeader([]string{"Source", "Ip", "Reason", "Bans", "Action", "Country", "AS", "Events", "Expiration"})
 
 		dispcount := 0
-		totcount := 0
 		apicount := 0
-		localCount := 0
 		for _, rm := range ret {
 			if !displayAPI && rm["source"] == "api" {
 				apicount++

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -219,6 +219,7 @@ func BanList() error {
 		dispcount := 0
 		totcount := 0
 		apicount := 0
+		localCount := 0
 		for _, rm := range ret {
 			if !displayAPI && rm["source"] == "api" {
 				apicount++
@@ -234,30 +235,32 @@ func BanList() error {
 					if displayAPI {
 						table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
 						dispcount++
+						continue
 					}
 				} else {
 					table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
 					dispcount++
+					continue
 				}
 			} else if dispcount < displayLimit {
 				if displayAPI {
 					if rm["source"] == "api" {
 						table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
 						dispcount++
+						continue
 					}
 				} else {
 					if rm["source"] != "api" {
 						table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
 						dispcount++
+						continue
 					}
 				}
 			}
-			totcount++
-
 		}
 		if dispcount > 0 {
 			if !displayAPI {
-				fmt.Printf("%d local decisions:\n", totcount)
+				fmt.Printf("%d local decisions:\n", dispcount)
 			}
 			table.Render() // Send output
 			if dispcount > displayLimit && !displayALL {

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -241,7 +241,7 @@ func BanList() error {
 			} else if dispcount < displayLimit {
 				if displayAPI {
 					if rm["source"] == "api" {
-
+						table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
 					}
 				} else {
 					if rm["source"] != "api" {
@@ -258,7 +258,7 @@ func BanList() error {
 				fmt.Printf("%d local decisions:\n", totcount)
 			}
 			table.Render() // Send output
-			if dispcount > displayLimit {
+			if dispcount > displayLimit && !displayALL {
 				fmt.Printf("Additional records stripped : %d | %d.\n", dispcount, displayLimit)
 			}
 		} else {

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -259,6 +259,10 @@ func BanList() error {
 		if dispcount > 0 {
 			if !displayAPI {
 				fmt.Printf("%d local decisions:\n", dispcount)
+			} else if displayAPI && !displayALL {
+				fmt.Printf("%d decision from API", dispcount)
+			} else if displayALL && displayAPI {
+				fmt.Printf("%d decision from crowdsec and API", dispcount)
 			}
 			table.Render() // Send output
 			if dispcount > displayLimit && !displayALL {

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -233,9 +233,11 @@ func BanList() error {
 				if rm["source"] == "api" {
 					if displayAPI {
 						table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
+						dispcount++
 					}
 				} else {
 					table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
+					dispcount++
 				}
 			} else if dispcount < displayLimit {
 				if displayAPI {

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -260,9 +260,9 @@ func BanList() error {
 			if !displayAPI {
 				fmt.Printf("%d local decisions:\n", dispcount)
 			} else if displayAPI && !displayALL {
-				fmt.Printf("%d decision from API", dispcount)
+				fmt.Printf("%d decision from API\n", dispcount)
 			} else if displayALL && displayAPI {
-				fmt.Printf("%d decision from crowdsec and API", dispcount)
+				fmt.Printf("%d decision from crowdsec and API\n", dispcount)
 			}
 			table.Render() // Send output
 			if dispcount > displayLimit && !displayALL {
@@ -271,7 +271,7 @@ func BanList() error {
 		} else {
 			fmt.Printf("No local decisions.\n")
 		}
-		if !displayALL || displayAPI {
+		if !displayALL || !displayAPI {
 			fmt.Printf("And %d records from API, %d distinct AS, %d distinct countries\n", apicount, len(uniqAS), len(uniqCN))
 		}
 	}

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -271,7 +271,7 @@ func BanList() error {
 		} else {
 			fmt.Printf("No local decisions.\n")
 		}
-		if !displayALL || !displayAPI {
+		if !displayAPI {
 			fmt.Printf("And %d records from API, %d distinct AS, %d distinct countries\n", apicount, len(uniqAS), len(uniqCN))
 		}
 	}

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -270,9 +270,9 @@ func BanList() error {
 			}
 		} else {
 			if displayAPI {
-				fmt.Printf("No API decisions")
+				fmt.Println("No API decisions")
 			} else {
-				fmt.Printf("No local decisions.\n")
+				fmt.Println("No local decisions")
 			}
 		}
 		if !displayAPI {

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -259,7 +259,7 @@ func BanList() error {
 			}
 			table.Render() // Send output
 			if dispcount > displayLimit {
-				fmt.Printf("Additional records stripped.\n")
+				fmt.Printf("Additional records stripped : %d | %d.\n", dispcount, displayLimit)
 			}
 		} else {
 			fmt.Printf("No local decisions.\n")

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -24,6 +24,7 @@ var all bool
 
 //user supplied filters
 var ipFilter, rangeFilter, reasonFilter, countryFilter, asFilter string
+var displayLimit int
 
 func simpleBanToSignal(targetIP string, reason string, expirationStr string, action string, asName string, asNum string, country string, banSource string) (types.SignalOccurence, error) {
 	var signalOcc types.SignalOccurence
@@ -229,7 +230,7 @@ func BanList() error {
 				}
 				continue
 			}
-			if dispcount < 20 {
+			if dispcount < displayLimit {
 				table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
 			}
 			totcount++
@@ -241,7 +242,7 @@ func BanList() error {
 				fmt.Printf("%d local decisions:\n", totcount)
 			}
 			table.Render() // Send output
-			if dispcount > 20 {
+			if dispcount > displayLimit {
 				fmt.Printf("Additional records stripped.\n")
 			}
 		} else {
@@ -433,6 +434,7 @@ Time can be specified with --at and support a variety of date formats:
 	cmdBanList.PersistentFlags().StringVar(&reasonFilter, "reason", "", "List bans containing given reason")
 	cmdBanList.PersistentFlags().StringVar(&countryFilter, "country", "", "List bans belonging to given country code")
 	cmdBanList.PersistentFlags().StringVar(&asFilter, "as", "", "List bans belonging to given AS name")
+	cmdBanList.PersistentFlags().IntVar(&displayLimit, "limit", 50, "Limit of bans to display (default 50)")
 
 	cmdBan.AddCommand(cmdBanList)
 	return cmdBan

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -271,7 +271,7 @@ func BanList() error {
 		} else {
 			fmt.Printf("No local decisions.\n")
 		}
-		if !displayALL {
+		if !displayALL && displayAPI {
 			fmt.Printf("And %d records from API, %d distinct AS, %d distinct countries\n", apicount, len(uniqAS), len(uniqCN))
 		}
 	}

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -241,8 +241,11 @@ func BanList() error {
 			} else if dispcount < displayLimit {
 				if displayAPI {
 					if rm["source"] == "api" {
-						table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
 
+					}
+				} else {
+					if rm["source"] != "api" {
+						table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
 					}
 				}
 			}

--- a/cmd/crowdsec-cli/ban.go
+++ b/cmd/crowdsec-cli/ban.go
@@ -239,6 +239,7 @@ func BanList() error {
 					table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
 				}
 			} else if dispcount < displayLimit {
+				log.Printf("Displaying API ?? : %v  | source event : %s", displayAPI, rm["source"])
 				if displayAPI {
 					if rm["source"] == "api" {
 						table.Append([]string{rm["source"], rm["iptext"], rm["reason"], rm["bancount"], rm["action"], rm["cn"], rm["as"], rm["events_count"], rm["until"]})
@@ -254,7 +255,7 @@ func BanList() error {
 
 		}
 		if dispcount > 0 {
-			if !displayALL {
+			if !displayALL && !displayAPI {
 				fmt.Printf("%d local decisions:\n", totcount)
 			}
 			table.Render() // Send output


### PR DESCRIPTION
```
cscli ban list --limit 50 # return max 50 entries`
```

```
cscli ban list --api # return entries from API only
```

```
cscli ban list --all # return all local entries`
```

```
cscli ban list --all --api # return all local entries and API entries`
```

```
cscli ban list --api --limit 50 # return max 50 entries from API`
```

