### PR TITLE
pkg/cwhub: fix dropped error

### DIFF
--- a/pkg/cwhub/loader.go
+++ b/pkg/cwhub/loader.go
@@ -17,7 +17,9 @@ import (
 )
 
 func parser_visit(path string, f os.FileInfo, err error) error {
-
+	if err != nil {
+		return err
+	}
 	var target Item
 	var local bool
 	var hubpath string


### PR DESCRIPTION
An error variable was being passed in to `parser_visit()`, and then ignored. This is a fix.