### PR TITLE
Add debug expr

### DIFF
--- a/docs/references/output.md
+++ b/docs/references/output.md
@@ -3,7 +3,7 @@
 The output mechanism is composed of plugins. In order to store the bans for {{blockers.htmlname}}, at least one backend plugin must be loaded. Else, bans will not be stored and decisions cannot be applied. 
 
 
-Currently the supported {{backend.name}} are SQLite (default) and MySQL.
+Currently the supported backends are SQLite (default) and MySQL.
 
 In order to filter which signals will be sent to which plugin, {{crowdsec.name}} use a system of `profile` that can allow to granularly process your bans and signals.
 

--- a/docs/references/parsers.md
+++ b/docs/references/parsers.md
@@ -142,7 +142,37 @@ debug: true|false
 _default: false_
 
 If set to to `true`, enabled node level debugging.
-It is meant to help understanding parser node behaviour by providing contextual logging.
+It is meant to help understanding parser node behavior by providing contextual logging :
+  
+<details>
+  <summary>assignments made by statics</summary>
+```
+DEBU[31-07-2020 16:36:28] + Processing 4 statics                        id=withered-rain name=crowdsecurity/nginx-logs stage=s01-parse
+DEBU[31-07-2020 16:36:28] .Meta[service] = 'http'                       id=withered-rain name=crowdsecurity/nginx-logs stage=s01-parse
+DEBU[31-07-2020 16:36:28] .Meta[source_ip] = '127.0.0.1'                id=withered-rain name=crowdsecurity/nginx-logs stage=s01-parse
+DEBU[31-07-2020 16:36:28] .Meta[http_status] = '200'                    id=withered-rain name=crowdsecurity/nginx-logs stage=s01-parse
+DEBU[31-07-2020 16:36:28] .Meta[http_path] = '/'                        id=withered-rain name=crowdsecurity/nginx-logs stage=s01-parse
+```
+</details>
+<details>
+  <summary>assignments made by grok pattern</summary>
+```
+DEBU[31-07-2020 16:36:28] + Grok 'NGINXACCESS' returned 10 entries to merge in Parsed  id=dark-glitter name=child-crowdsecurity/nginx-logs stage=s01-parse
+DEBU[31-07-2020 16:36:28] 	.Parsed['time_local'] = '21/Jul/2020:16:13:05 +0200'  id=dark-glitter name=child-crowdsecurity/nginx-logs stage=s01-parse
+DEBU[31-07-2020 16:36:28] 	.Parsed['method'] = 'GET'                    id=dark-glitter name=child-crowdsecurity/nginx-logs stage=s01-parse
+DEBU[31-07-2020 16:36:28] 	.Parsed['request'] = '/'                     id=dark-glitter name=child-crowdsecurity/nginx-logs stage=s01-parse
+DEBU[31-07-2020 16:36:28] 	.Parsed['http_user_agent'] = 'curl/7.58.0'   id=dark-glitter name=child-crowdsecurity/nginx-logs stage=s01-parse
+DEBU[31-07-2020 16:36:28] 	.Parsed['remote_addr'] = '127.0.0.1'         id=dark-glitter name=child-crowdsecurity/nginx-logs stage=s01-parse
+```
+</details>
+<details>
+  <summary>debug of filters and expression results</summary>
+```
+DEBU[31-07-2020 16:36:28] eval(evt.Parsed.program == 'nginx') = TRUE    id=withered-rain name=crowdsecurity/nginx-logs stage=s01-parse
+DEBU[31-07-2020 16:36:28] eval variables:                               id=withered-rain name=crowdsecurity/nginx-logs stage=s01-parse
+DEBU[31-07-2020 16:36:28]        evt.Parsed.program = 'nginx'           id=withered-rain name=crowdsecurity/nginx-logs stage=s01-parse
+```
+</details>
 
 
 ### filter

--- a/docs/references/scenarios.md
+++ b/docs/references/scenarios.md
@@ -311,7 +311,16 @@ _default: false_
 
 
 If set to to `true`, enabled scenario level debugging.
-It is meant to help understanding scenario  behavior by providing contextual logging.
+It is meant to help understanding scenario  behavior by providing contextual logging :
+
+<summary>debug of filters and expression results</summary>
+```
+DEBU[31-07-2020 16:34:58] eval(evt.Meta.log_type in ["http_access-log", "http_error-log"] && any(File("bad_user_agents.txt"), {evt.Parsed.http_user_agent contains #})) = TRUE  cfg=still-feather file=config/scenarios/http-bad-user-agent.yaml name=crowdsecurity/http-bad-user-agent
+DEBU[31-07-2020 16:34:58] eval variables:                               cfg=still-feather file=config/scenarios/http-bad-user-agent.yaml name=crowdsecurity/http-bad-user-agent
+DEBU[31-07-2020 16:34:58]        evt.Meta.log_type = 'http_access-log'  cfg=still-feather file=config/scenarios/http-bad-user-agent.yaml name=crowdsecurity/http-bad-user-agent
+DEBU[31-07-2020 16:34:58]        evt.Parsed.http_user_agent = 'Mozilla/5.00 (Nikto/2.1.5) (Evasions:None) (Test:002810)'  cfg=still-feather file=config/scenarios/http-bad-user-agent.yaml name=crowdsecurity/http-bad-user-agent
+```
+</details>
 
 ### reprocess
 

--- a/pkg/exprhelpers/visitor.go
+++ b/pkg/exprhelpers/visitor.go
@@ -17,7 +17,7 @@ import (
 Visitor is used to reconstruct variables with its property called in an expr filter
 Thus, we can debug expr filter by displaying all variables contents present in the filter
 */
-type Visitor struct {
+type visitor struct {
 	newVar     bool
 	currentID  string
 	properties []string
@@ -27,14 +27,14 @@ type Visitor struct {
 /*
 Enter should be present for the interface but is never used
 */
-func (v *Visitor) Enter(node *ast.Node) {}
+func (v *visitor) Enter(node *ast.Node) {}
 
 /*
 Exit is called when running ast.Walk(node, visitor), each time a node exit.
 So we have the node information and we can get the identifier (first level of the struct)
 and its properties to reconstruct the complete variable.
 */
-func (v *Visitor) Exit(node *ast.Node) {
+func (v *visitor) Exit(node *ast.Node) {
 	if n, ok := (*node).(*ast.IdentifierNode); ok {
 		if !v.newVar {
 			v.newVar = true
@@ -54,7 +54,7 @@ func (v *Visitor) Exit(node *ast.Node) {
 /*
 Build reconstruct all the variables used in a filter (to display their content later).
 */
-func (v *Visitor) Build(filter string, exprEnv expr.Option) (*ExprDebugger, error) {
+func (v *visitor) Build(filter string, exprEnv expr.Option) (*ExprDebugger, error) {
 	var expressions []*expression
 	ret := &ExprDebugger{
 		filter: filter,
@@ -110,4 +110,11 @@ func (e *ExprDebugger) Run(logger *logrus.Entry, filterResult bool, exprEnv map[
 		}
 		logger.Debugf("       %s = '%s'", expression.Str, debug)
 	}
+}
+
+// NewDebugger is the exported function that build the debuggers expressions
+func NewDebugger(filter string, exprEnv expr.Option) (*ExprDebugger, error) {
+	visitor := &visitor{}
+	exprDebugger, err := visitor.Build(filter, exprEnv)
+	return exprDebugger, err
 }

--- a/pkg/exprhelpers/visitor.go
+++ b/pkg/exprhelpers/visitor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/ast"
 	"github.com/antonmedv/expr/vm"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 /*
@@ -55,7 +54,7 @@ func (v *Visitor) Exit(node *ast.Node) {
 /*
 Build reconstruct all the variables used in a filter (to display their content later).
 */
-func (v *Visitor) Build(filter string) (*ExprDebugger, error) {
+func (v *Visitor) Build(filter string, exprEnv expr.Option) (*ExprDebugger, error) {
 	var expressions []*expression
 	ret := &ExprDebugger{
 		filter: filter,
@@ -71,7 +70,7 @@ func (v *Visitor) Build(filter string) (*ExprDebugger, error) {
 	v.properties = []string{}
 	v.currentID = ""
 	for _, variable := range v.vars {
-		debugFilter, err := expr.Compile(variable, expr.Env(GetExprEnv(map[string]interface{}{"evt": &types.Event{}})))
+		debugFilter, err := expr.Compile(variable, exprEnv)
 		tmpExpression := &expression{
 			variable,
 			debugFilter,

--- a/pkg/exprhelpers/visitor.go
+++ b/pkg/exprhelpers/visitor.go
@@ -90,7 +90,7 @@ type ExprDebugger struct {
 	expression []*expression
 }
 
-// expression is the structure that represents the varialbe in string and compiled for debug
+// expression is the structure that represents the variable in string and compiled format
 type expression struct {
 	Str      string
 	Compiled *vm.Program

--- a/pkg/exprhelpers/visitor.go
+++ b/pkg/exprhelpers/visitor.go
@@ -1,0 +1,70 @@
+package exprhelpers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/antonmedv/expr/parser"
+
+	"github.com/antonmedv/expr"
+	"github.com/antonmedv/expr/ast"
+	"github.com/antonmedv/expr/vm"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
+)
+
+type Visitor struct {
+	newVar     bool
+	currentID  string
+	properties []string
+	vars       []string
+}
+
+func (v *Visitor) Enter(node *ast.Node) {}
+func (v *Visitor) Exit(node *ast.Node) {
+	if n, ok := (*node).(*ast.IdentifierNode); ok {
+		if !v.newVar {
+			v.newVar = true
+			v.currentID = n.Value
+		} else {
+			v.newVar = false
+			fullVar := fmt.Sprintf("%s.%s", v.currentID, strings.Join(v.properties, "."))
+			v.vars = append(v.vars, fullVar)
+			v.properties = []string{}
+			v.currentID = n.Value
+		}
+	}
+	if n, ok := (*node).(*ast.PropertyNode); ok {
+		v.properties = append(v.properties, n.Property)
+	}
+}
+
+func (v *Visitor) Build(filter string) ([]*DebugExpr, error) {
+	var ret []*DebugExpr
+	v.newVar = false
+	tree, err := parser.Parse(filter)
+	if err != nil {
+		return nil, err
+	}
+	ast.Walk(&tree.Node, v)
+	fullVar := fmt.Sprintf("%s.%s", v.currentID, strings.Join(v.properties, "."))
+	v.vars = append(v.vars, fullVar)
+	v.properties = []string{}
+	v.currentID = ""
+	for _, variable := range v.vars {
+		debugFilter, err := expr.Compile(variable, expr.Env(GetExprEnv(map[string]interface{}{"evt": &types.Event{}})))
+		debugExpr := &DebugExpr{
+			variable,
+			debugFilter,
+		}
+		ret = append(ret, debugExpr)
+		if err != nil {
+			return nil, fmt.Errorf("compilation of variable '%s' failed: %v", variable, err)
+		}
+	}
+	return ret, nil
+}
+
+type DebugExpr struct {
+	DebugStr  string
+	DebugExpr *vm.Program
+}

--- a/pkg/exprhelpers/visitor.go
+++ b/pkg/exprhelpers/visitor.go
@@ -2,9 +2,11 @@ package exprhelpers
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/antonmedv/expr/parser"
+	"github.com/sirupsen/logrus"
 
 	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/ast"
@@ -12,6 +14,10 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
+/*
+Visitor is used to reconstruct variables with its property called in an expr filter
+Thus, we can debug expr filter by displaying all variables contents present in the filter
+*/
 type Visitor struct {
 	newVar     bool
 	currentID  string
@@ -19,7 +25,16 @@ type Visitor struct {
 	vars       []string
 }
 
+/*
+Enter should be present for the interface but is never used
+*/
 func (v *Visitor) Enter(node *ast.Node) {}
+
+/*
+Exit is called when running ast.Walk(node, visitor), each time a node exit.
+So we have the node information and we can get the identifier (first level of the struct)
+and its properties to reconstruct the complete variable.
+*/
 func (v *Visitor) Exit(node *ast.Node) {
 	if n, ok := (*node).(*ast.IdentifierNode); ok {
 		if !v.newVar {
@@ -32,14 +47,19 @@ func (v *Visitor) Exit(node *ast.Node) {
 			v.properties = []string{}
 			v.currentID = n.Value
 		}
-	}
-	if n, ok := (*node).(*ast.PropertyNode); ok {
+	} else if n, ok := (*node).(*ast.PropertyNode); ok {
 		v.properties = append(v.properties, n.Property)
 	}
 }
 
-func (v *Visitor) Build(filter string) ([]*DebugExpr, error) {
-	var ret []*DebugExpr
+/*
+Build reconstruct all the variables used in a filter (to display their content later).
+*/
+func (v *Visitor) Build(filter string) (*ExprDebugger, error) {
+	var expressions []*expression
+	ret := &ExprDebugger{
+		filter: filter,
+	}
 	v.newVar = false
 	tree, err := parser.Parse(filter)
 	if err != nil {
@@ -52,19 +72,43 @@ func (v *Visitor) Build(filter string) ([]*DebugExpr, error) {
 	v.currentID = ""
 	for _, variable := range v.vars {
 		debugFilter, err := expr.Compile(variable, expr.Env(GetExprEnv(map[string]interface{}{"evt": &types.Event{}})))
-		debugExpr := &DebugExpr{
+		tmpExpression := &expression{
 			variable,
 			debugFilter,
 		}
-		ret = append(ret, debugExpr)
+		expressions = append(expressions, tmpExpression)
 		if err != nil {
 			return nil, fmt.Errorf("compilation of variable '%s' failed: %v", variable, err)
 		}
 	}
+	ret.expression = expressions
 	return ret, nil
 }
 
-type DebugExpr struct {
-	DebugStr  string
-	DebugExpr *vm.Program
+// ExprDebugger contains the list of expression to be run when debugging an expression filter
+type ExprDebugger struct {
+	filter     string
+	expression []*expression
+}
+
+// expression is the structure that represents the varialbe in string and compiled for debug
+type expression struct {
+	Str      string
+	Compiled *vm.Program
+}
+
+/*
+Run display the content of each variable of a filter by evaluating them with expr,
+again the expr environment given in parameter
+*/
+func (e *ExprDebugger) Run(logger *logrus.Entry, filterResult bool, exprEnv map[string]interface{}) {
+	logger.Debugf("eval(%s) = %s", e.filter, strings.ToUpper(strconv.FormatBool(filterResult)))
+	logger.Debugf("variables:")
+	for _, expression := range e.expression {
+		debug, err := expr.Run(expression.Compiled, exprEnv)
+		if err != nil {
+			logger.Errorf("unable to print debug expression for '%s': %s", expression.Str, err)
+		}
+		logger.Debugf("       %s = '%s'", expression.Str, debug)
+	}
 }

--- a/pkg/exprhelpers/visitor.go
+++ b/pkg/exprhelpers/visitor.go
@@ -102,7 +102,7 @@ again the expr environment given in parameter
 */
 func (e *ExprDebugger) Run(logger *logrus.Entry, filterResult bool, exprEnv map[string]interface{}) {
 	logger.Debugf("eval(%s) = %s", e.filter, strings.ToUpper(strconv.FormatBool(filterResult)))
-	logger.Debugf("variables:")
+	logger.Debugf("eval variables:")
 	for _, expression := range e.expression {
 		debug, err := expr.Run(expression.Compiled, exprEnv)
 		if err != nil {

--- a/pkg/leakybucket/manager.go
+++ b/pkg/leakybucket/manager.go
@@ -509,12 +509,12 @@ func PourItemToHolders(parsed types.Event, holders []BucketFactory, buckets *Buc
 				log.Fatalf("Filter issue")
 			}
 
+			if condition {
+				holder.logger.Debugf("eval(%s) = TRUE ", holder.Filter)
+			} else {
+				holder.logger.Debugf("eval(%s) = FALSE ", holder.Filter)
+			}
 			if holder.Debug {
-				if condition {
-					holder.logger.Debugf("eval(%s) = TRUE ", holder.Filter)
-				} else {
-					holder.logger.Debugf("eval(%s) = FALSE ", holder.Filter)
-				}
 				holder.logger.Debugf("variables:")
 				for _, d := range holder.DebugExprs {
 					debug, err := expr.Run(d.DebugExpr, exprhelpers.GetExprEnv(map[string]interface{}{"evt": &parsed}))
@@ -523,10 +523,10 @@ func PourItemToHolders(parsed types.Event, holders []BucketFactory, buckets *Buc
 					}
 					holder.logger.Debugf("       %s = '%s'", d.DebugStr, debug)
 				}
-				if !condition {
-					holder.logger.Debugf("Event leaving node : ko")
-					continue
-				}
+			}
+			if !condition {
+				holder.logger.Debugf("Event leaving node : ko")
+				continue
 			}
 		}
 

--- a/pkg/leakybucket/manager.go
+++ b/pkg/leakybucket/manager.go
@@ -31,37 +31,37 @@ import (
 // BucketFactory struct holds all fields for any bucket configuration. This is to have a
 // generic struct for buckets. This can be seen as a bucket factory.
 type BucketFactory struct {
-	FormatVersion  string                   `yaml:"format"`
-	Author         string                   `yaml:"author"`
-	Description    string                   `yaml:"description"`
-	References     []string                 `yaml:"references"`
-	Type           string                   `yaml:"type"`                //Type can be : leaky, counter, trigger. It determines the main bucket characteristics
-	Name           string                   `yaml:"name"`                //Name of the bucket, used later in log and user-messages. Should be unique
-	Capacity       int                      `yaml:"capacity"`            //Capacity is applicable to leaky buckets and determines the "burst" capacity
-	LeakSpeed      string                   `yaml:"leakspeed"`           //Leakspeed is a float representing how many events per second leak out of the bucket
-	Duration       string                   `yaml:"duration"`            //Duration allows 'counter' buckets to have a fixed life-time
-	Filter         string                   `yaml:"filter"`              //Filter is an expr that determines if an event is elligible for said bucket. Filter is evaluated against the Event struct
-	GroupBy        string                   `yaml:"groupby,omitempty"`   //groupy is an expr that allows to determine the partitions of the bucket. A common example is the source_ip
-	Distinct       string                   `yaml:"distinct"`            //Distinct, when present, adds a `Pour()` processor that will only pour uniq items (based on uniq_filter expr result)
-	Debug          bool                     `yaml:"debug"`               //Debug, when set to true, will enable debugging for _this_ scenario specifically
-	Labels         map[string]string        `yaml:"labels"`              //Labels is K:V list aiming at providing context the overflow
-	Blackhole      string                   `yaml:"blackhole,omitempty"` //Blackhole is a duration that, if present, will prevent same bucket partition to overflow more often than $duration
-	logger         *log.Entry               `yaml:"-"`                   //logger is bucket-specific logger (used by Debug as well)
-	Reprocess      bool                     `yaml:"reprocess"`           //Reprocess, if true, will for the bucket to be re-injected into processing chain
-	CacheSize      int                      `yaml:"cache_size"`          //CacheSize, if > 0, limits the size of in-memory cache of the bucket
-	Profiling      bool                     `yaml:"profiling"`           //Profiling, if true, will make the bucket record pours/overflows/etc.
-	OverflowFilter string                   `yaml:"overflow_filter"`     //OverflowFilter if present, is a filter that must return true for the overflow to go through
-	BucketName     string                   `yaml:"-"`
-	Filename       string                   `yaml:"-"`
-	RunTimeFilter  *vm.Program              `json:"-"`
-	DebugExprs     []*exprhelpers.DebugExpr `yaml:"-" json:"-"`
-	RunTimeGroupBy *vm.Program              `json:"-"`
-	Data           []*types.DataSource      `yaml:"data,omitempty"`
-	leakspeed      time.Duration            //internal representation of `Leakspeed`
-	duration       time.Duration            //internal representation of `Duration`
-	ret            chan types.Event         //the bucket-specific output chan for overflows
-	processors     []Processor              //processors is the list of hooks for pour/overflow/create (cf. uniq, blackhole etc.)
-	output         bool                     //??
+	FormatVersion  string                    `yaml:"format"`
+	Author         string                    `yaml:"author"`
+	Description    string                    `yaml:"description"`
+	References     []string                  `yaml:"references"`
+	Type           string                    `yaml:"type"`                //Type can be : leaky, counter, trigger. It determines the main bucket characteristics
+	Name           string                    `yaml:"name"`                //Name of the bucket, used later in log and user-messages. Should be unique
+	Capacity       int                       `yaml:"capacity"`            //Capacity is applicable to leaky buckets and determines the "burst" capacity
+	LeakSpeed      string                    `yaml:"leakspeed"`           //Leakspeed is a float representing how many events per second leak out of the bucket
+	Duration       string                    `yaml:"duration"`            //Duration allows 'counter' buckets to have a fixed life-time
+	Filter         string                    `yaml:"filter"`              //Filter is an expr that determines if an event is elligible for said bucket. Filter is evaluated against the Event struct
+	GroupBy        string                    `yaml:"groupby,omitempty"`   //groupy is an expr that allows to determine the partitions of the bucket. A common example is the source_ip
+	Distinct       string                    `yaml:"distinct"`            //Distinct, when present, adds a `Pour()` processor that will only pour uniq items (based on uniq_filter expr result)
+	Debug          bool                      `yaml:"debug"`               //Debug, when set to true, will enable debugging for _this_ scenario specifically
+	Labels         map[string]string         `yaml:"labels"`              //Labels is K:V list aiming at providing context the overflow
+	Blackhole      string                    `yaml:"blackhole,omitempty"` //Blackhole is a duration that, if present, will prevent same bucket partition to overflow more often than $duration
+	logger         *log.Entry                `yaml:"-"`                   //logger is bucket-specific logger (used by Debug as well)
+	Reprocess      bool                      `yaml:"reprocess"`           //Reprocess, if true, will for the bucket to be re-injected into processing chain
+	CacheSize      int                       `yaml:"cache_size"`          //CacheSize, if > 0, limits the size of in-memory cache of the bucket
+	Profiling      bool                      `yaml:"profiling"`           //Profiling, if true, will make the bucket record pours/overflows/etc.
+	OverflowFilter string                    `yaml:"overflow_filter"`     //OverflowFilter if present, is a filter that must return true for the overflow to go through
+	BucketName     string                    `yaml:"-"`
+	Filename       string                    `yaml:"-"`
+	RunTimeFilter  *vm.Program               `json:"-"`
+	ExprDebugger   *exprhelpers.ExprDebugger `yaml:"-" json:"-"`
+	RunTimeGroupBy *vm.Program               `json:"-"`
+	Data           []*types.DataSource       `yaml:"data,omitempty"`
+	leakspeed      time.Duration             //internal representation of `Leakspeed`
+	duration       time.Duration             //internal representation of `Duration`
+	ret            chan types.Event          //the bucket-specific output chan for overflows
+	processors     []Processor               //processors is the list of hooks for pour/overflow/create (cf. uniq, blackhole etc.)
+	output         bool                      //??
 }
 
 func ValidateFactory(b *BucketFactory) error {
@@ -235,7 +235,7 @@ func LoadBucket(g *BucketFactory, dataFolder string) error {
 	}
 	if g.Debug {
 		visitor := &exprhelpers.Visitor{}
-		g.DebugExprs, err = visitor.Build(g.Filter)
+		g.ExprDebugger, err = visitor.Build(g.Filter)
 		if err != nil {
 			log.Errorf("unable to build debug filter for '%s' : %s", g.Filter, err)
 		}
@@ -509,20 +509,8 @@ func PourItemToHolders(parsed types.Event, holders []BucketFactory, buckets *Buc
 				log.Fatalf("Filter issue")
 			}
 
-			if condition {
-				holder.logger.Debugf("eval(%s) = TRUE ", holder.Filter)
-			} else {
-				holder.logger.Debugf("eval(%s) = FALSE ", holder.Filter)
-			}
 			if holder.Debug {
-				holder.logger.Debugf("variables:")
-				for _, d := range holder.DebugExprs {
-					debug, err := expr.Run(d.DebugExpr, exprhelpers.GetExprEnv(map[string]interface{}{"evt": &parsed}))
-					if err != nil {
-						holder.logger.Errorf("unable to print debug expression for '%s': %s", d.DebugStr, err)
-					}
-					holder.logger.Debugf("       %s = '%s'", d.DebugStr, debug)
-				}
+				holder.ExprDebugger.Run(holder.logger, condition, exprhelpers.GetExprEnv(map[string]interface{}{"evt": &parsed}))
 			}
 			if !condition {
 				holder.logger.Debugf("Event leaving node : ko")

--- a/pkg/leakybucket/manager.go
+++ b/pkg/leakybucket/manager.go
@@ -54,7 +54,7 @@ type BucketFactory struct {
 	BucketName     string                    `yaml:"-"`
 	Filename       string                    `yaml:"-"`
 	RunTimeFilter  *vm.Program               `json:"-"`
-	ExprDebugger   *exprhelpers.ExprDebugger `yaml:"-" json:"-"`
+	ExprDebugger   *exprhelpers.ExprDebugger `yaml:"-" json:"-"` // used to debug expression by printing the content of each variable of the expression
 	RunTimeGroupBy *vm.Program               `json:"-"`
 	Data           []*types.DataSource       `yaml:"data,omitempty"`
 	leakspeed      time.Duration             //internal representation of `Leakspeed`
@@ -235,7 +235,7 @@ func LoadBucket(g *BucketFactory, dataFolder string) error {
 	}
 	if g.Debug {
 		visitor := &exprhelpers.Visitor{}
-		g.ExprDebugger, err = visitor.Build(g.Filter)
+		g.ExprDebugger, err = visitor.Build(g.Filter, expr.Env(exprhelpers.GetExprEnv(map[string]interface{}{"evt": &types.Event{}})))
 		if err != nil {
 			log.Errorf("unable to build debug filter for '%s' : %s", g.Filter, err)
 		}

--- a/pkg/leakybucket/manager.go
+++ b/pkg/leakybucket/manager.go
@@ -525,7 +525,7 @@ func PourItemToHolders(parsed types.Event, holders []BucketFactory, buckets *Buc
 				}
 				if !condition {
 					holder.logger.Debugf("Event leaving node : ko")
-					return false, nil
+					continue
 				}
 			}
 		}

--- a/pkg/leakybucket/manager.go
+++ b/pkg/leakybucket/manager.go
@@ -31,36 +31,37 @@ import (
 // BucketFactory struct holds all fields for any bucket configuration. This is to have a
 // generic struct for buckets. This can be seen as a bucket factory.
 type BucketFactory struct {
-	FormatVersion  string              `yaml:"format"`
-	Author         string              `yaml:"author"`
-	Description    string              `yaml:"description"`
-	References     []string            `yaml:"references"`
-	Type           string              `yaml:"type"`                //Type can be : leaky, counter, trigger. It determines the main bucket characteristics
-	Name           string              `yaml:"name"`                //Name of the bucket, used later in log and user-messages. Should be unique
-	Capacity       int                 `yaml:"capacity"`            //Capacity is applicable to leaky buckets and determines the "burst" capacity
-	LeakSpeed      string              `yaml:"leakspeed"`           //Leakspeed is a float representing how many events per second leak out of the bucket
-	Duration       string              `yaml:"duration"`            //Duration allows 'counter' buckets to have a fixed life-time
-	Filter         string              `yaml:"filter"`              //Filter is an expr that determines if an event is elligible for said bucket. Filter is evaluated against the Event struct
-	GroupBy        string              `yaml:"groupby,omitempty"`   //groupy is an expr that allows to determine the partitions of the bucket. A common example is the source_ip
-	Distinct       string              `yaml:"distinct"`            //Distinct, when present, adds a `Pour()` processor that will only pour uniq items (based on uniq_filter expr result)
-	Debug          bool                `yaml:"debug"`               //Debug, when set to true, will enable debugging for _this_ scenario specifically
-	Labels         map[string]string   `yaml:"labels"`              //Labels is K:V list aiming at providing context the overflow
-	Blackhole      string              `yaml:"blackhole,omitempty"` //Blackhole is a duration that, if present, will prevent same bucket partition to overflow more often than $duration
-	logger         *log.Entry          `yaml:"-"`                   //logger is bucket-specific logger (used by Debug as well)
-	Reprocess      bool                `yaml:"reprocess"`           //Reprocess, if true, will for the bucket to be re-injected into processing chain
-	CacheSize      int                 `yaml:"cache_size"`          //CacheSize, if > 0, limits the size of in-memory cache of the bucket
-	Profiling      bool                `yaml:"profiling"`           //Profiling, if true, will make the bucket record pours/overflows/etc.
-	OverflowFilter string              `yaml:"overflow_filter"`     //OverflowFilter if present, is a filter that must return true for the overflow to go through
-	BucketName     string              `yaml:"-"`
-	Filename       string              `yaml:"-"`
-	RunTimeFilter  *vm.Program         `json:"-"`
-	RunTimeGroupBy *vm.Program         `json:"-"`
-	Data           []*types.DataSource `yaml:"data,omitempty"`
-	leakspeed      time.Duration       //internal representation of `Leakspeed`
-	duration       time.Duration       //internal representation of `Duration`
-	ret            chan types.Event    //the bucket-specific output chan for overflows
-	processors     []Processor         //processors is the list of hooks for pour/overflow/create (cf. uniq, blackhole etc.)
-	output         bool                //??
+	FormatVersion  string                   `yaml:"format"`
+	Author         string                   `yaml:"author"`
+	Description    string                   `yaml:"description"`
+	References     []string                 `yaml:"references"`
+	Type           string                   `yaml:"type"`                //Type can be : leaky, counter, trigger. It determines the main bucket characteristics
+	Name           string                   `yaml:"name"`                //Name of the bucket, used later in log and user-messages. Should be unique
+	Capacity       int                      `yaml:"capacity"`            //Capacity is applicable to leaky buckets and determines the "burst" capacity
+	LeakSpeed      string                   `yaml:"leakspeed"`           //Leakspeed is a float representing how many events per second leak out of the bucket
+	Duration       string                   `yaml:"duration"`            //Duration allows 'counter' buckets to have a fixed life-time
+	Filter         string                   `yaml:"filter"`              //Filter is an expr that determines if an event is elligible for said bucket. Filter is evaluated against the Event struct
+	GroupBy        string                   `yaml:"groupby,omitempty"`   //groupy is an expr that allows to determine the partitions of the bucket. A common example is the source_ip
+	Distinct       string                   `yaml:"distinct"`            //Distinct, when present, adds a `Pour()` processor that will only pour uniq items (based on uniq_filter expr result)
+	Debug          bool                     `yaml:"debug"`               //Debug, when set to true, will enable debugging for _this_ scenario specifically
+	Labels         map[string]string        `yaml:"labels"`              //Labels is K:V list aiming at providing context the overflow
+	Blackhole      string                   `yaml:"blackhole,omitempty"` //Blackhole is a duration that, if present, will prevent same bucket partition to overflow more often than $duration
+	logger         *log.Entry               `yaml:"-"`                   //logger is bucket-specific logger (used by Debug as well)
+	Reprocess      bool                     `yaml:"reprocess"`           //Reprocess, if true, will for the bucket to be re-injected into processing chain
+	CacheSize      int                      `yaml:"cache_size"`          //CacheSize, if > 0, limits the size of in-memory cache of the bucket
+	Profiling      bool                     `yaml:"profiling"`           //Profiling, if true, will make the bucket record pours/overflows/etc.
+	OverflowFilter string                   `yaml:"overflow_filter"`     //OverflowFilter if present, is a filter that must return true for the overflow to go through
+	BucketName     string                   `yaml:"-"`
+	Filename       string                   `yaml:"-"`
+	RunTimeFilter  *vm.Program              `json:"-"`
+	DebugExprs     []*exprhelpers.DebugExpr `yaml:"-" json:"-"`
+	RunTimeGroupBy *vm.Program              `json:"-"`
+	Data           []*types.DataSource      `yaml:"data,omitempty"`
+	leakspeed      time.Duration            //internal representation of `Leakspeed`
+	duration       time.Duration            //internal representation of `Duration`
+	ret            chan types.Event         //the bucket-specific output chan for overflows
+	processors     []Processor              //processors is the list of hooks for pour/overflow/create (cf. uniq, blackhole etc.)
+	output         bool                     //??
 }
 
 func ValidateFactory(b *BucketFactory) error {
@@ -231,6 +232,13 @@ func LoadBucket(g *BucketFactory, dataFolder string) error {
 	g.RunTimeFilter, err = expr.Compile(g.Filter, expr.Env(exprhelpers.GetExprEnv(map[string]interface{}{"evt": &types.Event{}})))
 	if err != nil {
 		return fmt.Errorf("invalid filter '%s' in %s : %v", g.Filter, g.Filename, err)
+	}
+	if g.Debug {
+		visitor := &exprhelpers.Visitor{}
+		g.DebugExprs, err = visitor.Build(g.Filter)
+		if err != nil {
+			log.Errorf("unable to build debug filter for '%s' : %s", g.Filter, err)
+		}
 	}
 
 	if g.GroupBy != "" {
@@ -500,13 +508,25 @@ func PourItemToHolders(parsed types.Event, holders []BucketFactory, buckets *Buc
 				holder.logger.Errorf("unexpected non-bool return : %T", output)
 				log.Fatalf("Filter issue")
 			}
-			if !condition {
-				holder.logger.Debugf("eval(FALSE) %s", holder.Filter)
-				//log.Debugf("%s -> FALSE", holder.Filter)
-				//holder.logger.Debugf("Filter eval failed")
-				continue
-			} else {
-				holder.logger.Debugf("eval(TRUE) %s", holder.Filter)
+
+			if holder.Debug {
+				if condition {
+					holder.logger.Debugf("eval(%s) = TRUE ", holder.Filter)
+				} else {
+					holder.logger.Debugf("eval(%s) = FALSE ", holder.Filter)
+				}
+				holder.logger.Debugf("variables:")
+				for _, d := range holder.DebugExprs {
+					debug, err := expr.Run(d.DebugExpr, exprhelpers.GetExprEnv(map[string]interface{}{"evt": &parsed}))
+					if err != nil {
+						holder.logger.Errorf("unable to print debug expression for '%s': %s", d.DebugStr, err)
+					}
+					holder.logger.Debugf("       %s = '%s'", d.DebugStr, debug)
+				}
+				if !condition {
+					holder.logger.Debugf("Event leaving node : ko")
+					return false, nil
+				}
 			}
 		}
 

--- a/pkg/leakybucket/manager.go
+++ b/pkg/leakybucket/manager.go
@@ -234,8 +234,7 @@ func LoadBucket(g *BucketFactory, dataFolder string) error {
 		return fmt.Errorf("invalid filter '%s' in %s : %v", g.Filter, g.Filename, err)
 	}
 	if g.Debug {
-		visitor := &exprhelpers.Visitor{}
-		g.ExprDebugger, err = visitor.Build(g.Filter, expr.Env(exprhelpers.GetExprEnv(map[string]interface{}{"evt": &types.Event{}})))
+		g.ExprDebugger, err = exprhelpers.NewDebugger(g.Filter, expr.Env(exprhelpers.GetExprEnv(map[string]interface{}{"evt": &types.Event{}})))
 		if err != nil {
 			log.Errorf("unable to build debug filter for '%s' : %s", g.Filter, err)
 		}

--- a/pkg/parser/node.go
+++ b/pkg/parser/node.go
@@ -3,8 +3,12 @@ package parser
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/antonmedv/expr"
+	"github.com/antonmedv/expr/ast"
+	"github.com/antonmedv/expr/parser"
+
 	"github.com/antonmedv/expr/vm"
 	"github.com/crowdsecurity/crowdsec/pkg/exprhelpers"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
@@ -13,6 +17,37 @@ import (
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
+
+type visitor struct {
+	newVar     bool
+	currentID  string
+	properties []string
+	vars       []string
+}
+
+func (v *visitor) Enter(node *ast.Node) {}
+func (v *visitor) Exit(node *ast.Node) {
+	if n, ok := (*node).(*ast.IdentifierNode); ok {
+		if !v.newVar {
+			v.newVar = true
+			v.currentID = n.Value
+		} else {
+			v.newVar = false
+			fullVar := fmt.Sprintf("%s.%s", v.currentID, strings.Join(v.properties, "."))
+			v.vars = append(v.vars, fullVar)
+			v.properties = []string{}
+			v.currentID = n.Value
+		}
+	}
+	if n, ok := (*node).(*ast.PropertyNode); ok {
+		v.properties = append(v.properties, n.Property)
+	}
+}
+
+type DebugExpr struct {
+	debugStr  string
+	debugExpr *vm.Program
+}
 
 type Node struct {
 	FormatVersion string `yaml:"format"`
@@ -36,9 +71,9 @@ type Node struct {
 	rn        string //this is only for us in debug, a random generated name for each node
 	//Filter is executed at runtime (with current log line as context)
 	//and must succeed or node is exited
-	Filter        string      `yaml:"filter,omitempty"`
-	RunTimeFilter *vm.Program `yaml:"-" json:"-"` //the actual compiled filter
-
+	Filter        string       `yaml:"filter,omitempty"`
+	RunTimeFilter *vm.Program  `yaml:"-" json:"-"` //the actual compiled filter
+	DebugExprs    []*DebugExpr `yaml:"-" json:"-"`
 	//If node has leafs, execute all of them until one asks for a 'break'
 	SuccessNodes []Node `yaml:"nodes,omitempty"`
 	//Flag used to describe when to 'break' or return an 'error'
@@ -121,11 +156,26 @@ func (n *Node) process(p *types.Event, ctx UnixParserCtx) (bool, error) {
 			clog.Debugf("Event leaving node : ko")
 			return false, nil
 		}
+
 		switch out := output.(type) {
 		case bool:
 			/* filter returned false, don't process Node */
 			if !out {
-				clog.Debugf("eval(FALSE) '%s'", n.Filter)
+				if n.Debug {
+					if out {
+						clog.Debugf("result: TRUE | expression: '%s'", n.Filter)
+					} else {
+						clog.Debugf("result: FALSE | expression: '%s'", n.Filter)
+					}
+					log.Printf("variables list: ")
+					for _, d := range n.DebugExprs {
+						debug, err := expr.Run(d.debugExpr, exprhelpers.GetExprEnv(map[string]interface{}{"evt": p}))
+						if err != nil {
+							log.Errorf("unable to print debug expression for '%s': %s", d.debugStr, err)
+						}
+						log.Printf("   %s = '%s'", d.debugStr, debug)
+					}
+				}
 				clog.Debugf("Event leaving node : ko")
 				return false, nil
 			}
@@ -377,6 +427,29 @@ func (n *Node) compile(pctx *UnixParserCtx) error {
 		if err != nil {
 			return fmt.Errorf("compilation of '%s' failed: %v", n.Filter, err)
 		}
+
+		if n.Debug {
+			tree, err := parser.Parse(n.Filter)
+			if err != nil {
+				log.Errorf("unable to parse tree filter for '%s' : %s", n.Filter, err)
+			}
+			visitor := &visitor{newVar: false}
+			ast.Walk(&tree.Node, visitor)
+			fullVar := fmt.Sprintf("%s.%s", visitor.currentID, strings.Join(visitor.properties, "."))
+			visitor.vars = append(visitor.vars, fullVar)
+			for _, variable := range visitor.vars {
+				debugFilter, err := expr.Compile(variable, expr.Env(exprhelpers.GetExprEnv(map[string]interface{}{"evt": &types.Event{}})))
+				debugExpr := &DebugExpr{
+					variable,
+					debugFilter,
+				}
+				n.DebugExprs = append(n.DebugExprs, debugExpr)
+				if err != nil {
+					return fmt.Errorf("compilation of variable '%s' failed: %v", variable, err)
+				}
+			}
+		}
+
 	}
 
 	/* handle pattern_syntax and groks */

--- a/pkg/parser/node.go
+++ b/pkg/parser/node.go
@@ -383,8 +383,7 @@ func (n *Node) compile(pctx *UnixParserCtx) error {
 		}
 
 		if n.Debug {
-			visitor := &exprhelpers.Visitor{}
-			n.ExprDebugger, err = visitor.Build(n.Filter, expr.Env(exprhelpers.GetExprEnv(map[string]interface{}{"evt": &types.Event{}})))
+			n.ExprDebugger, err = exprhelpers.NewDebugger(n.Filter, expr.Env(exprhelpers.GetExprEnv(map[string]interface{}{"evt": &types.Event{}})))
 			if err != nil {
 				log.Errorf("unable to build debug filter for '%s' : %s", n.Filter, err)
 			}
@@ -493,8 +492,7 @@ func (n *Node) compile(pctx *UnixParserCtx) error {
 		if err != nil {
 			n.logger.Fatalf("Unable to compile whitelist expression '%s' : %v.", filter, err)
 		}
-		visitor := exprhelpers.Visitor{}
-		expression.ExprDebugger, err = visitor.Build(filter, expr.Env(exprhelpers.GetExprEnv(map[string]interface{}{"evt": &types.Event{}})))
+		expression.ExprDebugger, err = exprhelpers.NewDebugger(filter, expr.Env(exprhelpers.GetExprEnv(map[string]interface{}{"evt": &types.Event{}})))
 		if err != nil {
 			log.Errorf("unable to build debug filter for '%s' : %s", filter, err)
 		}

--- a/pkg/parser/node.go
+++ b/pkg/parser/node.go
@@ -125,13 +125,12 @@ func (n *Node) process(p *types.Event, ctx UnixParserCtx) (bool, error) {
 
 		switch out := output.(type) {
 		case bool:
-			/* filter returned false, don't process Node */
+			if out {
+				clog.Debugf("eval(%s) = TRUE ", n.Filter)
+			} else {
+				clog.Debugf("eval(%s) = FALSE ", n.Filter)
+			}
 			if n.Debug {
-				if out {
-					clog.Debugf("eval(%s) = TRUE ", n.Filter)
-				} else {
-					clog.Debugf("eval(%s) = FALSE ", n.Filter)
-				}
 				clog.Debugf("variables:")
 				for _, d := range n.DebugExprs {
 					debug, err := expr.Run(d.DebugExpr, exprhelpers.GetExprEnv(map[string]interface{}{"evt": p}))
@@ -140,10 +139,10 @@ func (n *Node) process(p *types.Event, ctx UnixParserCtx) (bool, error) {
 					}
 					clog.Debugf("       %s = '%s'", d.DebugStr, debug)
 				}
-				if !out {
-					clog.Debugf("Event leaving node : ko")
-					return false, nil
-				}
+			}
+			if !out {
+				clog.Debugf("Event leaving node : ko")
+				return false, nil
 			}
 		default:
 			clog.Warningf("Expr '%s' returned non-bool, abort : %T", n.Filter, output)

--- a/pkg/parser/stage.go
+++ b/pkg/parser/stage.go
@@ -48,6 +48,7 @@ func LoadStages(stageFiles []Stagefile, pctx *UnixParserCtx) ([]Node, error) {
 			log.Warningf("skip non yaml : %s", stageFile.Filename)
 			continue
 		}
+		log.Debugf("loading parser file '%s'", stageFile)
 		st, err := os.Stat(stageFile.Filename)
 		if err != nil {
 			return nil, fmt.Errorf("failed to stat %s : %v", stageFile, err)

--- a/pkg/types/whitelist.go
+++ b/pkg/types/whitelist.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	"github.com/antonmedv/expr/vm"
+	"github.com/crowdsecurity/crowdsec/pkg/exprhelpers"
 )
 
 type Whitelist struct {
@@ -13,5 +14,10 @@ type Whitelist struct {
 	Cidrs   []string `yaml:"cidr,omitempty"`
 	B_Cidrs []*net.IPNet
 	Exprs   []string `yaml:"expression,omitempty"`
-	B_Exprs []*vm.Program
+	B_Exprs []*ExprWhitelist
+}
+
+type ExprWhitelist struct {
+	Filter       *vm.Program
+	ExprDebugger *exprhelpers.ExprDebugger // used to debug expression by printing the content of each variable of the expression
 }


### PR DESCRIPTION
Possibility to debug filter expression in parser and leakybucket by setting de node debug to `true` .

Exemple: 

```
EBU[30-07-2020 21:38:48] eval(evt.Meta.log_type == 'ssh_failed-auth') = TRUE   cfg=misty-dream file=config/scenarios/ssh-bf.yaml name=crowdsecurity/ssh-bf
DEBU[30-07-2020 21:38:48] variables:                                    cfg=misty-dream file=config/scenarios/ssh-bf.yaml name=crowdsecurity/ssh-bf
DEBU[30-07-2020 21:38:48]        evt.Meta.log_type = 'ssh_failed-auth'  cfg=misty-dream file=config/scenarios/ssh-bf.yaml name=crowdsecurity/ssh-bf
DEBU[30-07-2020 21:38:48] Pouring event.                                bucket_id=bitter-cloud capacity=5 cfg=misty-dream file=config/scenarios/ssh-bf.yaml name=crowdsecurity/ssh-bf
```