### PR TITLE
add a warning when a grok pattern ends with \n

### DIFF
--- a/pkg/parser/node.go
+++ b/pkg/parser/node.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/antonmedv/expr"
 
@@ -412,6 +413,9 @@ func (n *Node) compile(pctx *UnixParserCtx) error {
 		n.logger.Debugf("%s regexp: %s", n.Grok.RegexpName, n.Grok.RunTimeRegexp.Regexp.String())
 		valid = true
 	} else if n.Grok.RegexpValue != "" {
+		if strings.HasSuffix(n.Grok.RegexpValue, "\n") {
+			n.logger.Debugf("Beware, pattern ends with \\n : '%s'", n.Grok.RegexpValue)
+		}
 		//n.logger.Debugf("+ Regexp Compilation '%s'", n.Grok.RegexpValue)
 		n.Grok.RunTimeRegexp, err = pctx.Grok.Compile(n.Grok.RegexpValue)
 		if err != nil {


### PR DESCRIPTION
 ... because it might not be what the user wants and might lead to some weird pattern matching issues :+1: 