### PR TITLE
[wip_lapi] Fix flush alerts

### DIFF
--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -510,6 +510,11 @@ func (c *Client) FlushAlerts(MaxAge string, MaxItems int) error {
 	var deletedByNbItem int
 	var totalAlerts int
 	var err error
+	totalAlerts, err = c.TotalAlerts()
+	if err != nil {
+		log.Warningf("FlushAlerts (max items count) : %s", err)
+		return errors.Wrap(err, "unable to get alerts count")
+	}
 	if MaxAge != "" {
 		filter := map[string][]string{
 			"created_before": {MaxAge},
@@ -522,11 +527,6 @@ func (c *Client) FlushAlerts(MaxAge string, MaxItems int) error {
 		deletedByAge = len(deleted)
 	}
 	if MaxItems > 0 {
-		totalAlerts, err = c.TotalAlerts()
-		if err != nil {
-			log.Warningf("FlushAlerts (max items count) : %s", err)
-			return errors.Wrap(err, "unable to get alerts count")
-		}
 		if totalAlerts > MaxItems {
 			nbToDelete := totalAlerts - MaxItems
 			alerts, err := c.QueryAlertWithFilter(map[string][]string{
@@ -553,7 +553,7 @@ func (c *Client) FlushAlerts(MaxAge string, MaxItems int) error {
 		log.Infof("flushed %d/%d alerts because max number of alerts has been reached (%d max)", deletedByNbItem, totalAlerts, MaxItems)
 	}
 	if deletedByAge > 0 {
-		log.Infof("flushed %d/%d alerts because of they were created %s ago or more", deletedByAge, totalAlerts, MaxAge)
+		log.Infof("flushed %d/%d alerts because they were created %s ago or more", deletedByAge, totalAlerts, MaxAge)
 	}
 	return nil
 }

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -539,7 +539,7 @@ func (c *Client) FlushAlerts(MaxAge string, MaxItems int) error {
 		}
 	}
 	if deletedByNbItem > 0 {
-		log.Infof("flushed %d alerts because max number of alerts has been reached (%s max)", deletedByNbItem, MaxItems)
+		log.Infof("flushed %d alerts because max number of alerts has been reached (%d max)", deletedByNbItem, MaxItems)
 	}
 	if deletedByAge > 0 {
 		log.Infof("flushed %d alerts because of they were created '%s' days ago or more", deletedByAge, MaxAge)

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -433,7 +433,7 @@ func (c *Client) QueryAlertWithFilter(filter map[string][]string) ([]*ent.Alert,
 		if diff := limit - len(ret); diff < paginationSize {
 			if len(result) < diff {
 				ret = append(ret, result...)
-				log.Infof("Pagination done, %d < %d", len(result), diff)
+				log.Debugf("Pagination done, %d < %d", len(result), diff)
 				break
 			}
 			ret = append(ret, result[0:diff]...)
@@ -441,7 +441,7 @@ func (c *Client) QueryAlertWithFilter(filter map[string][]string) ([]*ent.Alert,
 			ret = append(ret, result...)
 		}
 		if len(ret) == limit || len(ret) == 0 {
-			log.Infof("Pagination done len(ret) = %d", len(ret))
+			log.Debugf("Pagination done len(ret) = %d", len(ret))
 			break
 		}
 		offset += paginationSize
@@ -525,7 +525,6 @@ func (c *Client) FlushAlerts(MaxAge string, MaxItems int) error {
 		}
 		if totalAlerts > MaxItems {
 			nbToDelete := totalAlerts - MaxItems
-			log.Infof("Number of alerts to delete: %d (%d - %d)", nbToDelete, totalAlerts, MaxItems)
 			alerts, err := c.QueryAlertWithFilter(map[string][]string{
 				"sort":  {"ASC"},
 				"limit": {strconv.Itoa(nbToDelete)},
@@ -534,7 +533,6 @@ func (c *Client) FlushAlerts(MaxAge string, MaxItems int) error {
 				log.Warningf("FlushAlerts (max items query) : %s", err)
 				return errors.Wrap(err, "unable to get all alerts")
 			}
-			log.Infof("Alerts query returned %d alerts", len(alerts))
 			for itemNb, alert := range alerts {
 				if itemNb < nbToDelete {
 					err := c.DeleteAlertGraph(alert)

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -401,7 +401,7 @@ func (c *Client) QueryAlertWithFilter(filter map[string][]string) ([]*ent.Alert,
 		limit = limitConv
 
 	}
-
+	log.Infof("Filter: %+v", filter)
 	offset := 0
 	ret := make([]*ent.Alert, 0)
 	for {
@@ -433,6 +433,7 @@ func (c *Client) QueryAlertWithFilter(filter map[string][]string) ([]*ent.Alert,
 		if diff := limit - len(ret); diff < paginationSize {
 			if len(result) < diff {
 				ret = append(ret, result...)
+				log.Infof("Pagination done, %d < %d", len(result), diff)
 				break
 			}
 			ret = append(ret, result[0:diff]...)
@@ -440,6 +441,7 @@ func (c *Client) QueryAlertWithFilter(filter map[string][]string) ([]*ent.Alert,
 			ret = append(ret, result...)
 		}
 		if len(ret) == limit || len(ret) == 0 {
+			log.Infof("Pagination done len(ret) = %d", len(ret))
 			break
 		}
 		offset += paginationSize

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -328,7 +328,7 @@ func BuildAlertRequestFromFilter(alerts *ent.AlertQuery, filter map[string][]str
 			if since.IsZero() {
 				return nil, fmt.Errorf("Empty time now() - %s", since.String())
 			}
-			alerts = alerts.Where(alert.CreatedAtGTE(since))
+			alerts = alerts.Where(alert.CreatedAtLTE(since))
 		case "until":
 			duration, err := types.ParseDuration(value[0])
 			if err != nil {
@@ -405,7 +405,6 @@ func (c *Client) QueryAlertWithFilter(filter map[string][]string) ([]*ent.Alert,
 		limit = limitConv
 
 	}
-	log.Infof("Filter: %+v", filter)
 	offset := 0
 	ret := make([]*ent.Alert, 0)
 	for {

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -523,11 +523,13 @@ func (c *Client) FlushAlerts(MaxAge string, MaxItems int) error {
 		}
 		if totalAlerts > MaxItems {
 			nbToDelete := totalAlerts - MaxItems
+			log.Infof("Number of alerts to delete: %d (%d - %d)", nbToDelete, totalAlerts, MaxItems)
 			alerts, err := c.QueryAlertWithFilter(map[string][]string{"sort": {"ASC"}}) // we want to delete older alerts if we reach the max number of items
 			if err != nil {
 				log.Warningf("FlushAlerts (max items query) : %s", err)
 				return errors.Wrap(err, "unable to get all alerts")
 			}
+			log.Infof("Alerts query returned %d alerts", len(alerts))
 			for itemNb, alert := range alerts {
 				if itemNb < nbToDelete {
 					err := c.DeleteAlertGraph(alert)

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -524,7 +524,10 @@ func (c *Client) FlushAlerts(MaxAge string, MaxItems int) error {
 		if totalAlerts > MaxItems {
 			nbToDelete := totalAlerts - MaxItems
 			log.Infof("Number of alerts to delete: %d (%d - %d)", nbToDelete, totalAlerts, MaxItems)
-			alerts, err := c.QueryAlertWithFilter(map[string][]string{"sort": {"ASC"}}) // we want to delete older alerts if we reach the max number of items
+			alerts, err := c.QueryAlertWithFilter(map[string][]string{
+				"sort":  {"ASC"},
+				"limit": {strconv.Itoa(nbToDelete)},
+			}) // we want to delete older alerts if we reach the max number of items
 			if err != nil {
 				log.Warningf("FlushAlerts (max items query) : %s", err)
 				return errors.Wrap(err, "unable to get all alerts")
@@ -546,7 +549,7 @@ func (c *Client) FlushAlerts(MaxAge string, MaxItems int) error {
 		log.Infof("flushed %d/%d alerts because max number of alerts has been reached (%d max)", deletedByNbItem, totalAlerts, MaxItems)
 	}
 	if deletedByAge > 0 {
-		log.Infof("flushed %d/%d alerts because of they were created '%s' days ago or more", deletedByAge, totalAlerts, MaxAge)
+		log.Infof("flushed %d/%d alerts because of they were created %s ago or more", deletedByAge, totalAlerts, MaxAge)
 	}
 	return nil
 }

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -502,6 +502,8 @@ func (c *Client) DeleteAlertWithFilter(filter map[string][]string) ([]*ent.Alert
 func (c *Client) FlushAlerts(MaxAge string, MaxItems int) error {
 	var deletedByAge int
 	var deletedByNbItem int
+	var totalAlerts int
+	var err error
 	if MaxAge != "" {
 		filter := map[string][]string{
 			"created_before": {MaxAge},
@@ -514,7 +516,7 @@ func (c *Client) FlushAlerts(MaxAge string, MaxItems int) error {
 		deletedByAge = len(deleted)
 	}
 	if MaxItems > 0 {
-		totalAlerts, err := c.Ent.Alert.Query().Count(c.CTX)
+		totalAlerts, err = c.Ent.Alert.Query().Count(c.CTX)
 		if err != nil {
 			log.Warningf("FlushAlerts (max items count) : %s", err)
 			return errors.Wrap(err, "unable to get alerts count")
@@ -539,10 +541,10 @@ func (c *Client) FlushAlerts(MaxAge string, MaxItems int) error {
 		}
 	}
 	if deletedByNbItem > 0 {
-		log.Infof("flushed %d alerts because max number of alerts has been reached (%d max)", deletedByNbItem, MaxItems)
+		log.Infof("flushed %d/%d alerts because max number of alerts has been reached (%d max)", deletedByNbItem, totalAlerts, MaxItems)
 	}
 	if deletedByAge > 0 {
-		log.Infof("flushed %d alerts because of they were created '%s' days ago or more", deletedByAge, MaxAge)
+		log.Infof("flushed %d/%d alerts because of they were created '%s' days ago or more", deletedByAge, totalAlerts, MaxAge)
 	}
 	return nil
 }

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -383,6 +383,10 @@ func BuildAlertRequestFromFilter(alerts *ent.AlertQuery, filter map[string][]str
 	return alerts, nil
 }
 
+func (c *Client) TotalAlerts() (int, error) {
+	return c.Ent.Alert.Query().Count(c.CTX)
+}
+
 func (c *Client) QueryAlertWithFilter(filter map[string][]string) ([]*ent.Alert, error) {
 	sort := "DESC" // we sort by desc by default
 	if val, ok := filter["sort"]; ok {
@@ -518,7 +522,7 @@ func (c *Client) FlushAlerts(MaxAge string, MaxItems int) error {
 		deletedByAge = len(deleted)
 	}
 	if MaxItems > 0 {
-		totalAlerts, err = c.Ent.Alert.Query().Count(c.CTX)
+		totalAlerts, err = c.TotalAlerts()
 		if err != nil {
 			log.Warningf("FlushAlerts (max items count) : %s", err)
 			return errors.Wrap(err, "unable to get alerts count")


### PR DESCRIPTION
- Use pagination to flush items based on "max_items"
- flush alerts from their creation date and not `started_at` for `max_age`