### PR TITLE
SQLite : busy timeout to 10s rather than 1s

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -66,7 +66,7 @@ func NewDatabase(cfg map[string]string) (*Context, error) {
 	}
 
 	if cfg["type"] == "sqlite" {
-		c.Db, err = gorm.Open("sqlite3", cfg["db_path"]+"?_busy_timeout=1000")
+		c.Db, err = gorm.Open("sqlite3", cfg["db_path"]+"?_busy_timeout=10000")
 		if err != nil {
 			return nil, fmt.Errorf("failed to open %s : %s", cfg["db_path"], err)
 		}


### PR DESCRIPTION
`busy_timeout` for SQLite was set to `1s`. On machines with slow disk it can lead to "database is busy" errors when ie. crowdsec is starting while `cscli api pull` is running and such.
 