### PR TITLE
Fix the GTE/LTE than dance when user queries a range

### DIFF
--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -247,10 +247,20 @@ func BuildAlertRequestFromFilter(alerts *ent.AlertQuery, filter map[string][]str
 		}
 	}
 	if startIP != 0 && endIP != 0 {
-		alerts = alerts.Where(alert.And(
-			alert.HasDecisionsWith(decision.StartIPLTE(startIP)),
-			alert.HasDecisionsWith(decision.EndIPGTE(endIP)),
-		))
+		/*the user is checking for a single IP*/
+		if startIP == endIP {
+			//DECISION_START <= IP_Q >= DECISON_END
+			alerts = alerts.Where(alert.And(
+				alert.HasDecisionsWith(decision.StartIPLTE(startIP)),
+				alert.HasDecisionsWith(decision.EndIPGTE(endIP)),
+			))
+		} else { /*the user is checking for a RANGE */
+			//START_Q >= DECISION_START AND END_Q <= DECISION_END
+			alerts = alerts.Where(alert.And(
+				alert.HasDecisionsWith(decision.StartIPGTE(startIP)),
+				alert.HasDecisionsWith(decision.EndIPLTE(endIP)),
+			))
+		}
 	}
 	return alerts, nil
 }

--- a/pkg/database/decisions.go
+++ b/pkg/database/decisions.go
@@ -61,10 +61,20 @@ func BuildDecisionRequestWithFilter(query *ent.DecisionQuery, filter map[string]
 	}
 
 	if startIP != 0 && endIP != 0 {
-		query = query.Where(decision.And(
-			decision.StartIPLTE(startIP),
-			decision.EndIPGTE(endIP),
-		))
+		/*the user is checking for a single IP*/
+		if startIP == endIP {
+			//DECISION_START <= IP_Q >= DECISON_END
+			query = query.Where(decision.And(
+				decision.StartIPLTE(startIP),
+				decision.EndIPGTE(endIP),
+			))
+		} else { /*the user is checking for a RANGE */
+			//START_Q >= DECISION_START AND END_Q <= DECISION_END
+			query = query.Where(decision.And(
+				decision.StartIPGTE(startIP),
+				decision.EndIPLTE(endIP),
+			))
+		}
 	}
 	return query, nil
 }


### PR DESCRIPTION
Fix the maths for range so that the decision list on range and IPs play well tgth :


```
$ ./cscli -c dev.yaml decisions list -i 1.2.3.5
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+
| ID | SOURCE |   SCOPE:VALUE    | REASON | ACTION | COUNTRY | AS | EVENTS |     EXPIRATION     |
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+
|  3 | cscli  | Range:1.2.3.0/24 |        | ban    |         |    |      1 | 3h55m32.494001263s |
|  6 | cscli  | Ip:1.2.3.5       |        | ban    |         |    |      1 | 3h59m29.340378252s |
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+

$ ./cscli -c dev.yaml decisions list -i 1.2.3.6
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+
| ID | SOURCE |   SCOPE:VALUE    | REASON | ACTION | COUNTRY | AS | EVENTS |     EXPIRATION     |
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+
|  3 | cscli  | Range:1.2.3.0/24 |        | ban    |         |    |      1 | 3h55m30.634387999s |
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+

$ ./cscli -c dev.yaml decisions list -i 1.2.4.6
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+
| ID | SOURCE |   SCOPE:VALUE    | REASON | ACTION | COUNTRY | AS | EVENTS |     EXPIRATION     |
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+
|  7 | cscli  | Range:1.2.4.0/24 |        | ban    |         |    |      1 | 3h59m37.825610451s |
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+

$ ./cscli -c dev.yaml decisions list -r 1.2.3.0/24
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+
| ID | SOURCE |   SCOPE:VALUE    | REASON | ACTION | COUNTRY | AS | EVENTS |     EXPIRATION     |
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+
|  1 | cscli  | Ip:1.2.3.4       |        | ban    |         |    |      1 | 3h54m0.185493685s  |
|  3 | cscli  | Range:1.2.3.0/24 |        | ban    |         |    |      1 | 3h55m15.276552747s |
|  5 | cscli  | Ip:1.2.3.1       |        | ban    |         |    |      1 | 3h57m10.781924221s |
|  6 | cscli  | Ip:1.2.3.5       |        | ban    |         |    |      1 | 3h59m12.122926295s |
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+

$ ./cscli -c dev.yaml decisions list -r 1.2.3.0/16
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+
| ID | SOURCE |   SCOPE:VALUE    | REASON | ACTION | COUNTRY | AS | EVENTS |     EXPIRATION     |
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+
|  1 | cscli  | Ip:1.2.3.4       |        | ban    |         |    |      1 | 3h53m56.890703516s |
|  3 | cscli  | Range:1.2.3.0/24 |        | ban    |         |    |      1 | 3h55m11.981762847s |
|  5 | cscli  | Ip:1.2.3.1       |        | ban    |         |    |      1 | 3h57m7.48713447s   |
|  6 | cscli  | Ip:1.2.3.5       |        | ban    |         |    |      1 | 3h59m8.828136441s  |
|  7 | cscli  | Range:1.2.4.0/24 |        | ban    |         |    |      1 | 3h59m23.825294148s |
+----+--------+------------------+--------+--------+---------+----+--------+--------------------+

```