### PR TITLE
[Wip/lapi] routines control

### DIFF
--- a/cmd/crowdsec/crowdsec.go
+++ b/cmd/crowdsec/crowdsec.go
@@ -55,23 +55,29 @@ func runCrowdsec(parsers *parsers) error {
 		})
 	}
 
-	bucketsTomb.Go(func() error {
-		err := runPour(inputEventChan, holders, buckets)
-		if err != nil {
-			log.Errorf("runPour error : %s", err)
-			return err
-		}
-		return nil
-	})
+	//start go-routines for parsing, buckets pour and ouputs.
+	for i := 0; i < cConfig.Crowdsec.BucketRoutinesCount; i++ {
+		bucketsTomb.Go(func() error {
+			err := runPour(inputEventChan, holders, buckets)
+			if err != nil {
+				log.Errorf("runPour error : %s", err)
+				return err
+			}
+			return nil
+		})
+	}
 
-	outputsTomb.Go(func() error {
-		err := runOutput(inputEventChan, outputEventChan, buckets, *parsers.povfwctx, parsers.povfwnodes, *cConfig.API.Client.Credentials)
-		if err != nil {
-			log.Errorf("runOutput error : %s", err)
-			return err
-		}
-		return nil
-	})
+	//start go-routines for parsing, buckets pour and ouputs.
+	for i := 0; i < cConfig.Crowdsec.OutputRoutinesCount; i++ {
+		outputsTomb.Go(func() error {
+			err := runOutput(inputEventChan, outputEventChan, buckets, *parsers.povfwctx, parsers.povfwnodes, *cConfig.API.Client.Credentials)
+			if err != nil {
+				log.Errorf("runOutput error : %s", err)
+				return err
+			}
+			return nil
+		})
+	}
 	log.Warningf("Starting processing data")
 
 	if err := acquisition.AcquisStartReading(acquisitionCTX, inputLineChan, &acquisTomb); err != nil {

--- a/pkg/csconfig/config.go
+++ b/pkg/csconfig/config.go
@@ -84,6 +84,15 @@ func (c *GlobalConfig) LoadConfiguration() error {
 		return errors.Wrap(err, "invalid config")
 	}
 
+	if c.Crowdsec.ParserRoutinesCount <= 0 {
+		c.Crowdsec.ParserRoutinesCount = 1
+	}
+	if c.Crowdsec.BucketRoutinesCount <= 0 {
+		c.Crowdsec.BucketRoutinesCount = 1
+	}
+	if c.Crowdsec.OutputRoutinesCount <= 0 {
+		c.Crowdsec.OutputRoutinesCount = 1
+	}
 	c.Crowdsec.ConfigDir = c.ConfigPaths.ConfigDir
 	c.Crowdsec.DataDir = c.ConfigPaths.DataDir
 	c.Crowdsec.HubDir = c.ConfigPaths.HubDir

--- a/pkg/csconfig/crowdsec_service.go
+++ b/pkg/csconfig/crowdsec_service.go
@@ -2,13 +2,16 @@ package csconfig
 
 /*Configurations needed for crowdsec to load parser/scenarios/... + acquisition*/
 type CrowdsecServiceCfg struct {
-	AcquisitionFilePath string            `yaml:"acquisition_path,omitempty"`
-	ParserRoutinesCount int               `yaml:"parser_routines"`
-	SimulationConfig    *SimulationConfig `yaml:"-"`
-	LintOnly            bool              `yaml:"-"`                          //if set to true, exit after loading configs
-	BucketStateFile     string            `yaml:"state_input_file,omitempty"` //if we need to unserialize buckets at start
-	BucketStateDumpDir  string            `yaml:"state_output_dir,omitempty"` //if we need to unserialize buckets on shutdown
-	BucketsGCEnabled    bool              `yaml:"-"`                          //we need to garbage collect buckets when in forensic mode
+	AcquisitionFilePath string `yaml:"acquisition_path,omitempty"`
+	ParserRoutinesCount int    `yaml:"parser_routines"`
+	BucketRoutinesCount int    `yaml:"bucket_routines"`
+	OutputRoutinesCount int    `yaml:"output_routines"`
+
+	SimulationConfig   *SimulationConfig `yaml:"-"`
+	LintOnly           bool              `yaml:"-"`                          //if set to true, exit after loading configs
+	BucketStateFile    string            `yaml:"state_input_file,omitempty"` //if we need to unserialize buckets at start
+	BucketStateDumpDir string            `yaml:"state_output_dir,omitempty"` //if we need to unserialize buckets on shutdown
+	BucketsGCEnabled   bool              `yaml:"-"`                          //we need to garbage collect buckets when in forensic mode
 
 	HubDir             string `yaml:"-"`
 	DataDir            string `yaml:"-"`


### PR DESCRIPTION
 - Allow directives BucketRoutinesCount & OutputRoutinesCount along ParserRoutinesCount
 - Those defaults to `1` and allow to control the number of running go-routines