### PR TITLE
Wip/lapi fix simulation display

### DIFF
--- a/cmd/crowdsec-cli/alerts.go
+++ b/cmd/crowdsec-cli/alerts.go
@@ -24,8 +24,12 @@ func DecisionsFromAlert(alert *models.Alert) string {
 	ret := ""
 	var decMap = make(map[string]int)
 	for _, decision := range alert.Decisions {
-		v := decMap[*decision.Type]
-		decMap[*decision.Type] = v + 1
+		k := *decision.Type
+		if *decision.Simulated {
+			k = fmt.Sprintf("(simul)%s", k)
+		}
+		v := decMap[k]
+		decMap[k] = v + 1
 	}
 	for k, v := range decMap {
 		if len(ret) > 0 {
@@ -84,7 +88,7 @@ func AlertsToTable(alerts *models.GetAlertsResponse, printMachine bool) error {
 		}
 
 		if len(*alerts) == 0 {
-			fmt.Println("No active decisions")
+			fmt.Println("No active alerts")
 			return nil
 		}
 

--- a/cmd/crowdsec-cli/decisions.go
+++ b/cmd/crowdsec-cli/decisions.go
@@ -31,7 +31,7 @@ func DecisionsToTable(alerts *models.GetAlertsResponse) error {
 	for aIdx := len(*alerts) - 1; aIdx >= 0; aIdx-- {
 		alertItem := (*alerts)[aIdx]
 		for _, decisionItem := range alertItem.Decisions {
-			spamKey := fmt.Sprintf("%s:%s:%s", *decisionItem.Type, *decisionItem.Scope, *decisionItem.Value)
+			spamKey := fmt.Sprintf("%t:%s:%s:%s", *decisionItem.Simulated, *decisionItem.Type, *decisionItem.Scope, *decisionItem.Value)
 			if _, ok := spamLimit[spamKey]; ok {
 				alertItem.Decisions = nil
 			} else {

--- a/pkg/csprofiles/csprofiles.go
+++ b/pkg/csprofiles/csprofiles.go
@@ -18,6 +18,18 @@ func GenerateDecisionFromProfile(Profile *csconfig.ProfileCfg, Alert *models.Ale
 
 	for _, refDecision := range Profile.Decisions {
 		decision := models.Decision{}
+		decisionType := *refDecision.Type
+		/*the reference decision from profile is in sumulated mode */
+		if refDecision.Simulated != nil && *refDecision.Simulated {
+			decisionType = fmt.Sprintf("(simulation) %s", decisionType)
+			decision.Simulated = new(bool)
+			*decision.Simulated = true
+			/*the event is already in simulation mode */
+		} else if Alert.Simulated != nil && *Alert.Simulated {
+			decisionType = fmt.Sprintf("(simulation) %s", decisionType)
+			decision.Simulated = new(bool)
+			*decision.Simulated = true
+		}
 		/*If the profile specifies a scope, this will prevail.
 		If not, we're going to get the scope from the source itself*/
 		decision.Scope = new(string)
@@ -72,7 +84,7 @@ func GenerateDecisionFromProfile(Profile *csconfig.ProfileCfg, Alert *models.Ale
 		}
 		decision.Scenario = new(string)
 		*decision.Scenario = *Alert.Scenario
-		log.Printf("%s %s decision : %s %s", *decision.Scope, *decision.Value, *decision.Duration, *decision.Type)
+		log.Printf("%s %s decision : %s %s", *decision.Scope, *decision.Value, *decision.Duration, decisionType)
 		decisions = append(decisions, &decision)
 	}
 	return decisions, nil

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -173,8 +173,6 @@ func BuildAlertRequestFromFilter(alerts *ent.AlertQuery, filter map[string][]str
 			alerts = alerts.Where(alert.SimulatedEQ(false))
 		}
 		delete(filter, "simulated")
-	} else {
-		alerts = alerts.Where(alert.SimulatedEQ(false))
 	}
 
 	for param, value := range filter {


### PR DESCRIPTION
 - don't exclude simulated alerts by default in `GET /alerts`
 - properly display it to the user by prefixing `(simul)` before decision type
 - in `decisions` list, take care of simulation flag for unicity of item (so that if one IP has two decisions and one in simulated, we show both)
