### PR TITLE
deal with LAPI down : ensure client will reauthenticate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ clean:
 	@rm -f $(CSCLI_BIN)
 	@rm -f *.log
 	@rm crowdsec-release.tgz
-	@rm -rf crowdsec-v*
 
 cscli:
 ifeq ($(lastword $(RESPECT_VERSION)), $(CURRENT_GOVERSION))

--- a/cmd/crowdsec/output.go
+++ b/cmd/crowdsec/output.go
@@ -110,6 +110,10 @@ LOOP:
 				cacheMutex.Unlock()
 				if err := PushAlerts(cachecopy, Client); err != nil {
 					log.Errorf("while pushing to api : %s", err)
+					//just push back the events to the queue
+					cacheMutex.Lock()
+					cache = append(cache, cachecopy...)
+					cacheMutex.Unlock()
 				}
 			}
 		case <-outputsTomb.Dying():

--- a/pkg/apiclient/auth.go
+++ b/pkg/apiclient/auth.go
@@ -192,6 +192,8 @@ func (t *JWTTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		log.Tracef("resp-jwt: %s", string(dump))
 	}
 	if err != nil {
+		/*we had an error, reset the token ?*/
+		t.token = ""
 		return resp, errors.Wrapf(err, "performing jwt auth")
 	}
 	log.Debugf("resp-jwt: %d", resp.StatusCode)

--- a/pkg/apiclient/auth.go
+++ b/pkg/apiclient/auth.go
@@ -97,7 +97,7 @@ func (t *JWTTransport) refreshJwtToken() error {
 		if err != nil {
 			return fmt.Errorf("can't update scenario list: %s", err)
 		}
-		log.Infof("scenarios list updated for '%s'", *t.MachineID)
+		log.Debugf("scenarios list updated for '%s'", *t.MachineID)
 	}
 
 	var auth = models.WatcherAuthRequest{

--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -301,11 +301,15 @@ func (a *apic) Pull() error {
 	var err error
 
 	scenario := a.scenarioList
+	told_once := false
 	for {
 		if len(scenario) > 0 {
 			break
 		}
-		log.Warningf("scenario list is empty, will not pull yet")
+		if !told_once {
+			log.Warningf("scenario list is empty, will not pull yet")
+			told_once = true
+		}
 		time.Sleep(1 * time.Second)
 		scenario, err = a.FetchScenariosListFromDB()
 		if err != nil {

--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -301,14 +301,14 @@ func (a *apic) Pull() error {
 	var err error
 
 	scenario := a.scenarioList
-	told_once := false
+	toldOnce := false
 	for {
 		if len(scenario) > 0 {
 			break
 		}
-		if !told_once {
+		if !toldOnce {
 			log.Warningf("scenario list is empty, will not pull yet")
-			told_once = true
+			toldOnce = true
 		}
 		time.Sleep(1 * time.Second)
 		scenario, err = a.FetchScenariosListFromDB()


### PR DESCRIPTION
 - when facing an error while pushing to LAPI, reset the token (at jwt middleware) to ensure that we re-authenticate when LAPI becomes available again
 - when facing an error while pushing to LAPI, re-queue the events to be pushed once LAPI becomes available again
 - lower verbosity of some messages

