### PR TITLE
Wip/lapi cscli dedup

### DIFF
--- a/cmd/crowdsec-cli/decisions.go
+++ b/cmd/crowdsec-cli/decisions.go
@@ -33,17 +33,15 @@ var Client *apiclient.ApiClient
 func DecisionsToTable(alerts *models.GetAlertsResponse) error {
 	/*here we cheat a bit : to make it more readable for the user, we dedup some entries*/
 	var spamLimit map[string]bool = make(map[string]bool)
-	//var realAlerts []*models.Alert = alerts.([]*models.Alert)
 
-	for _, alertItem := range *alerts {
+	/*process in reverse order to keep the latest item only*/
+	for aIdx := len(*alerts) - 1; aIdx >= 0; aIdx-- {
+		alertItem := (*alerts)[aIdx]
 		for _, decisionItem := range alertItem.Decisions {
-
 			spamKey := fmt.Sprintf("%s:%s:%s", *decisionItem.Type, *decisionItem.Scope, *decisionItem.Value)
 			if _, ok := spamLimit[spamKey]; ok {
-				log.Printf("discard '%s' -> already exists", spamKey)
 				alertItem.Decisions = nil
 			} else {
-				log.Printf("create '%s' -> new", spamKey)
 				spamLimit[spamKey] = true
 			}
 		}

--- a/cmd/crowdsec-cli/decisions.go
+++ b/cmd/crowdsec-cli/decisions.go
@@ -51,7 +51,7 @@ func DecisionsToTable(alerts *models.GetAlertsResponse) error {
 		fmt.Printf("id,source,ip,reason,action,country,as,events_count,expiration,simulated\n")
 		for _, alertItem := range *alerts {
 			for _, decisionItem := range alertItem.Decisions {
-				fmt.Printf("%v,%v,%v,%v,%v,%v,%v,%v,%v\n",
+				fmt.Printf("%v,%v,%v,%v,%v,%v,%v,%v,%v,%v\n",
 					decisionItem.ID,
 					*decisionItem.Origin,
 					*decisionItem.Scope+":"+*decisionItem.Value,

--- a/cmd/crowdsec-cli/decisions.go
+++ b/cmd/crowdsec-cli/decisions.go
@@ -31,6 +31,24 @@ var DeleteAll bool
 var Client *apiclient.ApiClient
 
 func DecisionsToTable(alerts *models.GetAlertsResponse) error {
+	/*here we cheat a bit : to make it more readable for the user, we dedup some entries*/
+	var spamLimit map[string]bool = make(map[string]bool)
+	//var realAlerts []*models.Alert = alerts.([]*models.Alert)
+
+	for _, alertItem := range *alerts {
+		for _, decisionItem := range alertItem.Decisions {
+
+			spamKey := fmt.Sprintf("%s:%s:%s", *decisionItem.Type, *decisionItem.Scope, *decisionItem.Value)
+			if _, ok := spamLimit[spamKey]; ok {
+				log.Printf("discard '%s' -> already exists", spamKey)
+				alertItem.Decisions = nil
+			} else {
+				log.Printf("create '%s' -> new", spamKey)
+				spamLimit[spamKey] = true
+			}
+		}
+	}
+
 	if csConfig.Cscli.Output == "raw" {
 		fmt.Printf("id,source,ip,reason,action,country,as,events_count,expiration,simulated\n")
 		for _, alertItem := range *alerts {


### PR DESCRIPTION
 - To make `cscli decisions list` output more friendly & concise, merge decisions on `{source,type,scope}` to avoid repeating items