### PR TITLE
[wip] Fix mulitple plugins

### DIFF
--- a/pkg/cwplugin/backend.go
+++ b/pkg/cwplugin/backend.go
@@ -209,9 +209,9 @@ func (b *BackendManager) StartAutoCommit() error {
 
 func (b *BackendManager) ReadAT(timeAT time.Time) ([]map[string]string, error) {
 	var ret []map[string]string
-	var err error
 	for _, plugin := range b.backendPlugins {
-		ret, err = plugin.funcs.ReadAT(timeAT)
+		subret, err := plugin.funcs.ReadAT(timeAT)
+		ret = append(ret, subret...)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When more than one backend plugin is present and `ReadAT` is called, concat results from each plugin. This allow multiple plugins to coexist without breaking the `cscli ban list` feature.