### PR TITLE
control pushed signals

### DIFF
--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -165,6 +165,14 @@ func (a *apic) Push() error {
 		case alerts := <-a.alertToPush:
 			var signals []*models.AddSignalsRequestItem
 			for _, alert := range alerts {
+				/*we're only interested into decisions coming from scenarios of the hub*/
+				if alert.ScenarioHash == nil || *alert.ScenarioHash == "" {
+					continue
+				}
+				/*and we're not interested into tainted scenarios neither*/
+				if alert.ScenarioVersion == nil || *alert.ScenarioVersion == "" || *alert.ScenarioVersion == "?" {
+					continue
+				}
 				signals = append(signals, AlertToSignal(alert))
 			}
 			a.mu.Lock()


### PR DESCRIPTION
ensure decisions from local or tainted scenarios aren't push, neither are manual decisions