### PR TITLE
Wip lapi : lapi debug + lock discussion

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,6 +20,7 @@ db_config:
   type: sqlite
   db_path: /var/lib/crowdsec/data/crowdsec.db
   user: crowdsec
+  #log_level: info
   password: crowdsec
   db_name: crowdsec
   host: "127.0.0.1"
@@ -29,6 +30,7 @@ api:
     insecure_skip_verify: true # default true
     credentials_path: /etc/crowdsec/local_api_credentials.yaml
   server:
+    #log_level: info
     listen_uri: localhost:8080
     profiles_path: /etc/crowdsec/profiles.yaml
     online_client: # Crowdsec API

--- a/pkg/apiclient/auth.go
+++ b/pkg/apiclient/auth.go
@@ -182,9 +182,11 @@ func (t *JWTTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		dump, _ := httputil.DumpResponse(resp, true)
 		log.Tracef("resp-jwt: %s", string(dump))
 	}
+	if err != nil {
+		return resp, errors.Wrapf(err, "performing jwt auth")
+	}
 	log.Debugf("resp-jwt: %d", resp.StatusCode)
-
-	return resp, err
+	return resp, nil
 }
 
 func (t *JWTTransport) Client() *http.Client {

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -103,7 +103,6 @@ func NewServer(config *csconfig.LocalApiServerCfg) (*APIServer, error) {
 		Profiles: config.Profiles,
 		Log:      clog,
 	}
-	controller.DBClient.Log = clog
 
 	var apiClient *apic
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -59,10 +59,13 @@ func NewServer(config *csconfig.LocalApiServerCfg) (*APIServer, error) {
 	log.Debugf("starting router, logging to %s", logFile)
 	router := gin.New()
 
+	/*The logger that will be used by handlers*/
 	clog := log.New()
 	if err := types.ConfigureLogger(clog); err != nil {
 		return nil, errors.Wrap(err, "while configuring gin logger")
 	}
+	clog.SetLevel(config.LogLevel)
+
 	gin.DefaultErrorWriter = clog.Writer()
 
 	// Logging to a file.
@@ -98,7 +101,9 @@ func NewServer(config *csconfig.LocalApiServerCfg) (*APIServer, error) {
 		Ectx:     context.Background(),
 		Router:   router,
 		Profiles: config.Profiles,
+		Log:      clog,
 	}
+	controller.DBClient.Log = clog
 
 	var apiClient *apic
 

--- a/pkg/apiserver/controllers/controller.go
+++ b/pkg/apiserver/controllers/controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/database"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
 )
 
 type Controller struct {
@@ -16,6 +17,7 @@ type Controller struct {
 	Router   *gin.Engine
 	Profiles []*csconfig.ProfileCfg
 	CAPIChan chan []*models.Alert
+	Log      *log.Logger
 }
 
 func (c *Controller) Init() error {

--- a/pkg/csconfig/api.go
+++ b/pkg/csconfig/api.go
@@ -1,5 +1,7 @@
 package csconfig
 
+import log "github.com/sirupsen/logrus"
+
 type APICfg struct {
 	Client *LocalApiClientCfg `yaml:"client"`
 	Server *LocalApiServerCfg `yaml:"server"`
@@ -33,6 +35,7 @@ type LocalApiServerCfg struct {
 	OnlineClient *OnlineApiClientCfg `yaml:"online_client"`
 	ProfilesPath string              `yaml:"profiles_path,omitempty"`
 	Profiles     []*ProfileCfg       `yaml:"-"`
+	LogLevel     log.Level           `yaml:"log_level"`
 }
 
 type TLSCfg struct {

--- a/pkg/csconfig/database.go
+++ b/pkg/csconfig/database.go
@@ -1,5 +1,7 @@
 package csconfig
 
+import log "github.com/sirupsen/logrus"
+
 type DatabaseCfg struct {
 	User     string      `yaml:"user"`
 	Password string      `yaml:"password"`
@@ -9,6 +11,7 @@ type DatabaseCfg struct {
 	DbPath   string      `yaml:"db_path"`
 	Type     string      `yaml:"type"`
 	Flush    *FlushDBCfg `yaml:"flush"`
+	LogLevel log.Level   `yaml:"log_level"`
 }
 
 type FlushDBCfg struct {


### PR DESCRIPTION
 - Add individual `log_level` directives to api:server and db_config
 - If `log_level` is set to trace or higher, the `Ent` client will have Debug enabled (logs all outgoing SQL requests)
 - Add a timeout context to the `Push()` mechanism of cs -> LAPI (but this still needs to be discussed, it's just to avoid lock)
