### PR TITLE
Improve create alerts input

### DIFF
--- a/pkg/apiserver/controllers/v1/alerts.go
+++ b/pkg/apiserver/controllers/v1/alerts.go
@@ -121,6 +121,12 @@ func (c *Controller) CreateAlert(gctx *gin.Context) {
 	for _, alert := range input {
 		if len(alert.Decisions) > 0 {
 			log.Debugf("alert %s already has decisions, don't apply profiles", *alert.Message)
+			for _, decision := range alert.Decisions {
+				if decision.EndIP != 0 && decision.StartIP != 0 && decision.EndIP < decision.StartIP {
+					gctx.JSON(http.StatusBadRequest, gin.H{"message": fmt.Errorf("'start_ip' must be lower than 'end_ip' in a decision")})
+					return
+				}
+			}
 		} else {
 			decisions, err := csprofiles.EvaluateProfiles(c.Profiles, alert)
 			if err != nil {

--- a/pkg/apiserver/controllers/v1/alerts.go
+++ b/pkg/apiserver/controllers/v1/alerts.go
@@ -123,7 +123,7 @@ func (c *Controller) CreateAlert(gctx *gin.Context) {
 			log.Debugf("alert %s already has decisions, don't apply profiles", *alert.Message)
 			for _, decision := range alert.Decisions {
 				if decision.EndIP != 0 && decision.StartIP != 0 && decision.EndIP < decision.StartIP {
-					gctx.JSON(http.StatusBadRequest, gin.H{"message": "'start_ip' must be lower than 'end_ip' in decisions"})
+					gctx.JSON(http.StatusBadRequest, gin.H{"message": "'start_ip' must be lower or equal than 'end_ip' in decisions"})
 					return
 				}
 			}

--- a/pkg/apiserver/controllers/v1/alerts.go
+++ b/pkg/apiserver/controllers/v1/alerts.go
@@ -123,7 +123,7 @@ func (c *Controller) CreateAlert(gctx *gin.Context) {
 			log.Debugf("alert %s already has decisions, don't apply profiles", *alert.Message)
 			for _, decision := range alert.Decisions {
 				if decision.EndIP != 0 && decision.StartIP != 0 && decision.EndIP < decision.StartIP {
-					gctx.JSON(http.StatusBadRequest, gin.H{"message": fmt.Errorf("'start_ip' must be lower than 'end_ip' in a decision")})
+					gctx.JSON(http.StatusBadRequest, gin.H{"message": "'start_ip' must be lower than 'end_ip' in decisions"})
 					return
 				}
 			}

--- a/pkg/apiserver/controllers/v1/alerts.go
+++ b/pkg/apiserver/controllers/v1/alerts.go
@@ -123,7 +123,7 @@ func (c *Controller) CreateAlert(gctx *gin.Context) {
 			log.Debugf("alert %s already has decisions, don't apply profiles", *alert.Message)
 			for _, decision := range alert.Decisions {
 				if decision.EndIP != 0 && decision.StartIP != 0 && decision.EndIP < decision.StartIP {
-					gctx.JSON(http.StatusBadRequest, gin.H{"message": "'start_ip' must be lower or equal than 'end_ip' in decisions"})
+					gctx.JSON(http.StatusBadRequest, gin.H{"message": "'start_ip' must be lower than or equal to 'end_ip' in decisions"})
 					return
 				}
 			}


### PR DESCRIPTION
* Here we check in each alert decisions if `start_ip` & `end_ip` are valid. Before merging that we need to evaluate if it's less efficient or not.

Example result :
```
eren@linux ~/crowdsec (improve_createAlerts_input)$ http POST localhost:8080/v1/alerts 'Authorization: Bearer eyJhbGciOiJI.....' < pkg/apiserver/tests/alert_sample.json 
HTTP/1.1 400 Bad Request
Content-Length: 66
Content-Type: application/json; charset=utf-8
Date: Tue, 01 Dec 2020 11:32:08 GMT

{
    "message": "'start_ip' must be lower than 'end_ip' in a decision"
}
```