### PR TITLE
Wip/lapi simulation fix

### DIFF
--- a/cmd/crowdsec-cli/decisions.go
+++ b/cmd/crowdsec-cli/decisions.go
@@ -24,6 +24,7 @@ var (
 	Value      string
 	Type       string
 	DecisionID string
+	NoSimu     bool
 )
 var DeleteAll bool
 var Client *apiclient.ApiClient
@@ -61,7 +62,7 @@ func DecisionsToTable(alerts *models.GetAlertsResponse) error {
 
 		for _, alertItem := range *alerts {
 			for _, decisionItem := range alertItem.Decisions {
-				if alertItem.Simulated != nil && *alertItem.Simulated == true {
+				if *alertItem.Simulated {
 					*decisionItem.Type = fmt.Sprintf("(simul)%s", *decisionItem.Type)
 				}
 				table.Append([]string{
@@ -133,6 +134,8 @@ cscli decisions list --range 1.2.3.4/32
 
 			filter := apiclient.AlertsListOpts{}
 			filter.ActiveDecisionEquals = &activeDecision
+			NoSimu = !NoSimu //revert the flag before setting it
+			filter.IncludeSimulated = &NoSimu
 			if Scope != "" {
 				filter.ScopeEquals = &Scope
 			}
@@ -165,6 +168,7 @@ cscli decisions list --range 1.2.3.4/32
 	cmdDecisionsList.Flags().StringVar(&Scope, "scope", "", "scope to which the decision applies (ie. IP/Range/Username/Session/...)")
 	cmdDecisionsList.Flags().StringVar(&Value, "value", "", "the value to match for in the specified scope")
 	cmdDecisionsList.Flags().StringVar(&Type, "type", "", "type of decision")
+	cmdDecisionsList.Flags().BoolVar(&NoSimu, "no-simu", false, "exclude decisions in simulation mode")
 	cmdDecisions.AddCommand(cmdDecisionsList)
 
 	var cmdDecisionsAdd = &cobra.Command{

--- a/cmd/crowdsec-cli/decisions.go
+++ b/cmd/crowdsec-cli/decisions.go
@@ -30,7 +30,7 @@ var Client *apiclient.ApiClient
 
 func DecisionsToTable(alerts *models.GetAlertsResponse) error {
 	if csConfig.Cscli.Output == "raw" {
-		fmt.Printf("id,source,ip,reason,action,country,as,events_count,expiration\n")
+		fmt.Printf("id,source,ip,reason,action,country,as,events_count,expiration,simulated\n")
 		for _, alertItem := range *alerts {
 			for _, decisionItem := range alertItem.Decisions {
 				fmt.Printf("%v,%v,%v,%v,%v,%v,%v,%v,%v\n",
@@ -42,7 +42,8 @@ func DecisionsToTable(alerts *models.GetAlertsResponse) error {
 					alertItem.Source.Cn,
 					alertItem.Source.AsNumber+" "+alertItem.Source.AsName,
 					*alertItem.EventsCount,
-					*decisionItem.Duration)
+					*decisionItem.Duration,
+					*decisionItem.Simulated)
 			}
 		}
 	} else if csConfig.Cscli.Output == "json" {
@@ -60,6 +61,9 @@ func DecisionsToTable(alerts *models.GetAlertsResponse) error {
 
 		for _, alertItem := range *alerts {
 			for _, decisionItem := range alertItem.Decisions {
+				if alertItem.Simulated != nil && *alertItem.Simulated == true {
+					*decisionItem.Type = fmt.Sprintf("(simul)%s", *decisionItem.Type)
+				}
 				table.Append([]string{
 					strconv.Itoa(int(decisionItem.ID)),
 					*decisionItem.Origin,

--- a/cmd/crowdsec-cli/simulation.go
+++ b/cmd/crowdsec-cli/simulation.go
@@ -49,6 +49,7 @@ func dumpSimulationFile() error {
 	if err != nil {
 		return fmt.Errorf("write simulation config in '%s' failed: %s", csConfig.ConfigPaths.SimulationFilePath, err)
 	}
+	log.Debugf("updated simulation file %s", csConfig.ConfigPaths.SimulationFilePath)
 
 	return nil
 }
@@ -99,7 +100,7 @@ func simulationStatus() error {
 func NewSimulationCmds() *cobra.Command {
 	var cmdSimulation = &cobra.Command{
 		Use:   "simulation enable|disable [scenario_name]",
-		Short: "",
+		Short: "Manage simulation status of scenarios",
 		Long:  ``,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if csConfig.Cscli == nil {

--- a/cmd/crowdsec/output.go
+++ b/cmd/crowdsec/output.go
@@ -116,19 +116,6 @@ LOOP:
 				buckets.Bucket_map.Delete(event.Overflow.Mapkey)
 				break
 			}
-
-			if cConfig.Crowdsec.SimulationConfig != nil {
-				if *cConfig.Crowdsec.SimulationConfig.Simulation {
-					*event.Overflow.Alert.Simulated = true
-				}
-				for _, scenarioName := range cConfig.Crowdsec.SimulationConfig.Exclusions {
-					if *event.Overflow.Alert.Scenario == scenarioName {
-						result := *event.Overflow.Alert.Simulated
-						*event.Overflow.Alert.Simulated = !result
-					}
-				}
-			}
-
 			if event.Overflow.Reprocess {
 				log.Debugf("Overflow being reprocessed.")
 				input <- event

--- a/pkg/apiclient/alerts_service.go
+++ b/pkg/apiclient/alerts_service.go
@@ -23,6 +23,7 @@ type AlertsListOpts struct {
 	UntilEquals          *string `url:"until,omitempty"`
 	ActiveDecisionEquals *bool   `url:"has_active_decision,omitempty"`
 	SourceEquals         *string `url:"alert_source,omitempty"`
+	IncludeSimulated     *bool   `url:"simulated,omitempty"`
 	ListOpts
 }
 

--- a/pkg/apiserver/controllers/alerts.go
+++ b/pkg/apiserver/controllers/alerts.go
@@ -33,6 +33,7 @@ func FormatAlerts(result []*ent.Alert) models.AddAlertsRequest {
 			StopAt:      &StopAt,
 			Capacity:    &alertItem.Capacity,
 			Leakspeed:   &alertItem.LeakSpeed,
+			Simulated:   &alertItem.Simulated,
 			Source: &models.Source{
 				Scope:     &alertItem.SourceScope,
 				Value:     &alertItem.SourceValue,
@@ -70,15 +71,16 @@ func FormatAlerts(result []*ent.Alert) models.AddAlertsRequest {
 			var outputDecisions []*models.Decision
 			duration := decisionItem.Until.Sub(time.Now()).String()
 			outputDecisions = append(outputDecisions, &models.Decision{
-				Duration: &duration, // transform into time.Time ?
-				Scenario: &decisionItem.Scenario,
-				Type:     &decisionItem.Type,
-				StartIP:  decisionItem.StartIP,
-				EndIP:    decisionItem.EndIP,
-				Scope:    &decisionItem.Scope,
-				Value:    &decisionItem.Value,
-				Origin:   &decisionItem.Origin,
-				ID:       int64(decisionItem.ID),
+				Duration:  &duration, // transform into time.Time ?
+				Scenario:  &decisionItem.Scenario,
+				Type:      &decisionItem.Type,
+				StartIP:   decisionItem.StartIP,
+				EndIP:     decisionItem.EndIP,
+				Scope:     &decisionItem.Scope,
+				Value:     &decisionItem.Value,
+				Origin:    &decisionItem.Origin,
+				Simulated: outputAlert.Simulated,
+				ID:        int64(decisionItem.ID),
 			})
 			outputAlert.Decisions = outputDecisions
 		}

--- a/pkg/csconfig/simulation.go
+++ b/pkg/csconfig/simulation.go
@@ -4,3 +4,18 @@ type SimulationConfig struct {
 	Simulation *bool    `yaml:"simulation"`
 	Exclusions []string `yaml:"exclusions,omitempty"`
 }
+
+func (s *SimulationConfig) IsSimulated(scenario string) bool {
+	var simulated bool
+
+	if *s.Simulation == true {
+		simulated = true
+	}
+	for _, excluded := range s.Exclusions {
+		if excluded == scenario {
+			simulated = !simulated
+			break
+		}
+	}
+	return simulated
+}

--- a/pkg/csconfig/simulation.go
+++ b/pkg/csconfig/simulation.go
@@ -8,7 +8,7 @@ type SimulationConfig struct {
 func (s *SimulationConfig) IsSimulated(scenario string) bool {
 	var simulated bool
 
-	if *s.Simulation == true {
+	if *s.Simulation {
 		simulated = true
 	}
 	for _, excluded := range s.Exclusions {

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -93,7 +93,8 @@ func (c *Client) CreateAlertBulk(machineId string, alertList []*models.Alert) ([
 					SetEndIP(decisionItem.EndIP).
 					SetValue(*decisionItem.Value).
 					SetScope(*decisionItem.Scope).
-					SetOrigin(*decisionItem.Origin)
+					SetOrigin(*decisionItem.Origin).
+					SetSimulated(*alertItem.Simulated)
 			}
 			decisions, err = c.Ent.Decision.CreateBulk(decisionBulk...).Save(c.CTX)
 			if err != nil {
@@ -120,6 +121,7 @@ func (c *Client) CreateAlertBulk(machineId string, alertList []*models.Alert) ([
 			SetSourceLongitude(alertItem.Source.Longitude).
 			SetCapacity(*alertItem.Capacity).
 			SetLeakSpeed(*alertItem.Leakspeed).
+			SetSimulated(*alertItem.Simulated).
 			AddDecisions(decisions...).
 			AddEvents(events...).
 			AddMetas(metas...)

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -277,6 +277,17 @@ func BuildAlertRequestFromFilter(alerts *ent.AlertQuery, filter map[string][]str
 	var err error
 	var startIP, endIP int64
 	var hasActiveDecision bool
+
+	/*the simulated filter is a bit different : if it's not present *or* set to false, specifically exclude records with simulated to true */
+	if v, ok := filter["simulated"]; ok {
+		if v[0] == "false" {
+			alerts = alerts.Where(alert.SimulatedEQ(false))
+		}
+		delete(filter, "simulated")
+	} else {
+		alerts = alerts.Where(alert.SimulatedEQ(false))
+	}
+
 	for param, value := range filter {
 		switch param {
 		case "source_scope":

--- a/pkg/database/decisions.go
+++ b/pkg/database/decisions.go
@@ -14,6 +14,17 @@ import (
 func BuildDecisionRequestWithFilter(query *ent.DecisionQuery, filter map[string][]string) (*ent.DecisionQuery, error) {
 	var err error
 	var startIP, endIP int64
+
+	/*the simulated filter is a bit different : if it's not present *or* set to false, specifically exclude records with simulated to true */
+	if v, ok := filter["simulated"]; ok {
+		if v[0] == "false" {
+			query = query.Where(decision.SimulatedEQ(false))
+		}
+		delete(filter, "simulated")
+	} else {
+		query = query.Where(decision.SimulatedEQ(false))
+	}
+
 	for param, value := range filter {
 		switch param {
 		case "scope":

--- a/pkg/database/ent/alert.go
+++ b/pkg/database/ent/alert.go
@@ -55,6 +55,8 @@ type Alert struct {
 	Capacity int32 `json:"capacity,omitempty"`
 	// LeakSpeed holds the value of the "leakSpeed" field.
 	LeakSpeed string `json:"leakSpeed,omitempty"`
+	// Simulated holds the value of the "simulated" field.
+	Simulated bool `json:"simulated,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the AlertQuery when eager-loading is set.
 	Edges          AlertEdges `json:"edges"`
@@ -140,6 +142,7 @@ func (*Alert) scanValues() []interface{} {
 		&sql.NullString{},  // sourceValue
 		&sql.NullInt64{},   // capacity
 		&sql.NullString{},  // leakSpeed
+		&sql.NullBool{},    // simulated
 	}
 }
 
@@ -257,7 +260,12 @@ func (a *Alert) assignValues(values ...interface{}) error {
 	} else if value.Valid {
 		a.LeakSpeed = value.String
 	}
-	values = values[19:]
+	if value, ok := values[19].(*sql.NullBool); !ok {
+		return fmt.Errorf("unexpected type %T for field simulated", values[19])
+	} else if value.Valid {
+		a.Simulated = value.Bool
+	}
+	values = values[20:]
 	if len(values) == len(alert.ForeignKeys) {
 		if value, ok := values[0].(*sql.NullInt64); !ok {
 			return fmt.Errorf("unexpected type %T for edge-field machine_alerts", value)
@@ -350,6 +358,8 @@ func (a *Alert) String() string {
 	builder.WriteString(fmt.Sprintf("%v", a.Capacity))
 	builder.WriteString(", leakSpeed=")
 	builder.WriteString(a.LeakSpeed)
+	builder.WriteString(", simulated=")
+	builder.WriteString(fmt.Sprintf("%v", a.Simulated))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/database/ent/alert/alert.go
+++ b/pkg/database/ent/alert/alert.go
@@ -49,6 +49,8 @@ const (
 	FieldCapacity = "capacity"
 	// FieldLeakSpeed holds the string denoting the leakspeed field in the database.
 	FieldLeakSpeed = "leak_speed"
+	// FieldSimulated holds the string denoting the simulated field in the database.
+	FieldSimulated = "simulated"
 
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
 	EdgeOwner = "owner"
@@ -113,6 +115,7 @@ var Columns = []string{
 	FieldSourceValue,
 	FieldCapacity,
 	FieldLeakSpeed,
+	FieldSimulated,
 }
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Alert type.
@@ -150,4 +153,6 @@ var (
 	DefaultStartedAt func() time.Time
 	// DefaultStoppedAt holds the default value on creation for the stoppedAt field.
 	DefaultStoppedAt func() time.Time
+	// DefaultSimulated holds the default value on creation for the simulated field.
+	DefaultSimulated bool
 )

--- a/pkg/database/ent/alert/where.go
+++ b/pkg/database/ent/alert/where.go
@@ -226,6 +226,13 @@ func LeakSpeed(v string) predicate.Alert {
 	})
 }
 
+// Simulated applies equality check predicate on the "simulated" field. It's identical to SimulatedEQ.
+func Simulated(v bool) predicate.Alert {
+	return predicate.Alert(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldSimulated), v))
+	})
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Alert {
 	return predicate.Alert(func(s *sql.Selector) {
@@ -2276,6 +2283,20 @@ func LeakSpeedEqualFold(v string) predicate.Alert {
 func LeakSpeedContainsFold(v string) predicate.Alert {
 	return predicate.Alert(func(s *sql.Selector) {
 		s.Where(sql.ContainsFold(s.C(FieldLeakSpeed), v))
+	})
+}
+
+// SimulatedEQ applies the EQ predicate on the "simulated" field.
+func SimulatedEQ(v bool) predicate.Alert {
+	return predicate.Alert(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldSimulated), v))
+	})
+}
+
+// SimulatedNEQ applies the NEQ predicate on the "simulated" field.
+func SimulatedNEQ(v bool) predicate.Alert {
+	return predicate.Alert(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldSimulated), v))
 	})
 }
 

--- a/pkg/database/ent/alert_create.go
+++ b/pkg/database/ent/alert_create.go
@@ -282,6 +282,20 @@ func (ac *AlertCreate) SetNillableLeakSpeed(s *string) *AlertCreate {
 	return ac
 }
 
+// SetSimulated sets the simulated field.
+func (ac *AlertCreate) SetSimulated(b bool) *AlertCreate {
+	ac.mutation.SetSimulated(b)
+	return ac
+}
+
+// SetNillableSimulated sets the simulated field if the given value is not nil.
+func (ac *AlertCreate) SetNillableSimulated(b *bool) *AlertCreate {
+	if b != nil {
+		ac.SetSimulated(*b)
+	}
+	return ac
+}
+
 // SetOwnerID sets the owner edge to Machine by id.
 func (ac *AlertCreate) SetOwnerID(id int) *AlertCreate {
 	ac.mutation.SetOwnerID(id)
@@ -426,6 +440,10 @@ func (ac *AlertCreate) defaults() {
 		v := alert.DefaultStoppedAt()
 		ac.mutation.SetStoppedAt(v)
 	}
+	if _, ok := ac.mutation.Simulated(); !ok {
+		v := alert.DefaultSimulated
+		ac.mutation.SetSimulated(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -438,6 +456,9 @@ func (ac *AlertCreate) check() error {
 	}
 	if _, ok := ac.mutation.Scenario(); !ok {
 		return &ValidationError{Name: "scenario", err: errors.New("ent: missing required field \"scenario\"")}
+	}
+	if _, ok := ac.mutation.Simulated(); !ok {
+		return &ValidationError{Name: "simulated", err: errors.New("ent: missing required field \"simulated\"")}
 	}
 	return nil
 }
@@ -617,6 +638,14 @@ func (ac *AlertCreate) createSpec() (*Alert, *sqlgraph.CreateSpec) {
 			Column: alert.FieldLeakSpeed,
 		})
 		_node.LeakSpeed = value
+	}
+	if value, ok := ac.mutation.Simulated(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeBool,
+			Value:  value,
+			Column: alert.FieldSimulated,
+		})
+		_node.Simulated = value
 	}
 	if nodes := ac.mutation.OwnerIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/database/ent/alert_update.go
+++ b/pkg/database/ent/alert_update.go
@@ -414,6 +414,20 @@ func (au *AlertUpdate) ClearLeakSpeed() *AlertUpdate {
 	return au
 }
 
+// SetSimulated sets the simulated field.
+func (au *AlertUpdate) SetSimulated(b bool) *AlertUpdate {
+	au.mutation.SetSimulated(b)
+	return au
+}
+
+// SetNillableSimulated sets the simulated field if the given value is not nil.
+func (au *AlertUpdate) SetNillableSimulated(b *bool) *AlertUpdate {
+	if b != nil {
+		au.SetSimulated(*b)
+	}
+	return au
+}
+
 // SetOwnerID sets the owner edge to Machine by id.
 func (au *AlertUpdate) SetOwnerID(id int) *AlertUpdate {
 	au.mutation.SetOwnerID(id)
@@ -876,6 +890,13 @@ func (au *AlertUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: alert.FieldLeakSpeed,
+		})
+	}
+	if value, ok := au.mutation.Simulated(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeBool,
+			Value:  value,
+			Column: alert.FieldSimulated,
 		})
 	}
 	if au.mutation.OwnerCleared() {
@@ -1475,6 +1496,20 @@ func (auo *AlertUpdateOne) ClearLeakSpeed() *AlertUpdateOne {
 	return auo
 }
 
+// SetSimulated sets the simulated field.
+func (auo *AlertUpdateOne) SetSimulated(b bool) *AlertUpdateOne {
+	auo.mutation.SetSimulated(b)
+	return auo
+}
+
+// SetNillableSimulated sets the simulated field if the given value is not nil.
+func (auo *AlertUpdateOne) SetNillableSimulated(b *bool) *AlertUpdateOne {
+	if b != nil {
+		auo.SetSimulated(*b)
+	}
+	return auo
+}
+
 // SetOwnerID sets the owner edge to Machine by id.
 func (auo *AlertUpdateOne) SetOwnerID(id int) *AlertUpdateOne {
 	auo.mutation.SetOwnerID(id)
@@ -1935,6 +1970,13 @@ func (auo *AlertUpdateOne) sqlSave(ctx context.Context) (_node *Alert, err error
 		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: alert.FieldLeakSpeed,
+		})
+	}
+	if value, ok := auo.mutation.Simulated(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeBool,
+			Value:  value,
+			Column: alert.FieldSimulated,
 		})
 	}
 	if auo.mutation.OwnerCleared() {

--- a/pkg/database/ent/decision/decision.go
+++ b/pkg/database/ent/decision/decision.go
@@ -31,6 +31,8 @@ const (
 	FieldValue = "value"
 	// FieldOrigin holds the string denoting the origin field in the database.
 	FieldOrigin = "origin"
+	// FieldSimulated holds the string denoting the simulated field in the database.
+	FieldSimulated = "simulated"
 
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
 	EdgeOwner = "owner"
@@ -59,6 +61,7 @@ var Columns = []string{
 	FieldScope,
 	FieldValue,
 	FieldOrigin,
+	FieldSimulated,
 }
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the Decision type.
@@ -86,4 +89,6 @@ var (
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	DefaultUpdatedAt func() time.Time
+	// DefaultSimulated holds the default value on creation for the simulated field.
+	DefaultSimulated bool
 )

--- a/pkg/database/ent/decision/where.go
+++ b/pkg/database/ent/decision/where.go
@@ -163,6 +163,13 @@ func Origin(v string) predicate.Decision {
 	})
 }
 
+// Simulated applies equality check predicate on the "simulated" field. It's identical to SimulatedEQ.
+func Simulated(v bool) predicate.Decision {
+	return predicate.Decision(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldSimulated), v))
+	})
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Decision {
 	return predicate.Decision(func(s *sql.Selector) {
@@ -1123,6 +1130,20 @@ func OriginEqualFold(v string) predicate.Decision {
 func OriginContainsFold(v string) predicate.Decision {
 	return predicate.Decision(func(s *sql.Selector) {
 		s.Where(sql.ContainsFold(s.C(FieldOrigin), v))
+	})
+}
+
+// SimulatedEQ applies the EQ predicate on the "simulated" field.
+func SimulatedEQ(v bool) predicate.Decision {
+	return predicate.Decision(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldSimulated), v))
+	})
+}
+
+// SimulatedNEQ applies the NEQ predicate on the "simulated" field.
+func SimulatedNEQ(v bool) predicate.Decision {
+	return predicate.Decision(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldSimulated), v))
 	})
 }
 

--- a/pkg/database/ent/decision_create.go
+++ b/pkg/database/ent/decision_create.go
@@ -113,6 +113,20 @@ func (dc *DecisionCreate) SetOrigin(s string) *DecisionCreate {
 	return dc
 }
 
+// SetSimulated sets the simulated field.
+func (dc *DecisionCreate) SetSimulated(b bool) *DecisionCreate {
+	dc.mutation.SetSimulated(b)
+	return dc
+}
+
+// SetNillableSimulated sets the simulated field if the given value is not nil.
+func (dc *DecisionCreate) SetNillableSimulated(b *bool) *DecisionCreate {
+	if b != nil {
+		dc.SetSimulated(*b)
+	}
+	return dc
+}
+
 // SetOwnerID sets the owner edge to Alert by id.
 func (dc *DecisionCreate) SetOwnerID(id int) *DecisionCreate {
 	dc.mutation.SetOwnerID(id)
@@ -192,6 +206,10 @@ func (dc *DecisionCreate) defaults() {
 		v := decision.DefaultUpdatedAt()
 		dc.mutation.SetUpdatedAt(v)
 	}
+	if _, ok := dc.mutation.Simulated(); !ok {
+		v := decision.DefaultSimulated
+		dc.mutation.SetSimulated(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -219,6 +237,9 @@ func (dc *DecisionCreate) check() error {
 	}
 	if _, ok := dc.mutation.Origin(); !ok {
 		return &ValidationError{Name: "origin", err: errors.New("ent: missing required field \"origin\"")}
+	}
+	if _, ok := dc.mutation.Simulated(); !ok {
+		return &ValidationError{Name: "simulated", err: errors.New("ent: missing required field \"simulated\"")}
 	}
 	return nil
 }
@@ -326,6 +347,14 @@ func (dc *DecisionCreate) createSpec() (*Decision, *sqlgraph.CreateSpec) {
 			Column: decision.FieldOrigin,
 		})
 		_node.Origin = value
+	}
+	if value, ok := dc.mutation.Simulated(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeBool,
+			Value:  value,
+			Column: decision.FieldSimulated,
+		})
+		_node.Simulated = value
 	}
 	if nodes := dc.mutation.OwnerIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/database/ent/decision_update.go
+++ b/pkg/database/ent/decision_update.go
@@ -147,6 +147,20 @@ func (du *DecisionUpdate) SetOrigin(s string) *DecisionUpdate {
 	return du
 }
 
+// SetSimulated sets the simulated field.
+func (du *DecisionUpdate) SetSimulated(b bool) *DecisionUpdate {
+	du.mutation.SetSimulated(b)
+	return du
+}
+
+// SetNillableSimulated sets the simulated field if the given value is not nil.
+func (du *DecisionUpdate) SetNillableSimulated(b *bool) *DecisionUpdate {
+	if b != nil {
+		du.SetSimulated(*b)
+	}
+	return du
+}
+
 // SetOwnerID sets the owner edge to Alert by id.
 func (du *DecisionUpdate) SetOwnerID(id int) *DecisionUpdate {
 	du.mutation.SetOwnerID(id)
@@ -342,6 +356,13 @@ func (du *DecisionUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: decision.FieldOrigin,
 		})
 	}
+	if value, ok := du.mutation.Simulated(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeBool,
+			Value:  value,
+			Column: decision.FieldSimulated,
+		})
+	}
 	if du.mutation.OwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -510,6 +531,20 @@ func (duo *DecisionUpdateOne) SetValue(s string) *DecisionUpdateOne {
 // SetOrigin sets the origin field.
 func (duo *DecisionUpdateOne) SetOrigin(s string) *DecisionUpdateOne {
 	duo.mutation.SetOrigin(s)
+	return duo
+}
+
+// SetSimulated sets the simulated field.
+func (duo *DecisionUpdateOne) SetSimulated(b bool) *DecisionUpdateOne {
+	duo.mutation.SetSimulated(b)
+	return duo
+}
+
+// SetNillableSimulated sets the simulated field if the given value is not nil.
+func (duo *DecisionUpdateOne) SetNillableSimulated(b *bool) *DecisionUpdateOne {
+	if b != nil {
+		duo.SetSimulated(*b)
+	}
 	return duo
 }
 
@@ -704,6 +739,13 @@ func (duo *DecisionUpdateOne) sqlSave(ctx context.Context) (_node *Decision, err
 			Type:   field.TypeString,
 			Value:  value,
 			Column: decision.FieldOrigin,
+		})
+	}
+	if value, ok := duo.mutation.Simulated(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeBool,
+			Value:  value,
+			Column: decision.FieldSimulated,
 		})
 	}
 	if duo.mutation.OwnerCleared() {

--- a/pkg/database/ent/migrate/schema.go
+++ b/pkg/database/ent/migrate/schema.go
@@ -30,6 +30,7 @@ var (
 		{Name: "source_value", Type: field.TypeString, Nullable: true},
 		{Name: "capacity", Type: field.TypeInt32, Nullable: true},
 		{Name: "leak_speed", Type: field.TypeString, Nullable: true},
+		{Name: "simulated", Type: field.TypeBool},
 		{Name: "machine_alerts", Type: field.TypeInt, Nullable: true},
 	}
 	// AlertsTable holds the schema information for the "alerts" table.
@@ -40,7 +41,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:  "alerts_machines_alerts",
-				Columns: []*schema.Column{AlertsColumns[20]},
+				Columns: []*schema.Column{AlertsColumns[21]},
 
 				RefColumns: []*schema.Column{MachinesColumns[0]},
 				OnDelete:   schema.SetNull,

--- a/pkg/database/ent/migrate/schema.go
+++ b/pkg/database/ent/migrate/schema.go
@@ -80,6 +80,7 @@ var (
 		{Name: "scope", Type: field.TypeString},
 		{Name: "value", Type: field.TypeString},
 		{Name: "origin", Type: field.TypeString},
+		{Name: "simulated", Type: field.TypeBool},
 		{Name: "alert_decisions", Type: field.TypeInt, Nullable: true},
 	}
 	// DecisionsTable holds the schema information for the "decisions" table.
@@ -90,7 +91,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:  "decisions_alerts_decisions",
-				Columns: []*schema.Column{DecisionsColumns[11]},
+				Columns: []*schema.Column{DecisionsColumns[12]},
 
 				RefColumns: []*schema.Column{AlertsColumns[0]},
 				OnDelete:   schema.SetNull,

--- a/pkg/database/ent/mutation.go
+++ b/pkg/database/ent/mutation.go
@@ -2891,6 +2891,7 @@ type DecisionMutation struct {
 	scope         *string
 	value         *string
 	origin        *string
+	simulated     *bool
 	clearedFields map[string]struct{}
 	owner         *int
 	clearedowner  bool
@@ -3415,6 +3416,43 @@ func (m *DecisionMutation) ResetOrigin() {
 	m.origin = nil
 }
 
+// SetSimulated sets the simulated field.
+func (m *DecisionMutation) SetSimulated(b bool) {
+	m.simulated = &b
+}
+
+// Simulated returns the simulated value in the mutation.
+func (m *DecisionMutation) Simulated() (r bool, exists bool) {
+	v := m.simulated
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSimulated returns the old simulated value of the Decision.
+// If the Decision object wasn't provided to the builder, the object is fetched
+// from the database.
+// An error is returned if the mutation operation is not UpdateOne, or database query fails.
+func (m *DecisionMutation) OldSimulated(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, fmt.Errorf("OldSimulated is allowed only on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, fmt.Errorf("OldSimulated requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSimulated: %w", err)
+	}
+	return oldValue.Simulated, nil
+}
+
+// ResetSimulated reset all changes of the "simulated" field.
+func (m *DecisionMutation) ResetSimulated() {
+	m.simulated = nil
+}
+
 // SetOwnerID sets the owner edge to Alert by id.
 func (m *DecisionMutation) SetOwnerID(id int) {
 	m.owner = &id
@@ -3468,7 +3506,7 @@ func (m *DecisionMutation) Type() string {
 // this mutation. Note that, in order to get all numeric
 // fields that were in/decremented, call AddedFields().
 func (m *DecisionMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m.created_at != nil {
 		fields = append(fields, decision.FieldCreatedAt)
 	}
@@ -3499,6 +3537,9 @@ func (m *DecisionMutation) Fields() []string {
 	if m.origin != nil {
 		fields = append(fields, decision.FieldOrigin)
 	}
+	if m.simulated != nil {
+		fields = append(fields, decision.FieldSimulated)
+	}
 	return fields
 }
 
@@ -3527,6 +3568,8 @@ func (m *DecisionMutation) Field(name string) (ent.Value, bool) {
 		return m.Value()
 	case decision.FieldOrigin:
 		return m.Origin()
+	case decision.FieldSimulated:
+		return m.Simulated()
 	}
 	return nil, false
 }
@@ -3556,6 +3599,8 @@ func (m *DecisionMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldValue(ctx)
 	case decision.FieldOrigin:
 		return m.OldOrigin(ctx)
+	case decision.FieldSimulated:
+		return m.OldSimulated(ctx)
 	}
 	return nil, fmt.Errorf("unknown Decision field %s", name)
 }
@@ -3634,6 +3679,13 @@ func (m *DecisionMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetOrigin(v)
+		return nil
+	case decision.FieldSimulated:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSimulated(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Decision field %s", name)
@@ -3756,6 +3808,9 @@ func (m *DecisionMutation) ResetField(name string) error {
 		return nil
 	case decision.FieldOrigin:
 		m.ResetOrigin()
+		return nil
+	case decision.FieldSimulated:
+		m.ResetSimulated()
 		return nil
 	}
 	return fmt.Errorf("unknown Decision field %s", name)

--- a/pkg/database/ent/mutation.go
+++ b/pkg/database/ent/mutation.go
@@ -65,6 +65,7 @@ type AlertMutation struct {
 	capacity           *int32
 	addcapacity        *int32
 	leakSpeed          *string
+	simulated          *bool
 	clearedFields      map[string]struct{}
 	owner              *int
 	clearedowner       bool
@@ -1155,6 +1156,43 @@ func (m *AlertMutation) ResetLeakSpeed() {
 	delete(m.clearedFields, alert.FieldLeakSpeed)
 }
 
+// SetSimulated sets the simulated field.
+func (m *AlertMutation) SetSimulated(b bool) {
+	m.simulated = &b
+}
+
+// Simulated returns the simulated value in the mutation.
+func (m *AlertMutation) Simulated() (r bool, exists bool) {
+	v := m.simulated
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSimulated returns the old simulated value of the Alert.
+// If the Alert object wasn't provided to the builder, the object is fetched
+// from the database.
+// An error is returned if the mutation operation is not UpdateOne, or database query fails.
+func (m *AlertMutation) OldSimulated(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, fmt.Errorf("OldSimulated is allowed only on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, fmt.Errorf("OldSimulated requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSimulated: %w", err)
+	}
+	return oldValue.Simulated, nil
+}
+
+// ResetSimulated reset all changes of the "simulated" field.
+func (m *AlertMutation) ResetSimulated() {
+	m.simulated = nil
+}
+
 // SetOwnerID sets the owner edge to Machine by id.
 func (m *AlertMutation) SetOwnerID(id int) {
 	m.owner = &id
@@ -1367,7 +1405,7 @@ func (m *AlertMutation) Type() string {
 // this mutation. Note that, in order to get all numeric
 // fields that were in/decremented, call AddedFields().
 func (m *AlertMutation) Fields() []string {
-	fields := make([]string, 0, 19)
+	fields := make([]string, 0, 20)
 	if m.created_at != nil {
 		fields = append(fields, alert.FieldCreatedAt)
 	}
@@ -1425,6 +1463,9 @@ func (m *AlertMutation) Fields() []string {
 	if m.leakSpeed != nil {
 		fields = append(fields, alert.FieldLeakSpeed)
 	}
+	if m.simulated != nil {
+		fields = append(fields, alert.FieldSimulated)
+	}
 	return fields
 }
 
@@ -1471,6 +1512,8 @@ func (m *AlertMutation) Field(name string) (ent.Value, bool) {
 		return m.Capacity()
 	case alert.FieldLeakSpeed:
 		return m.LeakSpeed()
+	case alert.FieldSimulated:
+		return m.Simulated()
 	}
 	return nil, false
 }
@@ -1518,6 +1561,8 @@ func (m *AlertMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldCapacity(ctx)
 	case alert.FieldLeakSpeed:
 		return m.OldLeakSpeed(ctx)
+	case alert.FieldSimulated:
+		return m.OldSimulated(ctx)
 	}
 	return nil, fmt.Errorf("unknown Alert field %s", name)
 }
@@ -1659,6 +1704,13 @@ func (m *AlertMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetLeakSpeed(v)
+		return nil
+	case alert.FieldSimulated:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSimulated(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Alert field %s", name)
@@ -1916,6 +1968,9 @@ func (m *AlertMutation) ResetField(name string) error {
 		return nil
 	case alert.FieldLeakSpeed:
 		m.ResetLeakSpeed()
+		return nil
+	case alert.FieldSimulated:
+		m.ResetSimulated()
 		return nil
 	}
 	return fmt.Errorf("unknown Alert field %s", name)

--- a/pkg/database/ent/runtime.go
+++ b/pkg/database/ent/runtime.go
@@ -48,6 +48,10 @@ func init() {
 	alertDescStoppedAt := alertFields[7].Descriptor()
 	// alert.DefaultStoppedAt holds the default value on creation for the stoppedAt field.
 	alert.DefaultStoppedAt = alertDescStoppedAt.Default.(func() time.Time)
+	// alertDescSimulated is the schema descriptor for simulated field.
+	alertDescSimulated := alertFields[19].Descriptor()
+	// alert.DefaultSimulated holds the default value on creation for the simulated field.
+	alert.DefaultSimulated = alertDescSimulated.Default.(bool)
 	blockerFields := schema.Blocker{}.Fields()
 	_ = blockerFields
 	// blockerDescCreatedAt is the schema descriptor for created_at field.

--- a/pkg/database/ent/runtime.go
+++ b/pkg/database/ent/runtime.go
@@ -84,6 +84,10 @@ func init() {
 	decisionDescUpdatedAt := decisionFields[1].Descriptor()
 	// decision.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	decision.DefaultUpdatedAt = decisionDescUpdatedAt.Default.(func() time.Time)
+	// decisionDescSimulated is the schema descriptor for simulated field.
+	decisionDescSimulated := decisionFields[10].Descriptor()
+	// decision.DefaultSimulated holds the default value on creation for the simulated field.
+	decision.DefaultSimulated = decisionDescSimulated.Default.(bool)
 	eventFields := schema.Event{}.Fields()
 	_ = eventFields
 	// eventDescCreatedAt is the schema descriptor for created_at field.

--- a/pkg/database/ent/schema/alert.go
+++ b/pkg/database/ent/schema/alert.go
@@ -44,6 +44,7 @@ func (Alert) Fields() []ent.Field {
 		field.String("sourceValue").Optional(),
 		field.Int32("capacity").Optional(),
 		field.String("leakSpeed").Optional(),
+		field.Bool("simulated").Default(false),
 	}
 }
 

--- a/pkg/database/ent/schema/decision.go
+++ b/pkg/database/ent/schema/decision.go
@@ -28,6 +28,7 @@ func (Decision) Fields() []ent.Field {
 		field.String("scope"),
 		field.String("value"),
 		field.String("origin"),
+		field.Bool("simulated").Default(false),
 	}
 }
 

--- a/pkg/leakybucket/bucket.go
+++ b/pkg/leakybucket/bucket.go
@@ -48,6 +48,7 @@ type Leaky struct {
 	// chan for signaling
 	Signal       chan bool `json:"-"`
 	Reprocess    bool
+	Simulated    bool
 	Uuid         string
 	First_ts     time.Time
 	Last_ts      time.Time
@@ -158,6 +159,7 @@ func FromFactory(bucketFactory BucketFactory) *Leaky {
 		scopeType:       bucketFactory.ScopeType,
 		scenarioVersion: bucketFactory.ScenarioVersion,
 		hash:            bucketFactory.hash,
+		Simulated:       bucketFactory.Simulated,
 	}
 	if l.BucketConfig.Capacity > 0 && l.BucketConfig.leakspeed != time.Duration(0) {
 		l.Duration = time.Duration(l.BucketConfig.Capacity+1) * l.BucketConfig.leakspeed

--- a/pkg/leakybucket/manager_load.go
+++ b/pkg/leakybucket/manager_load.go
@@ -65,6 +65,7 @@ type BucketFactory struct {
 	output          bool                      //??
 	ScenarioVersion string                    `yaml:"version,omitempty"`
 	hash            string                    `yaml:"-"`
+	Simulated       bool                      `yaml:"simulated"` //Set to true if the scenario instanciating the bucket was in the exclusion list
 }
 
 func ValidateFactory(bucketFactory *BucketFactory) error {
@@ -184,6 +185,9 @@ func LoadBuckets(cscfg *csconfig.CrowdsecServiceCfg, files []string) ([]BucketFa
 			if err != nil {
 				log.Errorf("scenario %s (%s) couldn't be find in hub (ignore if in unit tests)", bucketFactory.Name, bucketFactory.Filename)
 			} else {
+				if cscfg.SimulationConfig != nil {
+					bucketFactory.Simulated = cscfg.SimulationConfig.IsSimulated(hubItem.Name)
+				}
 				if hubItem != nil {
 					bucketFactory.ScenarioVersion = hubItem.LocalVersion
 					bucketFactory.hash = hubItem.LocalHash

--- a/pkg/leakybucket/overflows.go
+++ b/pkg/leakybucket/overflows.go
@@ -223,9 +223,8 @@ func NewAlert(leaky *Leaky, queue *Queue) (types.RuntimeAlert, error) {
 		Message:         new(string),
 		StartAt:         &startAt,
 		StopAt:          &stopAt,
-		Simulated:       new(bool),
+		Simulated:       &leaky.Simulated,
 	}
-
 	if leaky.BucketConfig == nil {
 		return runtimeAlert, fmt.Errorf("leaky.BucketConfig is nil")
 	}

--- a/pkg/models/decision.go
+++ b/pkg/models/decision.go
@@ -40,6 +40,10 @@ type Decision struct {
 	// Required: true
 	Scope *string `json:"scope"`
 
+	// true if the decision result from a scenario in simulation mode
+	// Read Only: true
+	Simulated *bool `json:"simulated,omitempty"`
+
 	// (only relevant for GET ops) when the value is an IP or range, its numeric representation
 	StartIP int64 `json:"start_ip,omitempty"`
 

--- a/pkg/models/localapi_swagger.yaml
+++ b/pkg/models/localapi_swagger.yaml
@@ -340,6 +340,11 @@ paths:
           type: string
           format: date-time
           description: 'search alerts added before YYYY-mm-DD-HH:MM:SS'
+        - name: simulated
+          in: query
+          required: false
+          type: boolean
+          description: if set to true, decisions in simulation mode will be returned as well
         - name: has_active_decision
           in: query
           required: false

--- a/pkg/models/localapi_swagger.yaml
+++ b/pkg/models/localapi_swagger.yaml
@@ -114,6 +114,11 @@ paths:
           required: false
           type: string
           description: range to search for (shorthand for scope=range&value=)
+        - name: simulated
+          in: query
+          required: false
+          type: boolean
+          description: if set to true, decisions in simulation mode will be returned as well
       responses:
         '200':
           description: "successful operation"

--- a/pkg/models/localapi_swagger.yaml
+++ b/pkg/models/localapi_swagger.yaml
@@ -721,6 +721,10 @@ definitions:
         type: string
       scenario:
         type: string
+      simulated:
+        type: boolean
+        description: 'true if the decision result from a scenario in simulation mode'
+        readOnly: true
     required:
       - origin
       - type


### PR DESCRIPTION
Fix simulation for APIL :
 - Crowdsec : the simulation flag is set at load time (and present in Leaky/BucketFactory)
 - Swagger : The simulated flag is present in both Decision and Alert, and is R/O in Decision
 - APIServer : Simulated is present in schema of Decision and Alert