### PR TITLE
fix & improve collections remove + improve cscli args vars

### DIFF
--- a/cmd/crowdsec-cli/collections.go
+++ b/cmd/crowdsec-cli/collections.go
@@ -74,8 +74,9 @@ func NewCollectionsCmd() *cobra.Command {
 					if !forceAction {
 						item := cwhub.GetItem(cwhub.COLLECTIONS, name)
 						if len(item.BelongsToCollections) > 0 {
-							log.Fatalf("%s belongs to other collections :\n%s\n", name, item.BelongsToCollections)
+							log.Warningf("%s belongs to other collections :\n%s\n", name, item.BelongsToCollections)
 							log.Printf("Run 'sudo cscli collections remove %s --force' if you want to force remove this sub collection\n", name)
+							continue
 						}
 					}
 					RemoveMany(cwhub.COLLECTIONS, name)

--- a/cmd/crowdsec-cli/collections.go
+++ b/cmd/crowdsec-cli/collections.go
@@ -74,9 +74,8 @@ func NewCollectionsCmd() *cobra.Command {
 					if !forceAction {
 						item := cwhub.GetItem(cwhub.COLLECTIONS, name)
 						if len(item.BelongsToCollections) > 0 {
-							log.Warningf("%s belongs to other collections :\n%s\n", name, item.BelongsToCollections)
+							log.Fatalf("%s belongs to other collections :\n%s\n", name, item.BelongsToCollections)
 							log.Printf("Run 'sudo cscli collections remove %s --force' if you want to force remove this sub collection\n", name)
-							continue
 						}
 					}
 					RemoveMany(cwhub.COLLECTIONS, name)
@@ -86,7 +85,7 @@ func NewCollectionsCmd() *cobra.Command {
 	}
 	cmdCollectionsRemove.PersistentFlags().BoolVar(&purge, "purge", false, "Delete source file too")
 	cmdCollectionsRemove.PersistentFlags().BoolVar(&forceAction, "force", false, "Force remove : Remove tainted and outdated files")
-	cmdCollectionsRemove.PersistentFlags().BoolVar(&all, "all", false, "Delete all the files in selected scope")
+	cmdCollectionsRemove.PersistentFlags().BoolVar(&all, "all", false, "Delete all the collections")
 	cmdCollections.AddCommand(cmdCollectionsRemove)
 
 	var cmdCollectionsUpgrade = &cobra.Command{

--- a/cmd/crowdsec-cli/hub.go
+++ b/cmd/crowdsec-cli/hub.go
@@ -56,7 +56,7 @@ cscli hub update # Download list of available configurations from the hub
 			ListItem(cwhub.PARSERS_OVFLW, args)
 		},
 	}
-	cmdHub.PersistentFlags().BoolVarP(&listAll, "all", "a", false, "List as well disabled items")
+	cmdHub.PersistentFlags().BoolVarP(&all, "all", "a", false, "List as well disabled items")
 	cmdHub.AddCommand(cmdHubList)
 
 	var cmdHubUpdate = &cobra.Command{

--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -20,12 +20,9 @@ var dbClient *database.Client
 var OutputFormat string
 
 var downloadOnly bool
-var forceInstall bool
-var forceUpgrade bool
-var removeAll bool
-var purgeRemove bool
-var upgradeAll bool
-var listAll bool
+var forceAction bool
+var purge bool
+var all bool
 var restoreOldBackup bool
 
 var prometheusURL string

--- a/cmd/crowdsec-cli/parsers.go
+++ b/cmd/crowdsec-cli/parsers.go
@@ -51,12 +51,12 @@ cscli parsers remove crowdsecurity/sshd-logs
 				log.Infoln("Run 'sudo cscli hub update' to get the hub index")
 			}
 			for _, name := range args {
-				InstallItem(name, cwhub.PARSERS, forceInstall)
+				InstallItem(name, cwhub.PARSERS, forceAction)
 			}
 		},
 	}
 	cmdParsersInstall.PersistentFlags().BoolVarP(&downloadOnly, "download-only", "d", false, "Only download packages, don't enable")
-	cmdParsersInstall.PersistentFlags().BoolVar(&forceInstall, "force", false, "Force install : Overwrite tainted and outdated files")
+	cmdParsersInstall.PersistentFlags().BoolVar(&forceAction, "force", false, "Force install : Overwrite tainted and outdated files")
 	cmdParsers.AddCommand(cmdParsersInstall)
 
 	var cmdParsersRemove = &cobra.Command{
@@ -71,7 +71,7 @@ cscli parsers remove crowdsecurity/sshd-logs
 				log.Infoln("Run 'sudo cscli hub update' to get the hub index")
 			}
 
-			if removeAll {
+			if all {
 				RemoveMany(cwhub.PARSERS, "")
 			} else {
 				for _, name := range args {
@@ -80,8 +80,8 @@ cscli parsers remove crowdsecurity/sshd-logs
 			}
 		},
 	}
-	cmdParsersRemove.PersistentFlags().BoolVar(&purgeRemove, "purge", false, "Delete source file too")
-	cmdParsersRemove.PersistentFlags().BoolVar(&removeAll, "all", false, "Delete all the parsers")
+	cmdParsersRemove.PersistentFlags().BoolVar(&purge, "purge", false, "Delete source file too")
+	cmdParsersRemove.PersistentFlags().BoolVar(&all, "all", false, "Delete all the parsers")
 	cmdParsers.AddCommand(cmdParsersRemove)
 
 	var cmdParsersUpgrade = &cobra.Command{
@@ -95,17 +95,17 @@ cscli parsers remove crowdsecurity/sshd-logs
 				log.Fatalf("Failed to get Hub index : %v", err)
 				log.Infoln("Run 'sudo cscli hub update' to get the hub index")
 			}
-			if upgradeAll {
-				UpgradeConfig(cwhub.PARSERS, "", forceUpgrade)
+			if all {
+				UpgradeConfig(cwhub.PARSERS, "", forceAction)
 			} else {
 				for _, name := range args {
-					UpgradeConfig(cwhub.PARSERS, name, forceUpgrade)
+					UpgradeConfig(cwhub.PARSERS, name, forceAction)
 				}
 			}
 		},
 	}
-	cmdParsersUpgrade.PersistentFlags().BoolVar(&upgradeAll, "all", false, "Upgrade all the parsers")
-	cmdParsersUpgrade.PersistentFlags().BoolVar(&forceUpgrade, "force", false, "Force install : Overwrite tainted and outdated files")
+	cmdParsersUpgrade.PersistentFlags().BoolVar(&all, "all", false, "Upgrade all the parsers")
+	cmdParsersUpgrade.PersistentFlags().BoolVar(&forceAction, "force", false, "Force install : Overwrite tainted and outdated files")
 	cmdParsers.AddCommand(cmdParsersUpgrade)
 
 	var cmdParsersInspect = &cobra.Command{
@@ -139,7 +139,7 @@ cscli parser list crowdsecurity/xxx`,
 			ListItem(cwhub.PARSERS, args)
 		},
 	}
-	cmdParsersList.PersistentFlags().BoolVarP(&listAll, "all", "a", false, "List as well disabled items")
+	cmdParsersList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List as well disabled items")
 	cmdParsers.AddCommand(cmdParsersList)
 
 	return cmdParsers

--- a/cmd/crowdsec-cli/parsers.go
+++ b/cmd/crowdsec-cli/parsers.go
@@ -81,6 +81,7 @@ cscli parsers remove crowdsecurity/sshd-logs
 		},
 	}
 	cmdParsersRemove.PersistentFlags().BoolVar(&purge, "purge", false, "Delete source file too")
+	cmdParsersRemove.PersistentFlags().BoolVar(&forceAction, "force", false, "Force remove : Remove tainted and outdated files")
 	cmdParsersRemove.PersistentFlags().BoolVar(&all, "all", false, "Delete all the parsers")
 	cmdParsers.AddCommand(cmdParsersRemove)
 

--- a/cmd/crowdsec-cli/parsers.go
+++ b/cmd/crowdsec-cli/parsers.go
@@ -105,7 +105,7 @@ cscli parsers remove crowdsecurity/sshd-logs
 		},
 	}
 	cmdParsersUpgrade.PersistentFlags().BoolVar(&all, "all", false, "Upgrade all the parsers")
-	cmdParsersUpgrade.PersistentFlags().BoolVar(&forceAction, "force", false, "Force install : Overwrite tainted and outdated files")
+	cmdParsersUpgrade.PersistentFlags().BoolVar(&forceAction, "force", false, "Force upgrade : Overwrite tainted and outdated files")
 	cmdParsers.AddCommand(cmdParsersUpgrade)
 
 	var cmdParsersInspect = &cobra.Command{

--- a/cmd/crowdsec-cli/postoverflows.go
+++ b/cmd/crowdsec-cli/postoverflows.go
@@ -50,12 +50,12 @@ func NewPostOverflowsCmd() *cobra.Command {
 				log.Infoln("Run 'sudo cscli hub update' to get the hub index")
 			}
 			for _, name := range args {
-				InstallItem(name, cwhub.PARSERS_OVFLW, forceInstall)
+				InstallItem(name, cwhub.PARSERS_OVFLW, forceAction)
 			}
 		},
 	}
 	cmdPostOverflowsInstall.PersistentFlags().BoolVarP(&downloadOnly, "download-only", "d", false, "Only download packages, don't enable")
-	cmdPostOverflowsInstall.PersistentFlags().BoolVar(&forceInstall, "force", false, "Force install : Overwrite tainted and outdated files")
+	cmdPostOverflowsInstall.PersistentFlags().BoolVar(&forceAction, "force", false, "Force install : Overwrite tainted and outdated files")
 	cmdPostOverflows.AddCommand(cmdPostOverflowsInstall)
 
 	var cmdPostOverflowsRemove = &cobra.Command{
@@ -70,7 +70,7 @@ func NewPostOverflowsCmd() *cobra.Command {
 				log.Infoln("Run 'sudo cscli hub update' to get the hub index")
 			}
 
-			if removeAll {
+			if all {
 				RemoveMany(cwhub.PARSERS_OVFLW, "")
 			} else {
 				for _, name := range args {
@@ -79,8 +79,8 @@ func NewPostOverflowsCmd() *cobra.Command {
 			}
 		},
 	}
-	cmdPostOverflowsRemove.PersistentFlags().BoolVar(&purgeRemove, "purge", false, "Delete source file in ~/.cscli/hub/ too")
-	cmdPostOverflowsRemove.PersistentFlags().BoolVar(&removeAll, "all", false, "Delete all the files in selected scope")
+	cmdPostOverflowsRemove.PersistentFlags().BoolVar(&purge, "purge", false, "Delete source file in ~/.cscli/hub/ too")
+	cmdPostOverflowsRemove.PersistentFlags().BoolVar(&all, "all", false, "Delete all the files in selected scope")
 	cmdPostOverflows.AddCommand(cmdPostOverflowsRemove)
 
 	var cmdPostOverflowsUpgrade = &cobra.Command{
@@ -94,17 +94,17 @@ func NewPostOverflowsCmd() *cobra.Command {
 				log.Fatalf("Failed to get Hub index : %v", err)
 				log.Infoln("Run 'sudo cscli hub update' to get the hub index")
 			}
-			if upgradeAll {
-				UpgradeConfig(cwhub.PARSERS_OVFLW, "", forceUpgrade)
+			if all {
+				UpgradeConfig(cwhub.PARSERS_OVFLW, "", forceAction)
 			} else {
 				for _, name := range args {
-					UpgradeConfig(cwhub.PARSERS_OVFLW, name, forceUpgrade)
+					UpgradeConfig(cwhub.PARSERS_OVFLW, name, forceAction)
 				}
 			}
 		},
 	}
-	cmdPostOverflowsUpgrade.PersistentFlags().BoolVarP(&upgradeAll, "download-only", "d", false, "Only download packages, don't enable")
-	cmdPostOverflowsUpgrade.PersistentFlags().BoolVar(&forceUpgrade, "force", false, "Force install : Overwrite tainted and outdated files")
+	cmdPostOverflowsUpgrade.PersistentFlags().BoolVarP(&all, "download-only", "d", false, "Only download packages, don't enable")
+	cmdPostOverflowsUpgrade.PersistentFlags().BoolVar(&forceAction, "force", false, "Force install : Overwrite tainted and outdated files")
 	cmdPostOverflows.AddCommand(cmdPostOverflowsUpgrade)
 
 	var cmdPostOverflowsInspect = &cobra.Command{
@@ -137,7 +137,7 @@ cscli postoverflows list crowdsecurity/xxx`,
 			ListItem(cwhub.PARSERS_OVFLW, args)
 		},
 	}
-	cmdPostOverflowsList.PersistentFlags().BoolVarP(&listAll, "all", "a", false, "List as well disabled items")
+	cmdPostOverflowsList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List as well disabled items")
 	cmdPostOverflows.AddCommand(cmdPostOverflowsList)
 
 	return cmdPostOverflows

--- a/cmd/crowdsec-cli/postoverflows.go
+++ b/cmd/crowdsec-cli/postoverflows.go
@@ -104,7 +104,7 @@ func NewPostOverflowsCmd() *cobra.Command {
 		},
 	}
 	cmdPostOverflowsUpgrade.PersistentFlags().BoolVarP(&all, "download-only", "d", false, "Only download packages, don't enable")
-	cmdPostOverflowsUpgrade.PersistentFlags().BoolVar(&forceAction, "force", false, "Force install : Overwrite tainted and outdated files")
+	cmdPostOverflowsUpgrade.PersistentFlags().BoolVar(&forceAction, "force", false, "Force upgrade : Overwrite tainted and outdated files")
 	cmdPostOverflows.AddCommand(cmdPostOverflowsUpgrade)
 
 	var cmdPostOverflowsInspect = &cobra.Command{

--- a/cmd/crowdsec-cli/postoverflows.go
+++ b/cmd/crowdsec-cli/postoverflows.go
@@ -79,8 +79,9 @@ func NewPostOverflowsCmd() *cobra.Command {
 			}
 		},
 	}
-	cmdPostOverflowsRemove.PersistentFlags().BoolVar(&purge, "purge", false, "Delete source file in ~/.cscli/hub/ too")
-	cmdPostOverflowsRemove.PersistentFlags().BoolVar(&all, "all", false, "Delete all the files in selected scope")
+	cmdPostOverflowsRemove.PersistentFlags().BoolVar(&purge, "purge", false, "Delete source file too")
+	cmdPostOverflowsRemove.PersistentFlags().BoolVar(&forceAction, "force", false, "Force remove : Remove tainted and outdated files")
+	cmdPostOverflowsRemove.PersistentFlags().BoolVar(&all, "all", false, "Delete all the postoverflows")
 	cmdPostOverflows.AddCommand(cmdPostOverflowsRemove)
 
 	var cmdPostOverflowsUpgrade = &cobra.Command{

--- a/cmd/crowdsec-cli/scenarios.go
+++ b/cmd/crowdsec-cli/scenarios.go
@@ -105,7 +105,7 @@ cscli scenarios remove crowdsecurity/ssh-bf
 		},
 	}
 	cmdScenariosUpgrade.PersistentFlags().BoolVarP(&all, "download-only", "d", false, "Only download packages, don't enable")
-	cmdScenariosUpgrade.PersistentFlags().BoolVar(&forceAction, "force", false, "Force install : Overwrite tainted and outdated files")
+	cmdScenariosUpgrade.PersistentFlags().BoolVar(&forceAction, "force", false, "Force upgrade : Overwrite tainted and outdated files")
 	cmdScenarios.AddCommand(cmdScenariosUpgrade)
 
 	var cmdScenariosInspect = &cobra.Command{

--- a/cmd/crowdsec-cli/scenarios.go
+++ b/cmd/crowdsec-cli/scenarios.go
@@ -51,12 +51,12 @@ cscli scenarios remove crowdsecurity/ssh-bf
 				log.Infoln("Run 'sudo cscli hub update' to get the hub index")
 			}
 			for _, name := range args {
-				InstallItem(name, cwhub.SCENARIOS, forceInstall)
+				InstallItem(name, cwhub.SCENARIOS, forceAction)
 			}
 		},
 	}
 	cmdScenariosInstall.PersistentFlags().BoolVarP(&downloadOnly, "download-only", "d", false, "Only download packages, don't enable")
-	cmdScenariosInstall.PersistentFlags().BoolVar(&forceInstall, "force", false, "Force install : Overwrite tainted and outdated files")
+	cmdScenariosInstall.PersistentFlags().BoolVar(&forceAction, "force", false, "Force install : Overwrite tainted and outdated files")
 	cmdScenarios.AddCommand(cmdScenariosInstall)
 
 	var cmdScenariosRemove = &cobra.Command{
@@ -71,7 +71,7 @@ cscli scenarios remove crowdsecurity/ssh-bf
 				log.Infoln("Run 'sudo cscli hub update' to get the hub index")
 			}
 
-			if removeAll {
+			if all {
 				RemoveMany(cwhub.SCENARIOS, "")
 			} else {
 				for _, name := range args {
@@ -80,8 +80,8 @@ cscli scenarios remove crowdsecurity/ssh-bf
 			}
 		},
 	}
-	cmdScenariosRemove.PersistentFlags().BoolVar(&purgeRemove, "purge", false, "Delete source file in ~/.cscli/hub/ too")
-	cmdScenariosRemove.PersistentFlags().BoolVar(&removeAll, "all", false, "Delete all the files in selected scope")
+	cmdScenariosRemove.PersistentFlags().BoolVar(&purge, "purge", false, "Delete source file in ~/.cscli/hub/ too")
+	cmdScenariosRemove.PersistentFlags().BoolVar(&all, "all", false, "Delete all the files in selected scope")
 	cmdScenarios.AddCommand(cmdScenariosRemove)
 
 	var cmdScenariosUpgrade = &cobra.Command{
@@ -95,17 +95,17 @@ cscli scenarios remove crowdsecurity/ssh-bf
 				log.Fatalf("Failed to get Hub index : %v", err)
 				log.Infoln("Run 'sudo cscli hub update' to get the hub index")
 			}
-			if upgradeAll {
-				UpgradeConfig(cwhub.SCENARIOS, "", forceUpgrade)
+			if all {
+				UpgradeConfig(cwhub.SCENARIOS, "", forceAction)
 			} else {
 				for _, name := range args {
-					UpgradeConfig(cwhub.SCENARIOS, name, forceUpgrade)
+					UpgradeConfig(cwhub.SCENARIOS, name, forceAction)
 				}
 			}
 		},
 	}
-	cmdScenariosUpgrade.PersistentFlags().BoolVarP(&upgradeAll, "download-only", "d", false, "Only download packages, don't enable")
-	cmdScenariosUpgrade.PersistentFlags().BoolVar(&forceUpgrade, "force", false, "Force install : Overwrite tainted and outdated files")
+	cmdScenariosUpgrade.PersistentFlags().BoolVarP(&all, "download-only", "d", false, "Only download packages, don't enable")
+	cmdScenariosUpgrade.PersistentFlags().BoolVar(&forceAction, "force", false, "Force install : Overwrite tainted and outdated files")
 	cmdScenarios.AddCommand(cmdScenariosUpgrade)
 
 	var cmdScenariosInspect = &cobra.Command{
@@ -139,7 +139,7 @@ cscli scenarios list crowdsecurity/xxx`,
 			ListItem(cwhub.SCENARIOS, args)
 		},
 	}
-	cmdScenariosList.PersistentFlags().BoolVarP(&listAll, "all", "a", false, "List as well disabled items")
+	cmdScenariosList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List as well disabled items")
 	cmdScenarios.AddCommand(cmdScenariosList)
 
 	return cmdScenarios

--- a/cmd/crowdsec-cli/scenarios.go
+++ b/cmd/crowdsec-cli/scenarios.go
@@ -80,8 +80,9 @@ cscli scenarios remove crowdsecurity/ssh-bf
 			}
 		},
 	}
-	cmdScenariosRemove.PersistentFlags().BoolVar(&purge, "purge", false, "Delete source file in ~/.cscli/hub/ too")
-	cmdScenariosRemove.PersistentFlags().BoolVar(&all, "all", false, "Delete all the files in selected scope")
+	cmdScenariosRemove.PersistentFlags().BoolVar(&purge, "purge", false, "Delete source file too")
+	cmdScenariosRemove.PersistentFlags().BoolVar(&forceAction, "force", false, "Force remove : Remove tainted and outdated files")
+	cmdScenariosRemove.PersistentFlags().BoolVar(&all, "all", false, "Delete all the scenarios")
 	cmdScenarios.AddCommand(cmdScenariosRemove)
 
 	var cmdScenariosUpgrade = &cobra.Command{

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -99,9 +99,9 @@ func ListItem(itemType string, args []string) {
 	var hubStatus []map[string]string
 
 	if len(args) == 1 {
-		hubStatus = cwhub.HubStatus(itemType, args[0], listAll)
+		hubStatus = cwhub.HubStatus(itemType, args[0], all)
 	} else {
-		hubStatus = cwhub.HubStatus(itemType, "", listAll)
+		hubStatus = cwhub.HubStatus(itemType, "", all)
 	}
 
 	if csConfig.Cscli.Output == "human" {
@@ -142,7 +142,7 @@ func InstallItem(name string, obtype string, force bool) {
 			return
 		}
 	}
-	item, err := cwhub.DownloadLatest(csConfig.Cscli, item, forceInstall)
+	item, err := cwhub.DownloadLatest(csConfig.Cscli, item, force)
 	if err != nil {
 		log.Fatalf("error while downloading %s : %v", item.Name, err)
 	}
@@ -169,15 +169,15 @@ func RemoveMany(itemType string, name string) {
 			log.Fatalf("unable to retrieve: %s", name)
 		}
 		item := *it
-		item, err = cwhub.DisableItem(csConfig.Cscli, item, purgeRemove)
+		item, err = cwhub.DisableItem(csConfig.Cscli, item, purge, forceAction)
 		if err != nil {
 			log.Fatalf("unable to disable %s : %v", item.Name, err)
 		}
 		cwhub.AddItem(itemType, item)
 		return
-	} else if name == "" && removeAll {
+	} else if name == "" && all {
 		for _, v := range cwhub.GetItemMap(itemType) {
-			v, err = cwhub.DisableItem(csConfig.Cscli, v, purgeRemove)
+			v, err = cwhub.DisableItem(csConfig.Cscli, v, purge, forceAction)
 			if err != nil {
 				log.Fatalf("unable to disable %s : %v", v.Name, err)
 			}
@@ -185,7 +185,7 @@ func RemoveMany(itemType string, name string) {
 			disabled++
 		}
 	}
-	if name != "" && !removeAll {
+	if name != "" && !all {
 		log.Errorf("%s not found", name)
 		return
 	}
@@ -220,7 +220,7 @@ func UpgradeConfig(itemType string, name string, force bool) {
 				continue
 			}
 		}
-		v, err = cwhub.DownloadLatest(csConfig.Cscli, v, forceUpgrade)
+		v, err = cwhub.DownloadLatest(csConfig.Cscli, v, force)
 		if err != nil {
 			log.Fatalf("%s : download failed : %v", v.Name, err)
 		}
@@ -487,7 +487,7 @@ func silenceInstallItem(name string, obtype string) (string, error) {
 	if downloadOnly && it.Downloaded && it.UpToDate {
 		return fmt.Sprintf("%s is already downloaded and up-to-date", it.Name), nil
 	}
-	it, err := cwhub.DownloadLatest(csConfig.Cscli, it, forceInstall)
+	it, err := cwhub.DownloadLatest(csConfig.Cscli, it, forceAction)
 	if err != nil {
 		return "", fmt.Errorf("error while downloading %s : %v", it.Name, err)
 	}

--- a/docs/v1.X/docs/cscli/cscli_collections_upgrade.md
+++ b/docs/v1.X/docs/cscli/cscli_collections_upgrade.md
@@ -20,7 +20,7 @@ cscli collections upgrade crowdsec/xxx crowdsec/xyz
 
 ```
   -d, --download-only   Only download packages, don't enable
-      --force           Force install : Overwrite tainted and outdated files
+      --force           Force upgrade : Overwrite tainted and outdated files
   -h, --help            help for upgrade
 ```
 

--- a/docs/v1.X/docs/cscli/cscli_parsers_upgrade.md
+++ b/docs/v1.X/docs/cscli/cscli_parsers_upgrade.md
@@ -20,7 +20,7 @@ cscli parsers upgrade crowdsec/xxx crowdsec/xyz
 
 ```
       --all     Upgrade all the parsers
-      --force   Force install : Overwrite tainted and outdated files
+      --force   Force upgrade : Overwrite tainted and outdated files
   -h, --help    help for upgrade
 ```
 

--- a/docs/v1.X/docs/cscli/cscli_postoverflows_upgrade.md
+++ b/docs/v1.X/docs/cscli/cscli_postoverflows_upgrade.md
@@ -20,7 +20,7 @@ cscli postoverflows upgrade crowdsec/xxx crowdsec/xyz
 
 ```
   -d, --download-only   Only download packages, don't enable
-      --force           Force install : Overwrite tainted and outdated files
+      --force           Force upgrade : Overwrite tainted and outdated files
   -h, --help            help for upgrade
 ```
 

--- a/pkg/cwhub/cwhub.go
+++ b/pkg/cwhub/cwhub.go
@@ -234,7 +234,7 @@ func GetUpstreamInstalledScenarios() ([]Item, error) {
 }
 
 //Returns a list of entries for packages : name, status, local_path, local_version, utf8_status (fancy)
-func HubStatus(itemType string, name string, listAll bool) []map[string]string {
+func HubStatus(itemType string, name string, all bool) []map[string]string {
 	if _, ok := hubIdx[itemType]; !ok {
 		log.Errorf("type %s doesn't exist", itemType)
 
@@ -249,7 +249,7 @@ func HubStatus(itemType string, name string, listAll bool) []map[string]string {
 			continue
 		}
 		//Only enabled items ?
-		if !listAll && !item.Installed {
+		if !all && !item.Installed {
 			continue
 		}
 		//Check the item status

--- a/pkg/cwhub/cwhub_test.go
+++ b/pkg/cwhub/cwhub_test.go
@@ -267,7 +267,7 @@ func testDisableItem(cfg *csconfig.CscliCfg, t *testing.T, item Item) {
 		t.Fatalf("disable: %s should be installed", item.Name)
 	}
 	//Remove
-	item, err := DisableItem(cfg, item, false)
+	item, err := DisableItem(cfg, item, false, false)
 	if err != nil {
 		t.Fatalf("failed to disable item : %v", err)
 	}
@@ -285,7 +285,7 @@ func testDisableItem(cfg *csconfig.CscliCfg, t *testing.T, item Item) {
 		t.Fatalf("disable: %s should still be downloaded", item.Name)
 	}
 	//Purge
-	item, err = DisableItem(cfg, item, true)
+	item, err = DisableItem(cfg, item, true, false)
 	if err != nil {
 		t.Fatalf("failed to purge item : %v", err)
 	}


### PR DESCRIPTION
* can't remove sub collection unless it's forced (`--force`)
* can't remove tainted collection unless it's forced
* cscli args variables improvment

### Output 
```
/ # cscli collections list
---------------------------------------------------------------------------------
 NAME                 📦 STATUS    VERSION  LOCAL PATH                           
---------------------------------------------------------------------------------
 crowdsecurity/linux  ✔️  enabled  0.2      /etc/crowdsec/collections/linux.yaml 
 crowdsecurity/sshd   ✔️  enabled  0.1      /etc/crowdsec/collections/sshd.yaml  
---------------------------------------------------------------------------------
/ # cscli collections install crowdsecurity/nginx                 
..... 
INFO[0005] Enabled crowdsecurity/nginx                  
INFO[0005] Run 'sudo systemctl reload crowdsec' for the new configuration to be effective. 
/ # cscli collections list
-------------------------------------------------------------------------------------------------------------
 NAME                               📦 STATUS    VERSION  LOCAL PATH                                         
-------------------------------------------------------------------------------------------------------------
 crowdsecurity/nginx                ✔️  enabled  0.1      /etc/crowdsec/collections/nginx.yaml               
 crowdsecurity/sshd                 ✔️  enabled  0.1      /etc/crowdsec/collections/sshd.yaml                
 crowdsecurity/base-http-scenarios  ✔️  enabled  0.1      /etc/crowdsec/collections/base-http-scenarios.yaml 
 crowdsecurity/linux                ✔️  enabled  0.2      /etc/crowdsec/collections/linux.yaml               
-------------------------------------------------------------------------------------------------------------
/ # cscli collections remove crowdsecurity/base-http-scenarios
WARN[0000] crowdsecurity/base-http-scenarios belongs to other collections :
[crowdsecurity/nginx] 
INFO[0000] Run 'sudo cscli collections remove crowdsecurity/base-http-scenarios --force' if you want to force remove this sub collection 
INFO[0000] Run 'sudo systemctl reload crowdsec' for the new configuration to be effective. 
/ # cscli collections remove crowdsecurity/base-http-scenarios --force
INFO[0000] Removed symlink [crowdsecurity/http-logs] : /etc/crowdsec/parsers/s02-enrich/http-logs.yaml 
..........
INFO[0000] Run 'sudo systemctl reload crowdsec' for the new configuration to be effective. 
/ # cscli collections list
INFO[0000] dependency issue crowdsecurity/nginx : missing collections crowdsecurity/base-http-scenarios, tainted. 
INFO[0000] dependency issue crowdsecurity/nginx : missing collections crowdsecurity/base-http-scenarios, tainted. 
-----------------------------------------------------------------------------------------
 NAME                 📦 STATUS            VERSION  LOCAL PATH                           
-----------------------------------------------------------------------------------------
 crowdsecurity/linux  ✔️  enabled          0.2      /etc/crowdsec/collections/linux.yaml 
 crowdsecurity/nginx  ⚠️  enabled,tainted  0.1      /etc/crowdsec/collections/nginx.yaml 
 crowdsecurity/sshd   ✔️  enabled          0.1      /etc/crowdsec/collections/sshd.yaml  
-----------------------------------------------------------------------------------------
/ # cscli collections remove crowdsecurity/nginx
INFO[0000] dependency issue crowdsecurity/nginx : missing collections crowdsecurity/base-http-scenarios, tainted. 
INFO[0000] dependency issue crowdsecurity/nginx : missing collections crowdsecurity/base-http-scenarios, tainted. 
INFO[0000] Removed symlink [crowdsecurity/nginx-logs] : /etc/crowdsec/parsers/s01-parse/nginx-logs.yaml 
FATA[0000] unable to disable crowdsecurity/nginx : while disabling crowdsecurity/base-http-scenarios: while disabling crowdsecurity/http-logs: crowdsecurity/http-logs is tainted, won't remove unless --force 
/ # cscli collections remove crowdsecurity/nginx --force
INFO[0000] dependency issue crowdsecurity/nginx : missing parsers crowdsecurity/nginx-logs, tainted. 
INFO[0000] dependency issue crowdsecurity/nginx : missing parsers crowdsecurity/nginx-logs, tainted. 
INFO[0000] Removed symlink [crowdsecurity/nginx] : /etc/crowdsec/collections/nginx.yaml 
INFO[0000] Run 'sudo systemctl reload crowdsec' for the new configuration to be effective. 
/ # cscli collections list
---------------------------------------------------------------------------------
 NAME                 📦 STATUS    VERSION  LOCAL PATH                           
---------------------------------------------------------------------------------
 crowdsecurity/linux  ✔️  enabled  0.2      /etc/crowdsec/collections/linux.yaml 
 crowdsecurity/sshd   ✔️  enabled  0.1      /etc/crowdsec/collections/sshd.yaml  
---------------------------------------------------------------------------------
```