### PR TITLE
Wip/lapi catch panic

### DIFF
--- a/cmd/crowdsec-cli/metrics.go
+++ b/cmd/crowdsec-cli/metrics.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
@@ -65,6 +66,7 @@ func ShowPrometheus(url string) {
 	transport.ResponseHeaderTimeout = time.Minute
 
 	go func() {
+		defer types.CatchPanic("crowdsec/ShowPrometheus")
 		err := prom2json.FetchMetricFamilies(url, mfChan, transport)
 		if err != nil {
 			log.Fatalf("failed to fetch prometheus metrics : %v", err)

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/enescakir/emoji"
 	"github.com/olekukonko/tablewriter"
 	dto "github.com/prometheus/client_model/go"
@@ -394,6 +395,7 @@ func GetPrometheusMetric(url string) []*prom2json.Family {
 	transport.ResponseHeaderTimeout = time.Minute
 
 	go func() {
+		defer types.CatchPanic("crowdsec/GetPrometheusMetric")
 		err := prom2json.FetchMetricFamilies(url, mfChan, transport)
 		if err != nil {
 			log.Fatalf("failed to fetch prometheus metrics : %v", err)

--- a/cmd/crowdsec/api.go
+++ b/cmd/crowdsec/api.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/crowdsecurity/crowdsec/pkg/apiserver"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -27,6 +28,7 @@ func runAPIServer(apiServer *apiserver.APIServer) (*http.Server, error) {
 		Handler: handler,
 	}
 	go func() {
+		defer types.CatchPanic("crowdsec/runAPIServer")
 		if apiServer.TLS != nil && apiServer.TLS.CertFilePath != "" && apiServer.TLS.KeyFilePath != "" {
 			if err := httpAPIServer.ListenAndServeTLS(apiServer.TLS.CertFilePath, apiServer.TLS.KeyFilePath); err != nil {
 				log.Fatalf(err.Error())
@@ -44,6 +46,7 @@ func runAPIServer(apiServer *apiserver.APIServer) (*http.Server, error) {
 
 func serveAPIServer(httpAPIServer *http.Server) {
 	apiTomb.Go(func() error {
+		defer types.CatchPanic("serveAPIServer")
 		log.Info("local API server starting")
 		<-apiTomb.Dying() // lock until go routine is dying
 		if err := httpAPIServer.Shutdown(nil); err != nil {

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -267,6 +267,8 @@ func main() {
 		err error
 	)
 
+	defer types.CatchPanic("crowdsec/main")
+
 	cConfig = csconfig.NewConfig()
 	// Handle command line arguments
 	if err := LoadConfig(cConfig); err != nil {
@@ -286,6 +288,7 @@ func main() {
 	if cConfig.Prometheus != nil {
 		go registerPrometheus(cConfig.Prometheus.Level)
 	}
+
 	if err := Serve(); err != nil {
 		log.Fatalf(err.Error())
 	}

--- a/cmd/crowdsec/metrics.go
+++ b/cmd/crowdsec/metrics.go
@@ -7,6 +7,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
 	"github.com/crowdsecurity/crowdsec/pkg/parser"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -74,6 +75,7 @@ func dumpMetrics() {
 }
 
 func registerPrometheus(mode string) {
+	defer types.CatchPanic("crowdsec/registerPrometheus")
 	/*Registering prometheus*/
 	/*If in aggregated mode, do not register events associated to a source, keeps cardinality low*/
 	if mode == "aggregated" {

--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -10,6 +10,7 @@ import (
 	"github.com/coreos/go-systemd/daemon"
 
 	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/tomb.v2"
 	//"github.com/sevlyar/go-daemon"
@@ -181,6 +182,7 @@ func HandleSignals() {
 
 	exitChan := make(chan int)
 	go func() {
+		defer types.CatchPanic("crowdsec/HandleSignals")
 		for {
 			s := <-signalChan
 			switch s {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,7 +7,7 @@ common:
   working_dir: .
 config_paths:
   config_dir: /etc/crowdsec/
-  data_dir: /tmp/data/
+  data_dir: /var/cache/crowdsec/
   #simulation_path: /etc/crowdsec/config/simulation.yaml
   #hub_dir: /etc/crowdsec/hub/
   #index_path: ./config/hub/.index.json
@@ -18,7 +18,7 @@ cscli:
   output: human
 db_config:
   type: sqlite
-  db_path: /tmp/data/crowdsec.db
+  db_path: /var/cache/crowdsec.db
   user: root
   password: crowdsec
   db_name: crowdsec

--- a/pkg/acquisition/file_reader.go
+++ b/pkg/acquisition/file_reader.go
@@ -196,11 +196,13 @@ func AcquisStartReading(ctx *FileAcquisCtx, output chan types.Event, AcquisTomb 
 		case TAILMODE:
 			mode = "tail"
 			AcquisTomb.Go(func() error {
+				defer types.CatchPanic("crowdsec/TailFile")
 				return TailFile(fctx, output, AcquisTomb)
 			})
 		case CATMODE:
 			mode = "cat"
 			AcquisTomb.Go(func() error {
+				defer types.CatchPanic("crowdsec/CatFile")
 				return CatFile(fctx, output, AcquisTomb)
 			})
 		default:

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -126,13 +126,6 @@ func (s *APIServer) Router() (*gin.Engine, error) {
 		apiKeyAuth.GET("/decisions/stream", s.controller.StreamDecision)
 	}
 
-	/*puller, err := NewPuller(s.dbClient)
-	if err != nil {
-		return err
-	}
-
-	go puller.Pull()
-	*/
 	return router, nil
 }
 

--- a/pkg/cwversion/version.go
+++ b/pkg/cwversion/version.go
@@ -33,6 +33,15 @@ var (
 	Constraint_acquis   = ">= 1.0, < 2.0"
 )
 
+func ShowStr() string {
+	ret := ""
+	ret += fmt.Sprintf("version: %s-%s\n", Version, Tag)
+	ret += fmt.Sprintf("Codename: %s\n", Codename)
+	ret += fmt.Sprintf("BuildDate: %s\n", BuildDate)
+	ret += fmt.Sprintf("GoVersion: %s\n", GoVersion)
+	return ret
+}
+
 func Show() {
 	log.Printf("version: %s-%s", Version, Tag)
 	log.Printf("Codename: %s", Codename)

--- a/pkg/leakybucket/bucket.go
+++ b/pkg/leakybucket/bucket.go
@@ -1,6 +1,7 @@
 package leakybucket
 
 import (
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -176,6 +177,8 @@ func LeakRoutine(leaky *Leaky) {
 	var (
 		durationTicker <-chan time.Time = make(<-chan time.Time)
 	)
+
+	defer types.CatchPanic(fmt.Sprintf("crowdsec/LeakRoutine/%s", leaky.Name))
 
 	BucketsCurrentCount.With(prometheus.Labels{"name": leaky.Name}).Inc()
 	defer BucketsCurrentCount.With(prometheus.Labels{"name": leaky.Name}).Dec()


### PR DESCRIPTION
add a defer'ed function to catch panic in each and all go-routines. According to what I've read we can't catch it globally. Could add a wrapper, but as we use both tombs and direct goroutines, it would be painful :)
