### PR TITLE
Wip/lapi : proper top x display

### DIFF
--- a/cmd/crowdsec-cli/alerts.go
+++ b/cmd/crowdsec-cli/alerts.go
@@ -49,15 +49,11 @@ func AlertsToTable(alerts *models.GetAlertsResponse, printMachine bool) error {
 			fmt.Printf("id,Scope/Value,reason,country,as,decisions,created_at\n")
 		}
 		for _, alertItem := range *alerts {
-			if alertItem.ScenarioVersion == nil || *alertItem.ScenarioVersion == "" {
-				alertItem.ScenarioVersion = new(string)
-				*alertItem.ScenarioVersion = "N/A"
-			}
 			if printMachine {
 				fmt.Printf("%v,%v,%v,%v,%v,%v,%v,%v\n",
 					alertItem.ID,
 					*alertItem.Source.Scope+":"+*alertItem.Source.Value,
-					fmt.Sprintf("%s (%s)", *alertItem.Scenario, *alertItem.ScenarioVersion),
+					*alertItem.Scenario,
 					alertItem.Source.Cn,
 					alertItem.Source.AsNumber+" "+alertItem.Source.AsName,
 					DecisionsFromAlert(alertItem),
@@ -67,7 +63,7 @@ func AlertsToTable(alerts *models.GetAlertsResponse, printMachine bool) error {
 				fmt.Printf("%v,%v,%v,%v,%v,%v,%v\n",
 					alertItem.ID,
 					*alertItem.Source.Scope+":"+*alertItem.Source.Value,
-					fmt.Sprintf("%s (%s)", *alertItem.Scenario, *alertItem.ScenarioVersion),
+					*alertItem.Scenario,
 					alertItem.Source.Cn,
 					alertItem.Source.AsNumber+" "+alertItem.Source.AsName,
 					DecisionsFromAlert(alertItem),
@@ -93,15 +89,11 @@ func AlertsToTable(alerts *models.GetAlertsResponse, printMachine bool) error {
 		}
 
 		for _, alertItem := range *alerts {
-			if alertItem.ScenarioVersion == nil {
-				alertItem.ScenarioVersion = new(string)
-				*alertItem.ScenarioVersion = "N/A"
-			}
 			if printMachine {
 				table.Append([]string{
 					strconv.Itoa(int(alertItem.ID)),
 					*alertItem.Source.Scope + ":" + *alertItem.Source.Value,
-					fmt.Sprintf("%s (%s)", *alertItem.Scenario, *alertItem.ScenarioVersion),
+					*alertItem.Scenario,
 					alertItem.Source.Cn,
 					alertItem.Source.AsNumber + " " + alertItem.Source.AsName,
 					DecisionsFromAlert(alertItem),
@@ -112,7 +104,7 @@ func AlertsToTable(alerts *models.GetAlertsResponse, printMachine bool) error {
 				table.Append([]string{
 					strconv.Itoa(int(alertItem.ID)),
 					*alertItem.Source.Scope + ":" + *alertItem.Source.Value,
-					fmt.Sprintf("%s (%s)", *alertItem.Scenario, *alertItem.ScenarioVersion),
+					*alertItem.Scenario,
 					alertItem.Source.Cn,
 					alertItem.Source.AsNumber + " " + alertItem.Source.AsName,
 					DecisionsFromAlert(alertItem),

--- a/cmd/crowdsec-cli/alerts.go
+++ b/cmd/crowdsec-cli/alerts.go
@@ -44,15 +44,16 @@ func AlertsToTable(alerts *models.GetAlertsResponse, printMachine bool) error {
 
 	if csConfig.Cscli.Output == "raw" {
 		if printMachine {
-			fmt.Printf("id,Scope/Value,reason,country,as,decisions,created_at,machine\n")
+			fmt.Printf("id,scope,value,reason,country,as,decisions,created_at,machine\n")
 		} else {
-			fmt.Printf("id,Scope/Value,reason,country,as,decisions,created_at\n")
+			fmt.Printf("id,scope,value,reason,country,as,decisions,created_at\n")
 		}
 		for _, alertItem := range *alerts {
 			if printMachine {
-				fmt.Printf("%v,%v,%v,%v,%v,%v,%v,%v\n",
+				fmt.Printf("%v,%v,%v,%v,%v,%v,%v,%v,%v\n",
 					alertItem.ID,
-					*alertItem.Source.Scope+":"+*alertItem.Source.Value,
+					*alertItem.Source.Scope,
+					*alertItem.Source.Value,
 					*alertItem.Scenario,
 					alertItem.Source.Cn,
 					alertItem.Source.AsNumber+" "+alertItem.Source.AsName,
@@ -60,9 +61,10 @@ func AlertsToTable(alerts *models.GetAlertsResponse, printMachine bool) error {
 					alertItem.CreatedAt,
 					alertItem.MachineID)
 			} else {
-				fmt.Printf("%v,%v,%v,%v,%v,%v,%v\n",
+				fmt.Printf("%v,%v,%v,%v,%v,%v,%v,%v\n",
 					alertItem.ID,
-					*alertItem.Source.Scope+":"+*alertItem.Source.Value,
+					*alertItem.Source.Scope,
+					*alertItem.Source.Value,
 					*alertItem.Scenario,
 					alertItem.Source.Cn,
 					alertItem.Source.AsNumber+" "+alertItem.Source.AsName,
@@ -78,9 +80,9 @@ func AlertsToTable(alerts *models.GetAlertsResponse, printMachine bool) error {
 
 		table := tablewriter.NewWriter(os.Stdout)
 		if printMachine {
-			table.SetHeader([]string{"ID", "scope:value", "reason", "country", "as", "decisions", "created_at", "machine"})
+			table.SetHeader([]string{"ID", "value", "reason", "country", "as", "decisions", "created_at", "machine"})
 		} else {
-			table.SetHeader([]string{"ID", "scope:value", "reason", "country", "as", "decisions", "created_at"})
+			table.SetHeader([]string{"ID", "value", "reason", "country", "as", "decisions", "created_at"})
 		}
 
 		if len(*alerts) == 0 {
@@ -89,10 +91,14 @@ func AlertsToTable(alerts *models.GetAlertsResponse, printMachine bool) error {
 		}
 
 		for _, alertItem := range *alerts {
+			displayVal := *alertItem.Source.Scope
+			if *alertItem.Source.Value != "" {
+				displayVal += ":" + *alertItem.Source.Value
+			}
 			if printMachine {
 				table.Append([]string{
 					strconv.Itoa(int(alertItem.ID)),
-					*alertItem.Source.Scope + ":" + *alertItem.Source.Value,
+					displayVal,
 					*alertItem.Scenario,
 					alertItem.Source.Cn,
 					alertItem.Source.AsNumber + " " + alertItem.Source.AsName,
@@ -103,7 +109,7 @@ func AlertsToTable(alerts *models.GetAlertsResponse, printMachine bool) error {
 			} else {
 				table.Append([]string{
 					strconv.Itoa(int(alertItem.ID)),
-					*alertItem.Source.Scope + ":" + *alertItem.Source.Value,
+					displayVal,
 					*alertItem.Scenario,
 					alertItem.Source.Cn,
 					alertItem.Source.AsNumber + " " + alertItem.Source.AsName,

--- a/cmd/crowdsec-cli/decisions.go
+++ b/cmd/crowdsec-cli/decisions.go
@@ -136,6 +136,7 @@ func NewDecisionsCmd() *cobra.Command {
 		Since:          new(string),
 		Until:          new(string),
 		TypeEquals:     new(string),
+		IncludeCAPI:    new(bool),
 	}
 	var NoSimu bool
 	var cmdDecisionsList = &cobra.Command{
@@ -217,6 +218,7 @@ cscli decisions list -t ban
 		},
 	}
 	cmdDecisionsList.Flags().SortFlags = false
+	cmdDecisionsList.Flags().BoolVarP(filter.IncludeCAPI, "all", "a", false, "Include decisions from Central API")
 	cmdDecisionsList.Flags().StringVar(filter.Since, "since", "", "restrict to alerts newer than since (ie. 4h, 30d)")
 	cmdDecisionsList.Flags().StringVar(filter.Until, "until", "", "restrict to alerts older than until (ie. 4h, 30d)")
 	cmdDecisionsList.Flags().StringVarP(filter.TypeEquals, "type", "t", "", "restrict to this decision type (ie. ban,captcha)")

--- a/pkg/apiclient/alerts_service.go
+++ b/pkg/apiclient/alerts_service.go
@@ -23,6 +23,7 @@ type AlertsListOpts struct {
 	Until                *string `url:"until,omitempty"`
 	IncludeSimulated     *bool   `url:"simulated,omitempty"`
 	ActiveDecisionEquals *bool   `url:"has_active_decision,omitempty"`
+	IncludeCAPI          *bool   `url:"include_capi,omitempty"`
 	ListOpts
 }
 

--- a/pkg/apiclient/signal.go
+++ b/pkg/apiclient/signal.go
@@ -36,6 +36,6 @@ func (s *SignalService) Add(ctx context.Context, signals []*Signal) (interface{}
 	if err != nil {
 		return nil, resp, errors.Wrap(err, "while performing request")
 	}
-	log.Printf("signals add response : %s %s", resp.Response.Status, resp.Response.Body)
+	log.Printf("Signal push response : http %s", resp.Response.Status)
 	return &response, resp, nil
 }

--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -152,13 +152,12 @@ func (a *apic) Push() error {
 			err := a.Send(cache)
 			return err
 		case <-ticker.C:
-			// flush
 			if len(cache) > 0 {
 				a.mu.Lock()
 				cacheCopy := cache
 				cache = make([]*apiclient.Signal, 0)
 				a.mu.Unlock()
-				log.Infof("api push: pushed %d signals", len(cacheCopy))
+				log.Infof("Signal push: %d signals to push", len(cacheCopy))
 				err := a.Send(cacheCopy)
 				if err != nil {
 					log.Errorf("got an error while sending signal : %s", err)
@@ -218,19 +217,24 @@ func (a *apic) Pull() error {
 				log.Printf("pull top: deleted %s entries", nbDeleted)
 			}
 
+			alertCreated, err := a.dbClient.Ent.Alert.
+				Create().
+				SetScenario(fmt.Sprintf("consensus pull : %d IPs", len(data.New))).
+				SetSourceScope("Crowdsec consensus").
+				Save(a.dbClient.CTX)
+			if err != nil {
+				return errors.Wrap(err, "create alert from crowdsec-api")
+			}
+
 			// process new decisions
 			for _, decision := range data.New {
-				alertCreated, err := a.dbClient.Ent.Alert.
-					Create().
-					SetScenario(*decision.Scenario).
-					SetSourceIp(*decision.Value).
-					SetSourceValue(*decision.Value).
-					SetSourceScope(*decision.Scope).
-					Save(a.dbClient.CTX)
-				if err != nil {
-					return errors.Wrap(err, "create alert from crowdsec-api")
+				/*ensure scope makes sense no matter what consensus gives*/
+				if strings.ToLower(*decision.Scope) == "ip" {
+					*decision.Scope = types.Ip
+				} else if strings.ToLower(*decision.Scope) == "range" {
+					*decision.Scope = types.Range
 				}
-				log.Infof("alertcreated: %+v", alertCreated)
+
 				duration, err := time.ParseDuration(*decision.Duration)
 				if err != nil {
 					return errors.Wrapf(err, "parse decision duration '%s':", *decision.Duration)

--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -220,7 +220,7 @@ func (a *apic) Pull() error {
 			alertCreated, err := a.dbClient.Ent.Alert.
 				Create().
 				SetScenario(fmt.Sprintf("update : +%d/-%d IPs", len(data.New), len(data.Deleted))).
-				SetSourceScope("Reputation blocklist").
+				SetSourceScope("Comunity blocklist").
 				Save(a.dbClient.CTX)
 			if err != nil {
 				return errors.Wrap(err, "create alert from crowdsec-api")

--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -219,8 +219,8 @@ func (a *apic) Pull() error {
 
 			alertCreated, err := a.dbClient.Ent.Alert.
 				Create().
-				SetScenario(fmt.Sprintf("consensus pull : +%d/-%d", len(data.New), len(data.Deleted))).
-				SetSourceScope("Crowdsec consensus").
+				SetScenario(fmt.Sprintf("update : +%d/-%d IPs", len(data.New), len(data.Deleted))).
+				SetSourceScope("Reputation blocklist").
 				Save(a.dbClient.CTX)
 			if err != nil {
 				return errors.Wrap(err, "create alert from crowdsec-api")

--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -219,7 +219,7 @@ func (a *apic) Pull() error {
 
 			alertCreated, err := a.dbClient.Ent.Alert.
 				Create().
-				SetScenario(fmt.Sprintf("consensus pull : %d IPs", len(data.New))).
+				SetScenario(fmt.Sprintf("consensus pull : +%d/-%d", len(data.New), len(data.Deleted))).
 				SetSourceScope("Crowdsec consensus").
 				Save(a.dbClient.CTX)
 			if err != nil {

--- a/pkg/apiserver/controllers/v1/alerts.go
+++ b/pkg/apiserver/controllers/v1/alerts.go
@@ -77,8 +77,9 @@ func FormatAlerts(result []*ent.Alert) models.AddAlertsRequest {
 			})
 			outputAlert.Meta = outputMetas
 		}
+		var outputDecisions []*models.Decision
+
 		for _, decisionItem := range alertItem.Edges.Decisions {
-			var outputDecisions []*models.Decision
 			duration := decisionItem.Until.Sub(time.Now()).String()
 			outputDecisions = append(outputDecisions, &models.Decision{
 				Duration:  &duration, // transform into time.Time ?
@@ -92,8 +93,9 @@ func FormatAlerts(result []*ent.Alert) models.AddAlertsRequest {
 				Simulated: outputAlert.Simulated,
 				ID:        int64(decisionItem.ID),
 			})
-			outputAlert.Decisions = outputDecisions
 		}
+		outputAlert.Decisions = outputDecisions
+
 		data = append(data, &outputAlert)
 	}
 	return data

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -219,6 +219,12 @@ func BuildAlertRequestFromFilter(alerts *ent.AlertQuery, filter map[string][]str
 			alerts = alerts.Where(alert.CreatedAtLTE(since))
 		case "decision_type":
 			alerts = alerts.Where(alert.HasDecisionsWith(decision.TypeEQ(value[0])))
+		case "include_capi": //allows to exclude one or more specific origins
+			if value[0] == "false" {
+				alerts = alerts.Where(alert.HasDecisionsWith(decision.OriginNEQ("CAPI")))
+			} else if value[0] != "true" {
+				log.Errorf("Invalid bool '%s' for include_capi", value[0])
+			}
 		case "has_active_decision":
 			if hasActiveDecision, err = strconv.ParseBool(value[0]); err != nil {
 				return nil, errors.Wrap(ParseType, fmt.Sprintf("'%s' is not a boolean: %s", value[0], err))


### PR DESCRIPTION
 - One topX pull equals to *one* alert with *Y* decisions
 - `cscli decisions list` won't display topX unless `--all / -a` is given

```
$ ./cscli -c dev.yaml decisions list -a
+-----+----------+-----------------------+----------------------+--------+---------+----+--------+---------------------+
| ID  |  SOURCE  |      SCOPE:VALUE      |        REASON        | ACTION | COUNTRY | AS | EVENTS |     EXPIRATION      |
+-----+----------+-----------------------+----------------------+--------+---------+----+--------+---------------------+
|   1 | crowdsec | Ip:1.2.3.8            | crowdsecurity/ssh-bf | ban    | US      |    |      6 | 50m35.287905536s    |
| 143 | CAPI     | Ip:xxxxx/32  | crowdsec/ssh-bf      | ban    |         |    |      0 | 23h58m31.376043292s |

```

 - `cscli alerts list` shows topX pull in a condensed form :

```
$ ./cscli -c dev.yaml alerts list      
+----+--------------------+-------------------------+---------+----+-----------+---------------------------+
| ID |       VALUE        |         REASON          | COUNTRY | AS | DECISIONS |        CREATED AT         |
+----+--------------------+-------------------------+---------+----+-----------+---------------------------+
|  1 | Ip:1.2.3.8         | crowdsecurity/ssh-bf    | US      |    | ban:1     | 2020-11-03T15:49:32+01:00 |
|  2 | Crowdsec consensus | consensus pull : +47/-0 |         |    | ban:47    | 2020-11-03T15:51:29+01:00 |
```


