### PR TITLE
wip/lapi : fix `cscli X inspect` 

### DIFF
--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
-
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
@@ -262,7 +260,6 @@ func ShowMetrics(hubItem *cwhub.Item) {
 	switch hubItem.Type {
 	case cwhub.PARSERS:
 		metrics := GetParserMetric(prometheusURL, hubItem.Name)
-		log.Printf("-> %s", spew.Sdump(metrics))
 		ShowParserMetric(hubItem.Name, metrics)
 	case cwhub.SCENARIOS:
 		metrics := GetScenarioMetric(prometheusURL, hubItem.Name)

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
+
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
@@ -260,6 +262,7 @@ func ShowMetrics(hubItem *cwhub.Item) {
 	switch hubItem.Type {
 	case cwhub.PARSERS:
 		metrics := GetParserMetric(prometheusURL, hubItem.Name)
+		log.Printf("-> %s", spew.Sdump(metrics))
 		ShowParserMetric(hubItem.Name, metrics)
 	case cwhub.SCENARIOS:
 		metrics := GetScenarioMetric(prometheusURL, hubItem.Name)
@@ -453,11 +456,12 @@ func ShowScenarioMetric(itemName string, metrics map[string]int) {
 
 func ShowParserMetric(itemName string, metrics map[string]map[string]int) {
 	skip := true
+
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Source", "Lines read", "Lines parsed", "Lines unparsed"})
+	table.SetHeader([]string{"Parsers", "Hits", "Parsed", "Unparsed"})
 	for source, stats := range metrics {
-		if stats["read"] > 0 {
-			table.Append([]string{source, fmt.Sprintf("%d", stats["read"]), fmt.Sprintf("%d", stats["parsed"]), fmt.Sprintf("%d", stats["unparsed"])})
+		if stats["hits"] > 0 {
+			table.Append([]string{source, fmt.Sprintf("%d", stats["hits"]), fmt.Sprintf("%d", stats["parsed"]), fmt.Sprintf("%d", stats["unparsed"])})
 			skip = false
 		}
 	}

--- a/pkg/cwhub/loader.go
+++ b/pkg/cwhub/loader.go
@@ -274,7 +274,15 @@ func CollecDepsCheck(v *Item) error {
 						v.UpToDate = false
 						return fmt.Errorf("outdated %s %s", ptrtype, p)
 					}
-					val.BelongsToCollections = append(val.BelongsToCollections, v.Name)
+					skip := false
+					for idx := range val.BelongsToCollections {
+						if val.BelongsToCollections[idx] == v.Name {
+							skip = true
+						}
+					}
+					if !skip {
+						val.BelongsToCollections = append(val.BelongsToCollections, v.Name)
+					}
 					hubIdx[ptrtype][p] = val
 					log.Tracef("checking for %s - tainted:%t uptodate:%t", p, v.Tainted, v.UpToDate)
 				} else {


### PR DESCRIPTION
 - Ensure prometheus metrics are displayed correctly for parsers
 - Ensure non duplicate dependencies in `belongs to` etc. of Item (as we are susceptible to walk several time items belonging to the same collection and such)
