### PR TITLE
Improvement and fixes

### DIFF
--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -79,7 +79,7 @@ cscli dashboard setup -l 0.0.0.0 -p 443
 				log.Fatalf("Failed to start metabase container : %s", err)
 			}
 			log.Infof("Started metabase")
-			newpassword := generatePassword()
+			newpassword := generatePassword(passwordLength)
 			if err := resetMetabasePassword(newpassword); err != nil {
 				log.Fatalf("Failed to reset password : %s", err)
 			}

--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -20,6 +20,7 @@ import (
 	"github.com/enescakir/emoji"
 	"github.com/go-openapi/strfmt"
 	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -72,7 +73,7 @@ func generateID() (string, error) {
 	if id == "" || err != nil {
 		bID, err := ioutil.ReadFile(uuid)
 		if err != nil {
-			return "", fmt.Errorf("can'get a valid machine_id")
+			return "", errors.Wrap(err, "generating machine id")
 		}
 		id = string(bID)
 		id = strings.ReplaceAll(id, "-", "")[:32]

--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -32,6 +32,7 @@ var interactive bool
 var apiURL string
 var outputFile string
 var forceAdd bool
+var autoAdd bool
 
 var (
 	passwordLength = 64
@@ -172,7 +173,10 @@ The watcher will be validated automatically.
 
 			// create machineID if doesn't specified by user
 			if machineID == "" {
-				log.Infof("no machine ID provided, going to generate one")
+				if !autoAdd {
+					cmd.Help()
+					return
+				}
 				machineID, err = generateID()
 				if err != nil {
 					log.Fatalf("unable to generate machine id : %s", err)
@@ -181,7 +185,10 @@ The watcher will be validated automatically.
 
 			// create password if doesn't specified by user
 			if machinePassword == "" && !interactive {
-				log.Infof("no password provided, going to generate one")
+				if !autoAdd {
+					cmd.Help()
+					return
+				}
 				machinePassword = generatePassword(passwordLength)
 			} else if machinePassword == "" && interactive {
 				qs := &survey.Password{
@@ -239,6 +246,7 @@ The watcher will be validated automatically.
 	cmdMachinesAdd.Flags().StringVarP(&outputFile, "file", "f", "", "output file destination")
 	cmdMachinesAdd.Flags().StringVarP(&apiURL, "url", "u", "", "URL of the API")
 	cmdMachinesAdd.Flags().BoolVarP(&interactive, "interactive", "i", false, "machine ip address")
+	cmdMachinesAdd.Flags().BoolVarP(&autoAdd, "auto", "a", false, "add the machine automatically (generate the machine ID and the password)")
 	cmdMachinesAdd.Flags().BoolVar(&forceAdd, "force", false, "will force if the machine was already added")
 	cmdMachines.AddCommand(cmdMachinesAdd)
 

--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -175,7 +175,10 @@ The watcher will be validated automatically.
 			// create machineID if doesn't specified by user
 			if machineID == "" {
 				if !autoAdd {
-					cmd.Help()
+					err = cmd.Help()
+					if err != nil {
+						log.Fatalf("unable to print help(): %s", err)
+					}
 					return
 				}
 				machineID, err = generateID()
@@ -187,7 +190,10 @@ The watcher will be validated automatically.
 			// create password if doesn't specified by user
 			if machinePassword == "" && !interactive {
 				if !autoAdd {
-					cmd.Help()
+					err = cmd.Help()
+					if err != nil {
+						log.Fatalf("unable to print help(): %s", err)
+					}
 					return
 				}
 				machinePassword = generatePassword(passwordLength)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -26,6 +26,7 @@ db_config:
   port: 3306
 api:
   client:
+    insecure_skip_verify: true # default true
     credentials_path: /etc/crowdsec/local_api_credentials.yaml
   server:
     listen_uri: localhost:8080

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -30,6 +30,7 @@ api:
   client:
     credentials_path: ./config/local_api_credentials.yaml
   server:
+    #insecure_skip_verify: true
     listen_uri: localhost:8080
     tls:
       #cert_file: ./cert.pem

--- a/pkg/apiclient/client.go
+++ b/pkg/apiclient/client.go
@@ -1,6 +1,7 @@
 package apiclient
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -12,6 +13,9 @@ import (
 
 var BaseURL *url.URL
 var UserAgent string
+var (
+	InsecureSkipVerify = true
+)
 
 type ApiClient struct {
 	/*The http client used to make requests*/
@@ -37,6 +41,7 @@ func NewClient(httpClient *http.Client) *ApiClient {
 		httpClient = &http.Client{}
 	}
 	UserAgent := fmt.Sprintf("crowdsec-%s", cwversion.VersionStr())
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: InsecureSkipVerify}
 
 	c := &ApiClient{client: httpClient, BaseURL: BaseURL, UserAgent: UserAgent}
 	c.common.client = c

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -86,7 +86,7 @@ func (s *APIServer) Router() (*gin.Engine, error) {
 	gin.DefaultWriter = io.MultiWriter(file, os.Stdout)
 
 	router.Use(gin.LoggerWithFormatter(func(param gin.LogFormatterParams) string {
-		return fmt.Sprintf("%s - [%s] \"%s %s %s %d \"%s\" %s\"\n",
+		return fmt.Sprintf("%s - [%s] \"%s %s %s %d %s \"%s\" %s\"\n",
 			param.ClientIP,
 			param.TimeStamp.Format(time.RFC1123),
 			param.Method,

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -3,7 +3,10 @@ package apiserver
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/apiserver/controllers"
 	"github.com/crowdsecurity/crowdsec/pkg/apiserver/middlewares"
@@ -56,7 +59,7 @@ func NewServer(config *csconfig.LocalApiServerCfg) (*APIServer, error) {
 	return &APIServer{
 		URL:            config.ListenURI,
 		TLS:            config.TLS,
-		logFile:        fmt.Sprintf("%s/api.log", config.LogDir),
+		logFile:        fmt.Sprintf("%s/crowdsec_api.log", config.LogDir),
 		dbClient:       dbClient,
 		middlewares:    middleware,
 		controller:     controller,
@@ -73,8 +76,30 @@ func (s *APIServer) Router() (*gin.Engine, error) {
 	if err := types.ConfigureLogger(clog); err != nil {
 		return nil, errors.Wrap(err, "while configuring gin logger")
 	}
-
 	gin.DefaultErrorWriter = clog.Writer()
+	gin.DisableConsoleColor()
+	// Logging to a file.
+	f, err := os.Create("gin.log")
+	if err != nil {
+		return &gin.Engine{}, errors.Wrapf(err, "creating api access log file: %s", s.logFile)
+	}
+	gin.DefaultWriter = io.MultiWriter(f)
+	router.Use(gin.LoggerWithFormatter(func(param gin.LogFormatterParams) string {
+
+		// your custom format
+		return fmt.Sprintf("%s - [%s] \"%s %s %s %d %s \"%s\" %s\"\n",
+			param.ClientIP,
+			param.TimeStamp.Format(time.RFC1123),
+			param.Method,
+			param.Path,
+			param.Request.Proto,
+			param.StatusCode,
+			param.Latency,
+			param.Request.UserAgent(),
+			param.ErrorMessage,
+		)
+	}))
+
 	router.Use(gin.Recovery())
 
 	router.POST("/watchers", s.controller.CreateMachine)

--- a/pkg/apiserver/controllers/decisions.go
+++ b/pkg/apiserver/controllers/decisions.go
@@ -171,7 +171,7 @@ func (c *Controller) StreamDecision(gctx *gin.Context) {
 	}
 
 	// getting expired decisions
-	data, err = c.DBClient.QueryExpiredDecisionsSince(blockerInfo.LastPull) // do we want to give exactly lastPull time ?
+	data, err = c.DBClient.QueryExpiredDecisionsSince(blockerInfo.LastPull.Add((-2 * time.Second))) // do we want to give exactly lastPull time ?
 	if err != nil {
 		log.Errorf("unable to query expired decision for '%s' : %v", blockerInfo.Name, err)
 		gctx.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})

--- a/pkg/apiserver/controllers/decisions.go
+++ b/pkg/apiserver/controllers/decisions.go
@@ -171,7 +171,7 @@ func (c *Controller) StreamDecision(gctx *gin.Context) {
 	}
 
 	// getting expired decisions
-	data, err = c.DBClient.QueryExpiredDecisionsSince(blockerInfo.LastPull.Add(-5 * time.Minute)) // do we want to give exactly lastPull time ?
+	data, err = c.DBClient.QueryExpiredDecisionsSince(blockerInfo.LastPull) // do we want to give exactly lastPull time ?
 	if err != nil {
 		log.Errorf("unable to query expired decision for '%s' : %v", blockerInfo.Name, err)
 		gctx.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})

--- a/pkg/apiserver/middlewares/api_key.go
+++ b/pkg/apiserver/middlewares/api_key.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/crowdsecurity/crowdsec/pkg/database"
-	"github.com/crowdsecurity/crowdsec/pkg/database/ent/blocker"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 )
@@ -56,21 +55,40 @@ func (a *APIKey) MiddlewareFunc() gin.HandlerFunc {
 		}
 
 		hashStr := HashSHA512(val[0])
-		exist, err := a.DbClient.Ent.Blocker.Query().
-			Where(blocker.APIKeyEQ(hashStr)).
-			Select(blocker.FieldAPIKey).
-			Strings(a.DbClient.CTX)
+		bouncer, err := a.DbClient.SelectBlocker(hashStr)
 		if err != nil {
-			log.Errorf("unable to get current api key: %s", err)
-			c.Abort()
-			return
-		}
-
-		if len(exist) == 0 {
+			log.Errorf("auth api key error: %s", err)
 			c.JSON(http.StatusForbidden, gin.H{"message": "access forbidden"})
 			c.Abort()
 			return
 		}
+
+		if bouncer == nil {
+			c.JSON(http.StatusForbidden, gin.H{"message": "access forbidden"})
+			c.Abort()
+			return
+		}
+
+		if bouncer.IPAddress == "" {
+			err = a.DbClient.UpdateBlockerIP(c.ClientIP(), bouncer.ID)
+			if err != nil {
+				log.Errorf("Failed to update ip address for '%s': %s\n", bouncer.Name, err)
+				c.JSON(http.StatusForbidden, gin.H{"message": "access forbidden"})
+				c.Abort()
+				return
+			}
+		}
+		if bouncer.IPAddress != c.ClientIP() && bouncer.IPAddress != "" {
+			log.Warningf("new IP address detected for bouncer '%s': %s (old: %s)", bouncer.Name, c.ClientIP(), bouncer.IPAddress)
+			err = a.DbClient.UpdateBlockerIP(c.ClientIP(), bouncer.ID)
+			if err != nil {
+				log.Errorf("Failed to update ip address for '%s': %s\n", bouncer.ID, err)
+				c.JSON(http.StatusForbidden, gin.H{"message": "access forbidden"})
+				c.Abort()
+				return
+			}
+		}
+
 		c.Next()
 	}
 }

--- a/pkg/apiserver/middlewares/api_key.go
+++ b/pkg/apiserver/middlewares/api_key.go
@@ -82,7 +82,7 @@ func (a *APIKey) MiddlewareFunc() gin.HandlerFunc {
 			log.Warningf("new IP address detected for bouncer '%s': %s (old: %s)", bouncer.Name, c.ClientIP(), bouncer.IPAddress)
 			err = a.DbClient.UpdateBlockerIP(c.ClientIP(), bouncer.ID)
 			if err != nil {
-				log.Errorf("Failed to update ip address for '%s': %s\n", bouncer.ID, err)
+				log.Errorf("Failed to update ip address for '%s': %s\n", bouncer.Name, err)
 				c.JSON(http.StatusForbidden, gin.H{"message": "access forbidden"})
 				c.Abort()
 				return

--- a/pkg/apiserver/middlewares/jwt.go
+++ b/pkg/apiserver/middlewares/jwt.go
@@ -68,7 +68,7 @@ func (j *JWT) Authenticator(c *gin.Context) (interface{}, error) {
 		return nil, jwt.ErrFailedAuthentication
 	}
 
-	if machine.IsValidated == false {
+	if !machine.IsValidated {
 		return nil, jwt.ErrFailedAuthentication
 	}
 
@@ -103,7 +103,7 @@ func (j *JWT) Authenticator(c *gin.Context) (interface{}, error) {
 		log.Warningf("new IP address detected for bouncer '%s': %s (old: %s)", machine.MachineId, c.ClientIP(), machine.IpAddress)
 		err = j.DbClient.UpdateMachineIP(c.ClientIP(), machine.ID)
 		if err != nil {
-			log.Errorf("Failed to update ip address for '%s': %s\n", machine.ID, err)
+			log.Errorf("Failed to update ip address for '%s': %s\n", machine.MachineId, err)
 			return nil, jwt.ErrFailedAuthentication
 		}
 	}

--- a/pkg/apiserver/middlewares/jwt.go
+++ b/pkg/apiserver/middlewares/jwt.go
@@ -100,7 +100,7 @@ func (j *JWT) Authenticator(c *gin.Context) (interface{}, error) {
 	}
 
 	if machine.IpAddress != c.ClientIP() && machine.IpAddress != "" {
-		log.Warningf("new IP address detected for bouncer '%s': %s (old: %s)", machine.MachineId, c.ClientIP(), machine.IpAddress)
+		log.Warningf("new IP address detected for machine '%s': %s (old: %s)", machine.MachineId, c.ClientIP(), machine.IpAddress)
 		err = j.DbClient.UpdateMachineIP(c.ClientIP(), machine.ID)
 		if err != nil {
 			log.Errorf("Failed to update ip address for '%s': %s\n", machine.MachineId, err)

--- a/pkg/csconfig/api.go
+++ b/pkg/csconfig/api.go
@@ -21,6 +21,7 @@ type OnlineApiClientCfg struct {
 type LocalApiClientCfg struct {
 	CredentialsFilePath string             `yaml:"credentials_path,omitempty"` //credz will be edited by software, store in diff file
 	Credentials         *ApiCredentialsCfg `yaml:"-"`
+	InsecureSkipVerify  *bool              `yaml:"insecure_skip_verify"` // check if api certificate is bad or not
 }
 
 /*local api service configuration*/

--- a/pkg/csconfig/config.go
+++ b/pkg/csconfig/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -108,6 +109,11 @@ func (c *GlobalConfig) LoadConfiguration() error {
 			if !strings.HasSuffix(c.API.Client.Credentials.URL, "/") {
 				c.API.Client.Credentials.URL = c.API.Client.Credentials.URL + "/"
 			}
+		}
+		if c.API.Client.InsecureSkipVerify == nil {
+			apiclient.InsecureSkipVerify = true
+		} else {
+			apiclient.InsecureSkipVerify = *c.API.Client.InsecureSkipVerify
 		}
 	}
 

--- a/pkg/database/blockers.go
+++ b/pkg/database/blockers.go
@@ -9,8 +9,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (c *Client) SelectBlocker(apiKey string) (*ent.Blocker, error) {
-	result, err := c.Ent.Blocker.Query().Where(blocker.APIKeyEQ(apiKey)).First(c.CTX)
+func (c *Client) SelectBlocker(apiKeyHash string) (*ent.Blocker, error) {
+	result, err := c.Ent.Blocker.Query().Where(blocker.APIKeyEQ(apiKeyHash)).First(c.CTX)
 	if err != nil {
 		return &ent.Blocker{}, errors.Wrap(QueryFail, "can't get last blocker pull")
 	}
@@ -56,6 +56,14 @@ func (c *Client) UpdateBlockerLastPull(lastPull time.Time, ID int) error {
 		Save(c.CTX)
 	if err != nil {
 		return fmt.Errorf("unable to update machine in database: %s", err)
+	}
+	return nil
+}
+
+func (c *Client) UpdateBlockerIP(ipAddr string, ID int) error {
+	_, err := c.Ent.Blocker.UpdateOneID(ID).SetIPAddress(ipAddr).Save(c.CTX)
+	if err != nil {
+		return fmt.Errorf("unable to update Blocker in database: %s", err)
 	}
 	return nil
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -11,6 +11,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/database/ent"
 	"github.com/go-co-op/gocron"
 	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/pkg/errors"
 )
@@ -33,6 +34,11 @@ func NewClient(config *csconfig.DatabaseCfg) (*Client, error) {
 		client, err = ent.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=True", config.User, config.Password, config.Host, config.Port, config.DbName))
 		if err != nil {
 			return &Client{}, fmt.Errorf("failed opening connection to mysql: %v", err)
+		}
+	case "postgres":
+		client, err = ent.Open("postgres", fmt.Sprintf("host=%s port=%d user=%s dbname=%s password=%s", config.Host, config.Port, config.User, config.DbName, config.Password))
+		if err != nil {
+			return &Client{}, fmt.Errorf("failed opening connection to postgres: %v", err)
 		}
 	default:
 		return &Client{}, fmt.Errorf("unknown database type")

--- a/wizard.sh
+++ b/wizard.sh
@@ -238,6 +238,12 @@ install_collection() {
     if [[ ${SILENT} == "false" ]]; then
         whiptail --msgbox "Out of safety, I installed a parser called 'crowdsecurity/whitelists'. This one will prevent private IP adresses from being banned, feel free to remove it any time." 20 50
     fi
+
+
+    if [[ ${SILENT} == "false" ]]; then
+        whiptail --msgbox "CrowdSec alone will not block any IP address. If you want to block, you muse use a blocker. You can find them on https://hub.crowdsec.net/" 20 50
+    fi
+
 }
 
 

--- a/wizard.sh
+++ b/wizard.sh
@@ -241,7 +241,7 @@ install_collection() {
 
 
     if [[ ${SILENT} == "false" ]]; then
-        whiptail --msgbox "CrowdSec alone will not block any IP address. If you want to block them, you must use a blocker. You can find them on https://hub.crowdsec.net/" 20 50
+        whiptail --msgbox "CrowdSec alone will not block any IP address. If you want to block them, you must use a bouncer. You can find them on https://hub.crowdsec.net/" 20 50
     fi
 
 }

--- a/wizard.sh
+++ b/wizard.sh
@@ -241,7 +241,7 @@ install_collection() {
 
 
     if [[ ${SILENT} == "false" ]]; then
-        whiptail --msgbox "CrowdSec alone will not block any IP address. If you want to block, you muse use a blocker. You can find them on https://hub.crowdsec.net/" 20 50
+        whiptail --msgbox "CrowdSec alone will not block any IP address. If you want to block them, you must use a blocker. You can find them on https://hub.crowdsec.net/" 20 50
     fi
 
 }


### PR DESCRIPTION
This PR does:

- APIL: add the support of postegreSQL
- APIL: update bouncer IP address when it connect to the API
- APIL: in stream decision, only grab IP deleted since last blocker pull
- APIL: warn in logs if the ip address of a watcher or a bouncer changed
- APIL: fix access log
- APIL: make https work again after a lost in conflict merge
- crowdsec: apiclient now work with or without insecure certificate (added the option in `config.yaml`)
- wizard: add a warning in the wizard to inform user that crowdsec alone will not block ip addresses
- cscli: put the generation of a machine ID in a function and add a random number at then end of the machine ID
- cscli: `cscli machines add` will now generate automatically the machine ID and the password if none are provided.

