### PR TITLE
[wip/lapi] cscli http debug

### DIFF
--- a/cmd/crowdsec-cli/alerts.go
+++ b/cmd/crowdsec-cli/alerts.go
@@ -113,7 +113,7 @@ To list/add/delete alerts
 
 	var cmdAlertsList = &cobra.Command{
 		Use:     "list [filter]",
-		Short:   "List alertsxx",
+		Short:   "List alerts",
 		Long:    `List alerts from the LAPI`,
 		Example: `cscli alerts list --scope ip --value 1.2.3.4 --type ban"`,
 		Args:    cobra.MinimumNArgs(0),

--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra/doc"
 )
 
-var dbg_lvl, nfo_lvl, wrn_lvl, err_lvl bool
+var trace_lvl, dbg_lvl, nfo_lvl, wrn_lvl, err_lvl bool
 
 var ConfigFilePath string
 var csConfig *csconfig.GlobalConfig
@@ -31,7 +31,9 @@ var prometheusURL string
 
 func initConfig() {
 
-	if dbg_lvl {
+	if trace_lvl {
+		log.SetLevel(log.TraceLevel)
+	} else if dbg_lvl {
 		log.SetLevel(log.DebugLevel)
 	} else if nfo_lvl {
 		log.SetLevel(log.InfoLevel)
@@ -117,6 +119,7 @@ API interaction:
 	rootCmd.PersistentFlags().BoolVar(&nfo_lvl, "info", false, "Set logging to info.")
 	rootCmd.PersistentFlags().BoolVar(&wrn_lvl, "warning", false, "Set logging to warning.")
 	rootCmd.PersistentFlags().BoolVar(&err_lvl, "error", false, "Set logging to error.")
+	rootCmd.PersistentFlags().BoolVar(&trace_lvl, "trace", false, "Set logging to trace.")
 
 	rootCmd.PersistentFlags().StringVar(&cwhub.HubBranch, "branch", "", "Override hub branch on github")
 	if err := rootCmd.PersistentFlags().MarkHidden("branch"); err != nil {

--- a/pkg/apiclient/auth.go
+++ b/pkg/apiclient/auth.go
@@ -115,7 +115,7 @@ func (t *JWTTransport) refreshJwtToken() error {
 
 	if log.GetLevel() >= log.TraceLevel {
 		dump, _ := httputil.DumpResponse(resp, true)
-		log.Tracef("resp-api: %s", string(dump))
+		log.Tracef("resp-jwt: %s", string(dump))
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
 - cscli with `--debug` will provide extra info on outgoing HTTP requests.
 - cscli with `--trace` will print HTTP requests/responses


```
$ ./cmd/crowdsec-cli/cscli decisions list --debug
...
DEBU[0000] req-jwt: GET http://localhost:8080/alerts/?has_active_decision=true 
DEBU[0000] resp-jwt: 301                                
DEBU[0000] req-jwt: GET http://localhost:8080/alerts?has_active_decision=true 
DEBU[0000] resp-jwt: 200                                
+----+----------+--------------+-------------------------------------------+--------+---------+----+--------+---------------------------+
| ID |  SOURCE  | SCOPE:VALUE  |                  REASON                   | ACTION | COUNTRY | AS | EVENTS |        CREATED AT         |

```


```
$ ./cmd/crowdsec-cli/cscli decisions list --trace
...
TRAC[0000] req-jwt(auth): POST /watchers/login HTTP/1.1
Host: localhost:8080
Content-Type: application/json

{"machine_id":"82929df7ee39....arios":null} 
TRAC[0000] resp-api: HTTP/1.1 200 OK
Content-Length: 248
Content-Type: application/json; charset=utf-8
Date: Thu, 01 Oct 2020 08:29:02 GMT

{"code":2...k"} 
DEBU[0000] req-jwt: GET http://localhost:8080/alerts/?has_active_decision=true 
TRAC[0000] req-jwt: GET /alerts/?has_active_decision=true HTTP/1.1
Host: localhost:8080
Authorization: Bea...
User-Agent: crowdsec-v0.3.3-7c7d033b9305403849879bd542947741f8522e0b
 
TRAC[0000] resp-jwt: HTTP/1.1 301 Moved Permanently
Content-Length: 67
Content-Type: text/html; charset=utf-8
Date: Thu, 01 Oct 2020 08:29:02 GMT
Location: /alerts?has_active_decision=true

<a href="/alerts?has_active_decision=true">Moved Permanently</a>.
 
DEBU[0000] resp-jwt: 301                                
DEBU[0000] req-jwt: GET http://localhost:8080/alerts?has_active_decision=true 
TRAC[0000] req-jwt: GET /alerts?has_active_decision=true HTTP/0.0
Host: localhost:8080
Authorization: Be...
Referer: http://localhost:8080/alerts/?has_active_decision=true
User-Agent: crowdsec-v0.3.3-7c7d033b9305403849879bd542947741f8522e0b
 
TRAC[0000] resp-jwt: HTTP/1.1 200 OK
Transfer-Encoding: chunked
Content-Type: application/json; charset=utf-8
Date: Thu, 01 Oct 2020 08:29:02 GMT

20a7
[{"c...+0200"}]
0
 
DEBU[0000] resp-jwt: 200                                
+----+----------+--------------+-------------------------------------------+--------+---------+----+--------+---------------------------+
| ID |  SOURCE  | SCOPE:VALUE  |                  REASON                   | ACTION | COUNTRY | AS | EVENTS |        CREATED AT         |
+----+----------+--------------+-------------------------------------------+--------+---------+----+--------+---------------------------+
|  1 | crowdsec | Ip:127.0.0.1 | crowdsecurity/http-bad-user-agent         | ban    |         |    |      2 | 2020-10-01T09:14:09+02:00 |

```

