### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,15 @@ apt-get install bash gettext whiptail curl wget
 ```
 </details>
 
-<details>
+<details open>
   <summary>for RedHat based distributions</summary>
 
 ```bash
 yum install bash gettext newt curl wget
  ```
 </details>
+
+Then :
 
 ```bash
 curl -s https://api.github.com/repos/crowdsecurity/crowdsec/releases/latest | grep browser_download_url| cut -d '"' -f 4  | wget -i -


### PR DESCRIPTION
> ![image](https://user-images.githubusercontent.com/133747/96502465-70be4e80-1217-11eb-9841-7652eca1c47c.png)

As it is, it is not immediately apparent that the Redhat specific instructions are *not* the curl line below the `for RedHat based distributions` heading.

This cleans up the installation instructions a little to look like

> ![image](https://user-images.githubusercontent.com/133747/96502852-02c65700-1218-11eb-8875-2d4e9cbf3c3c.png)
