### PR TITLE
add metrics when inspecting an item

### DIFF
--- a/cmd/crowdsec-cli/collection.go
+++ b/cmd/crowdsec-cli/collection.go
@@ -123,6 +123,7 @@ you should [update cscli](./cscli_update.md).
 			InspectItem(args[0], cwhub.COLLECTIONS)
 		},
 	}
+	cmdCollectionInspect.PersistentFlags().StringVarP(&prometheusURL, "url", "u", "http://127.0.0.1:6060/metrics", "Prometheus url")
 	cmdCollection.AddCommand(cmdCollectionInspect)
 
 	return cmdCollection

--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -26,6 +26,8 @@ var removeAll bool
 var purgeRemove bool
 var upgradeAll bool
 
+var prometheusURL string
+
 func initConfig() {
 
 	csConfig = csconfig.NewConfig()

--- a/cmd/crowdsec-cli/metrics.go
+++ b/cmd/crowdsec-cli/metrics.go
@@ -229,7 +229,7 @@ func NewMetricsCmd() *cobra.Command {
 			ShowPrometheus(purl)
 		},
 	}
-	cmdMetrics.PersistentFlags().StringVarP(&purl, "url", "u", "http://127.0.0.1:6060/metrics", "Prometheus url")
+	cmdMetrics.PersistentFlags().StringVarP(&prometheusURL, "url", "u", "http://127.0.0.1:6060/metrics", "Prometheus url")
 
 	return cmdMetrics
 }

--- a/cmd/crowdsec-cli/parser.go
+++ b/cmd/crowdsec-cli/parser.go
@@ -123,6 +123,7 @@ you should [update cscli](./cscli_update.md).
 			InspectItem(args[0], cwhub.PARSERS)
 		},
 	}
+	cmdParserInspect.PersistentFlags().StringVarP(&prometheusURL, "url", "u", "http://127.0.0.1:6060/metrics", "Prometheus url")
 	cmdParser.AddCommand(cmdParserInspect)
 
 	return cmdParser

--- a/cmd/crowdsec-cli/scenario.go
+++ b/cmd/crowdsec-cli/scenario.go
@@ -123,6 +123,7 @@ you should [update cscli](./cscli_update.md).
 			InspectItem(args[0], cwhub.SCENARIOS)
 		},
 	}
+	cmdScenarioInspect.PersistentFlags().StringVarP(&prometheusURL, "url", "u", "http://127.0.0.1:6060/metrics", "Prometheus url")
 	cmdScenario.AddCommand(cmdScenarioInspect)
 
 	return cmdScenario

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -2,10 +2,18 @@ package main
 
 import (
 	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/enescakir/emoji"
+	"github.com/olekukonko/tablewriter"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/prom2json"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v2"
@@ -178,4 +186,196 @@ func InspectItem(name string, objectType string) {
 	}
 	fmt.Printf("%s", string(buff))
 
+	fmt.Printf("\nCurrent metrics : \n\n")
+	ShowMetrics(hubItem)
+
+}
+
+func ShowMetrics(hubItem *cwhub.Item) {
+	switch hubItem.Type {
+	case cwhub.PARSERS:
+		metrics := GetParserMetric(prometheusURL, hubItem.Name)
+		ShowParserMetric(hubItem.Name, metrics)
+	case cwhub.SCENARIOS:
+		metrics := GetScenarioMetric(prometheusURL, hubItem.Name)
+		ShowScenarioMetric(hubItem.Name, metrics)
+	case cwhub.COLLECTIONS:
+		for _, item := range hubItem.Parsers {
+			metrics := GetParserMetric(prometheusURL, item)
+			ShowParserMetric(item, metrics)
+		}
+		for _, item := range hubItem.Scenarios {
+			metrics := GetScenarioMetric(prometheusURL, item)
+			ShowScenarioMetric(item, metrics)
+		}
+		for _, item := range hubItem.Collections {
+			hubItem := cwhub.GetItem(cwhub.COLLECTIONS, item)
+			if hubItem == nil {
+				log.Fatalf("unable to retrieve item '%s' from collection '%s'", item, hubItem.Name)
+			}
+			ShowMetrics(hubItem)
+		}
+	default:
+		log.Errorf("item of type '%s' is unknown", hubItem.Type)
+	}
+}
+
+/*This is a complete rip from prom2json*/
+func GetParserMetric(url string, itemName string) map[string]map[string]int {
+	stats := make(map[string]map[string]int)
+
+	result := GetPrometheusMetric(url)
+	for idx, fam := range result {
+		if !strings.HasPrefix(fam.Name, "cs_") {
+			continue
+		}
+		log.Debugf("round %d", idx)
+		for _, m := range fam.Metrics {
+			metric := m.(prom2json.Metric)
+			name, ok := metric.Labels["name"]
+			if !ok {
+				log.Debugf("no name in Metric %v", metric.Labels)
+			}
+			if name != itemName {
+				continue
+			}
+			source, ok := metric.Labels["source"]
+			if !ok {
+				log.Debugf("no source in Metric %v", metric.Labels)
+			}
+			value := m.(prom2json.Metric).Value
+			fval, err := strconv.ParseFloat(value, 32)
+			if err != nil {
+				log.Errorf("Unexpected int value %s : %s", value, err)
+			}
+			ival := int(fval)
+
+			switch fam.Name {
+			case "cs_reader_hits_total":
+				if _, ok := stats[source]; !ok {
+					stats[source] = make(map[string]int)
+				}
+				stats[source]["reads"] += ival
+			case "cs_parser_hits_ok_total":
+				if _, ok := stats[source]; !ok {
+					stats[source] = make(map[string]int)
+				}
+				stats[source]["parsed"] += ival
+			case "cs_parser_hits_ko_total":
+				if _, ok := stats[source]; !ok {
+					stats[source] = make(map[string]int)
+				}
+				stats[source]["unparsed"] += ival
+			case "cs_node_hits_total":
+				if _, ok := stats[source]; !ok {
+					stats[source] = make(map[string]int)
+				}
+				stats[source]["hits"] += ival
+			case "cs_node_hits_ok_total":
+				if _, ok := stats[source]; !ok {
+					stats[source] = make(map[string]int)
+				}
+				stats[source]["parsed"] += ival
+			case "cs_node_hits_ko_total":
+				if _, ok := stats[source]; !ok {
+					stats[source] = make(map[string]int)
+				}
+				stats[source]["unparsed"] += ival
+			default:
+				continue
+			}
+		}
+	}
+	return stats
+}
+
+func GetScenarioMetric(url string, itemName string) map[string]int {
+	stats := make(map[string]int)
+
+	result := GetPrometheusMetric(url)
+	for idx, fam := range result {
+		if !strings.HasPrefix(fam.Name, "cs_") {
+			continue
+		}
+		log.Debugf("round %d", idx)
+		for _, m := range fam.Metrics {
+			metric := m.(prom2json.Metric)
+			name, ok := metric.Labels["name"]
+			if !ok {
+				log.Debugf("no name in Metric %v", metric.Labels)
+			}
+			if name != itemName {
+				continue
+			}
+			value := m.(prom2json.Metric).Value
+			fval, err := strconv.ParseFloat(value, 32)
+			if err != nil {
+				log.Errorf("Unexpected int value %s : %s", value, err)
+			}
+			ival := int(fval)
+
+			switch fam.Name {
+			case "cs_bucket_created_total":
+				stats["instanciation"] += ival
+			case "cs_buckets":
+				stats["curr_count"] += ival
+			case "cs_bucket_overflowed_total":
+				stats["overflow"] += ival
+			case "cs_bucket_poured_total":
+				stats["pour"] += ival
+			case "cs_bucket_underflowed_total":
+				stats["underflow"] += ival
+			default:
+				continue
+			}
+		}
+	}
+	return stats
+}
+
+func GetPrometheusMetric(url string) []*prom2json.Family {
+	mfChan := make(chan *dto.MetricFamily, 1024)
+
+	// Start with the DefaultTransport for sane defaults.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// Conservatively disable HTTP keep-alives as this program will only
+	// ever need a single HTTP request.
+	transport.DisableKeepAlives = true
+	// Timeout early if the server doesn't even return the headers.
+	transport.ResponseHeaderTimeout = time.Minute
+
+	go func() {
+		err := prom2json.FetchMetricFamilies(url, mfChan, transport)
+		if err != nil {
+			log.Fatalf("failed to fetch prometheus metrics : %v", err)
+		}
+	}()
+
+	result := []*prom2json.Family{}
+	for mf := range mfChan {
+		result = append(result, prom2json.NewFamily(mf))
+	}
+	log.Debugf("Finished reading prometheus output, %d entries", len(result))
+
+	return result
+}
+
+func ShowScenarioMetric(itemName string, metrics map[string]int) {
+	fmt.Printf(" - (Scenario) %s: \n", itemName)
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Current Count", "Overflows", "Instanciated", "Poured", "Expired"})
+	table.Append([]string{fmt.Sprintf("%d", metrics["curr_count"]), fmt.Sprintf("%d", metrics["overflow"]), fmt.Sprintf("%d", metrics["instanciation"]), fmt.Sprintf("%d", metrics["pour"]), fmt.Sprintf("%d", metrics["underflow"])})
+	table.Render()
+	fmt.Println()
+}
+
+func ShowParserMetric(itemName string, metrics map[string]map[string]int) {
+	fmt.Printf(" - (Parser) %s: \n", itemName)
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Source", "Lines read", "Lines parsed", "Lines unparsed"})
+	for source, stats := range metrics {
+		table.Append([]string{source, fmt.Sprintf("%d", stats["read"]), fmt.Sprintf("%d", stats["parsed"]), fmt.Sprintf("%d", stats["unparsed"])})
+	}
+	table.Render()
+	fmt.Println()
 }

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -324,7 +324,7 @@ func main() {
 
 	// Enable profiling early
 	if cConfig.Prometheus != nil {
-		registerPrometheus(cConfig.Prometheus.Level)
+		go registerPrometheus(cConfig.Prometheus.Level)
 	}
 	err = exprhelpers.Init()
 	if err != nil {

--- a/cmd/crowdsec/metrics.go
+++ b/cmd/crowdsec/metrics.go
@@ -91,4 +91,5 @@ func registerPrometheus(mode string) {
 
 	}
 	http.Handle("/metrics", promhttp.Handler())
+	http.ListenAndServe(":6060", nil)
 }


### PR DESCRIPTION
Example output when inspecting collection:

```
type: collections
name: crowdsecurity/base-http-scenarios
filename: base-http-scenarios.yaml
description: 'http common : scanners detection'
author: crowdsecurity
remote_path: collections/crowdsecurity/base-http-scenarios.yaml
version: "0.1"
local_path: /home/altered/cs/crowdsec/tests/config/collections/base-http-scenarios.yaml
localversion: "0.1"
localhash: 7ee043a9d2e063cad751e6ce5d048f02518a76d39ec81aebed3bae736b0ced9e
installed: true
downloaded: true
uptodate: true
tainted: false
local: false
parsers:
- crowdsecurity/http-logs
scenarios:
- crowdsecurity/http-crawl-non_statics
- crowdsecurity/http-probing
- crowdsecurity/http-bad-user-agent
- crowdsecurity/http-path-traversal-probing
- crowdsecurity/http-sensitive-files
- crowdsecurity/http-sqli-probing
- crowdsecurity/http-xss-probing
- crowdsecurity/http-backdoors-attempts

Current metrics : 

 - (Parser) crowdsecurity/http-logs: 
+---------------------------+------------+--------------+----------------+
|          SOURCE           | LINES READ | LINES PARSED | LINES UNPARSED |
+---------------------------+------------+--------------+----------------+
| /var/log/nginx/error.log  |          0 |            0 |              1 |
| /var/log/nginx/access.log |          0 |            1 |              0 |
+---------------------------+------------+--------------+----------------+

 - (Scenario) crowdsecurity/http-crawl-non_statics: 
+---------------+-----------+--------------+--------+---------+
| CURRENT COUNT | OVERFLOWS | INSTANCIATED | POURED | EXPIRED |
+---------------+-----------+--------------+--------+---------+
|             1 |         0 |            1 |      1 |       0 |
+---------------+-----------+--------------+--------+---------+

 - (Scenario) crowdsecurity/http-probing: 
+---------------+-----------+--------------+--------+---------+
| CURRENT COUNT | OVERFLOWS | INSTANCIATED | POURED | EXPIRED |
+---------------+-----------+--------------+--------+---------+
|             1 |         0 |            1 |      1 |       0 |
+---------------+-----------+--------------+--------+---------+

 - (Scenario) crowdsecurity/http-bad-user-agent: 
+---------------+-----------+--------------+--------+---------+
| CURRENT COUNT | OVERFLOWS | INSTANCIATED | POURED | EXPIRED |
+---------------+-----------+--------------+--------+---------+
|             0 |         0 |            0 |      0 |       0 |
+---------------+-----------+--------------+--------+---------+

 - (Scenario) crowdsecurity/http-path-traversal-probing: 
+---------------+-----------+--------------+--------+---------+
| CURRENT COUNT | OVERFLOWS | INSTANCIATED | POURED | EXPIRED |
+---------------+-----------+--------------+--------+---------+
|             0 |         0 |            0 |      0 |       0 |
+---------------+-----------+--------------+--------+---------+

 - (Scenario) crowdsecurity/http-sensitive-files: 
+---------------+-----------+--------------+--------+---------+
| CURRENT COUNT | OVERFLOWS | INSTANCIATED | POURED | EXPIRED |
+---------------+-----------+--------------+--------+---------+
|             0 |         0 |            0 |      0 |       0 |
+---------------+-----------+--------------+--------+---------+

 - (Scenario) crowdsecurity/http-sqli-probing: 
+---------------+-----------+--------------+--------+---------+
| CURRENT COUNT | OVERFLOWS | INSTANCIATED | POURED | EXPIRED |
+---------------+-----------+--------------+--------+---------+
|             0 |         0 |            0 |      0 |       0 |
+---------------+-----------+--------------+--------+---------+

 - (Scenario) crowdsecurity/http-xss-probing: 
+---------------+-----------+--------------+--------+---------+
| CURRENT COUNT | OVERFLOWS | INSTANCIATED | POURED | EXPIRED |
+---------------+-----------+--------------+--------+---------+
|             0 |         0 |            0 |      0 |       0 |
+---------------+-----------+--------------+--------+---------+

 - (Scenario) crowdsecurity/http-backdoors-attempts: 
+---------------+-----------+--------------+--------+---------+
| CURRENT COUNT | OVERFLOWS | INSTANCIATED | POURED | EXPIRED |
+---------------+-----------+--------------+--------+---------+
|             1 |         0 |            1 |      1 |       0 |
+---------------+-----------+--------------+--------+---------+
```