### PR TITLE
[lapi] fix oneshot shutdown

### DIFF
--- a/cmd/crowdsec/crowdsec.go
+++ b/cmd/crowdsec/crowdsec.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/acquisition"
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	"github.com/crowdsecurity/crowdsec/pkg/exprhelpers"
+	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -85,10 +87,69 @@ func serveCrowdsec(parsers *parsers) {
 			runCrowdsec(parsers)
 		}()
 
-		<-crowdsecTomb.Dying()
+		/*we should stop in two cases :
+		- crowdsecTomb has been Killed() : it might be shutdown or reload, so stop
+		- acquisTomb is dead, it means that we were in "cat" mode and files are done reading, quit
+		*/
+		waitOnTomb()
+		log.Warningf("Shutting down crowdsec routines")
 		if err := ShutdownCrowdsecRoutines(); err != nil {
 			log.Fatalf("unable to shutdown crowdsec routines: %s", err)
 		}
+		log.Errorf("everything is dead, return crowdsecTomb")
 		return nil
 	})
+}
+
+func waitOnTomb() {
+	for {
+		select {
+		case <-acquisTomb.Dead():
+			/*if it's acquisition dying it means that we were in "cat" mode.
+			while shutting down, we need to give time for all buckets to process in flight data*/
+			log.Warningf("Acquisition is finished, shutting down")
+			bucketCount := leaky.LeakyRoutineCount
+			rounds := 0
+			successiveStillRounds := 0
+			/*
+				While it might make sense to want to shut-down parser/buckets/etc. as soon as acquisition is finished,
+				we might have some pending buckets : buckets that overflowed, but which LeakRoutine are still alive because they
+				are waiting to be able to "commit" (push to api). This can happens specifically in a context where a lot of logs
+				are going to trigger overflow (ie. trigger buckets with ~100% of the logs triggering an overflow).
+
+				To avoid this (which would mean that we would "lose" some overflows), let's monitor the number of live buckets.
+				However, because of the blackhole mechanism, you can't really wait for the number of LeakRoutine to go to zero (we might have to wait $blackhole_duration).
+
+				So : we are waiting for the number of buckets to stop decreasing before returning. "how long" we should wait is a bit of the trick question,
+				as some operations (ie. reverse dns or such in post-overflow) can take some time :)
+			*/
+			for {
+				currBucketCount := leaky.LeakyRoutineCount
+
+				if currBucketCount == 0 {
+					/*no bucket to wait on*/
+					break
+				}
+				if currBucketCount != bucketCount {
+					if rounds == 0 || rounds%2 == 0 {
+						log.Printf("Still %d live LeakRoutines, waiting (was %d)", currBucketCount, bucketCount)
+					}
+					bucketCount = currBucketCount
+					successiveStillRounds = 0
+				} else {
+					if successiveStillRounds > 1 {
+						log.Printf("LeakRoutines commit over.")
+						break
+					}
+					successiveStillRounds++
+				}
+				rounds++
+				time.Sleep(5 * time.Second)
+			}
+			return
+		case <-crowdsecTomb.Dying():
+			log.Warningf("Crowdsec being killed, shutdown")
+			return
+		}
+	}
 }

--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -54,9 +54,11 @@ func reloadHandler(sig os.Signal) error {
 			return fmt.Errorf("unable to init api server: %s", err)
 		}
 		//restore bucket state
-		log.Warningf("Restoring buckets state from %s", tmpFile)
-		if err := leaky.LoadBucketsState(tmpFile, buckets, holders); err != nil {
-			log.Fatalf("unable to restore buckets : %s", err)
+		if tmpFile != "" {
+			log.Warningf("Restoring buckets state from %s", tmpFile)
+			if err := leaky.LoadBucketsState(tmpFile, buckets, holders); err != nil {
+				log.Fatalf("unable to restore buckets : %s", err)
+			}
 		}
 		//reload the simulation state
 		if err := cConfig.LoadSimulation(); err != nil {

--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -118,6 +118,9 @@ func ShutdownCrowdsecRoutines() error {
 	}
 	log.Infof("outputs are done")
 
+	//everything is dead johny
+	crowdsecTomb.Kill(nil)
+
 	return reterr
 }
 
@@ -148,58 +151,6 @@ func termHandler(sig os.Signal) error {
 
 	log.Warningf("all routines are done, bye.")
 	return daemon.ErrStop
-}
-
-func serveOneTimeRun() error {
-	if err := acquisTomb.Wait(); err != nil {
-		log.Warningf("acquisition returned error : %s", err)
-	}
-	log.Infof("acquisition is finished, wait for parser/bucket/ouputs.")
-
-	/*
-		While it might make sense to want to shut-down parser/buckets/etc. as soon as acquisition is finished,
-		we might have some pending buckets : buckets that overflowed, but which LeakRoutine are still alive because they
-		are waiting to be able to "commit" (push to db). This can happens specifically in a context where a lot of logs
-		are going to trigger overflow (ie. trigger buckets with ~100% of the logs triggering an overflow).
-
-		To avoid this (which would mean that we would "lose" some overflows), let's monitor the number of live buckets.
-		However, because of the blackhole mechanism, you can't really wait for the number of LeakRoutine to go to zero (we might have to wait $blackhole_duration).
-
-		So : we are waiting for the number of buckets to stop decreasing before returning. "how long" we should wait is a bit of the trick question,
-		as some operations (ie. reverse dns or such in post-overflow) can take some time :)
-	*/
-
-	bucketCount := leaky.LeakyRoutineCount
-	rounds := 0
-	successiveStillRounds := 0
-	for {
-		rounds++
-		time.Sleep(5 * time.Second)
-		currBucketCount := leaky.LeakyRoutineCount
-		if currBucketCount != bucketCount {
-			if rounds == 0 || rounds%2 == 0 {
-				log.Printf("Still %d live LeakRoutines, waiting (was %d)", currBucketCount, bucketCount)
-			}
-			bucketCount = currBucketCount
-			successiveStillRounds = 0
-		} else {
-			if successiveStillRounds > 1 {
-				log.Printf("LeakRoutines commit over.")
-				break
-			}
-			successiveStillRounds++
-		}
-	}
-
-	time.Sleep(5 * time.Second)
-
-	// wait for the parser to parse all events
-	if err := ShutdownCrowdsecRoutines(); err != nil {
-		log.Errorf("failed shutting down routines : %s", err)
-	}
-	dumpMetrics()
-	log.Warningf("all routines are done, bye.")
-	return nil
 }
 
 func Serve(daemonCTX daemon.Context) error {
@@ -234,35 +185,26 @@ func Serve(daemonCTX daemon.Context) error {
 			log.Infof("lint done")
 			os.Exit(0)
 		}
-		if cConfig.Common != nil && !cConfig.Common.Daemonize {
-			if err := serveOneTimeRun(); err != nil {
-				log.Errorf(err.Error())
-			}
-		} else {
-			serveCrowdsec(csParsers)
-		}
+		serveCrowdsec(csParsers)
 	}
 
-	if cConfig.Common != nil && !cConfig.Common.Daemonize {
+	if cConfig.Common != nil && cConfig.Common.Daemonize {
 		defer daemonCTX.Release() //nolint:errcheck // won't bother checking this error in defer statement
 		err := daemon.ServeSignals()
 		if err != nil {
 			log.Errorf("serveDaemon error : %s", err.Error())
 		}
-	}
-
-	for {
-		select {
-		case <-apiTomb.Dead():
-			if err := shutdownCrowdsec(); err != nil {
-				log.Fatalf("unable to shutdown crowdsec: %s", err)
+	} else {
+		for {
+			select {
+			case <-apiTomb.Dead():
+				log.Errorf("api shutdown")
+				os.Exit(0)
+			case <-crowdsecTomb.Dead():
+				log.Errorf("crowdsec shutdown")
+				os.Exit(0)
 			}
-			os.Exit(0)
-		case <-crowdsecTomb.Dead():
-			if err := shutdownAPI(); err != nil {
-				log.Fatalf("unable to shutdown api: %s", err)
-			}
-			os.Exit(0)
 		}
 	}
+	return nil
 }

--- a/pkg/acquisition/file_reader.go
+++ b/pkg/acquisition/file_reader.go
@@ -335,6 +335,5 @@ func CatFile(ctx FileCtx, output chan types.Event, AcquisTomb *tomb.Tomb) error 
 		clog.Warningf("unmarshaled %d events", count)
 
 	}
-	clog.Infof("force commit")
 	return nil
 }


### PR DESCRIPTION
handle the two case to shutdown :
 - either acquisition's chan is closed : we were in cat mode (daemon or not) and we have nothing to read, we can shutdown
 - either crowdsecTomb or apiTomb are dead and then it's a global shutdown ?
