### PR TITLE
fix postoverflow whitelists

### DIFF
--- a/cmd/crowdsec/output.go
+++ b/cmd/crowdsec/output.go
@@ -142,6 +142,10 @@ LOOP:
 				return fmt.Errorf("postoverflow failed : %s", err)
 			}
 			log.Printf("%s", *event.Overflow.Alert.Message)
+			if event.Overflow.Whitelisted {
+				log.Printf("[%s] is whitelisted, skip.", *event.Overflow.Alert.Message)
+				continue
+			}
 			cacheMutex.Lock()
 			cache = append(cache, event.Overflow)
 			cacheMutex.Unlock()


### PR DESCRIPTION
 - Fix the whitelists: don't send whitelisted events to the local API