### PR TITLE
No sql transaction + proper time-machine wait

### DIFF
--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -152,25 +152,25 @@ func serveOneTimeRun(outputRunner outputs.Output) error {
 		as some operations (ie. reverse dns or such in post-overflow) can take some time :)
 	*/
 
-	bucket_count := leaky.LeakyRoutineCount
+	bucketCount := leaky.LeakyRoutineCount
 	rounds := 0
-	successive_still_rounds := 0
+	successiveStillRounds := 0
 	for {
 		rounds++
 		time.Sleep(5 * time.Second)
-		curr_bucket_count := leaky.LeakyRoutineCount
-		if curr_bucket_count != bucket_count {
+		currBucketCount := leaky.LeakyRoutineCount
+		if currBucketCount != bucketCount {
 			if rounds == 0 || rounds%2 == 0 {
-				log.Printf("Still %d live LeakRoutines, waiting (was %d)", curr_bucket_count, bucket_count)
+				log.Printf("Still %d live LeakRoutines, waiting (was %d)", currBucketCount, bucketCount)
 			}
-			bucket_count = curr_bucket_count
-			successive_still_rounds = 0
+			bucketCount = currBucketCount
+			successiveStillRounds = 0
 		} else {
-			if successive_still_rounds > 1 {
+			if successiveStillRounds > 1 {
 				log.Printf("LeakRoutines commit over.")
 				break
 			}
-			successive_still_rounds++
+			successiveStillRounds++
 		}
 	}
 

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -107,17 +107,7 @@ func NewDatabase(cfg map[string]string) (*Context, error) {
 	c.Db.AutoMigrate(&types.EventSequence{}, &types.SignalOccurence{}, &types.BanApplication{})
 	c.Db.Model(&types.SignalOccurence{}).Related(&types.EventSequence{})
 	c.Db.Model(&types.SignalOccurence{}).Related(&types.BanApplication{})
-	c.tx = c.Db.Begin()
+
 	c.lastCommit = time.Now()
-	ret := c.tx.Commit()
-
-	if ret.Error != nil {
-		return nil, fmt.Errorf("failed to commit records : %v", ret.Error)
-
-	}
-	c.tx = c.Db.Begin()
-	if c.tx == nil {
-		return nil, fmt.Errorf("failed to begin %s transac : %s", cfg["type"], err)
-	}
 	return c, nil
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -18,7 +18,6 @@ import (
 
 type Context struct {
 	Db         *gorm.DB //Pointer to database
-	tx         *gorm.DB //Pointer to current transaction (flushed on a regular basis)
 	lastCommit time.Time
 	flush      bool
 	count      int32

--- a/pkg/database/write.go
+++ b/pkg/database/write.go
@@ -15,7 +15,7 @@ func (c *Context) WriteBanApplication(ban types.BanApplication) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	log.Debugf("Ban application being called : %s %s", ban.Scenario, ban.IpText)
-	ret := c.tx.Where(types.BanApplication{IpText: ban.IpText}).Assign(types.BanApplication{Until: ban.Until}).Assign(types.BanApplication{Reason: ban.Reason}).Assign(types.BanApplication{MeasureType: ban.MeasureType}).FirstOrCreate(&ban)
+	ret := c.Db.Where(types.BanApplication{IpText: ban.IpText}).Assign(types.BanApplication{Until: ban.Until}).Assign(types.BanApplication{Reason: ban.Reason}).Assign(types.BanApplication{MeasureType: ban.MeasureType}).FirstOrCreate(&ban)
 	if ret.Error != nil {
 		return fmt.Errorf("failed to write ban record : %v", ret.Error)
 	}
@@ -28,14 +28,14 @@ func (c *Context) WriteSignal(sig types.SignalOccurence) error {
 	defer c.lock.Unlock()
 	/*let's ensure we only have one ban active for a given scope*/
 	for _, ba := range sig.BanApplications {
-		ret := c.tx.Where("ip_text = ?", ba.IpText).Delete(types.BanApplication{})
+		ret := c.Db.Where("ip_text = ?", ba.IpText).Delete(types.BanApplication{})
 		if ret.Error != nil {
 			log.Errorf("While delete overlaping bans : %s", ret.Error)
 			return fmt.Errorf("failed to write signal occurrence : %v", ret.Error)
 		}
 	}
 	/*and add the new one(s)*/
-	ret := c.tx.Create(&sig)
+	ret := c.Db.Create(&sig)
 	if ret.Error != nil {
 		log.Errorf("While creating new bans : %s", ret.Error)
 		return fmt.Errorf("failed to write signal occurrence : %s", ret.Error)


### PR DESCRIPTION
 - Do not use transactions to commit changes to DB
 - Have a smarter mechanism waiting for "pending" buckets that overflowed but didn't commit to DB yet (for time-machine)
