### PR TITLE
gin: broken pipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ clean:
 	@rm -f $(CROWDSEC_BIN)
 	@rm -f $(CSCLI_BIN)
 	@rm -f *.log
-	@rm crowdsec-release.tgz
+	@rm -f crowdsec-release.tgz
 
 cscli:
 ifeq ($(lastword $(RESPECT_VERSION)), $(CURRENT_GOVERSION))


### PR DESCRIPTION
Following https://github.com/crowdsecurity/crowdsec/issues/532 :

[Gin handles broken pipe errors in a specific way](https://github.com/gin-gonic/gin/pull/1259), while we didn't, because we are putting our own deferred panic handler. This MR attempts to mimic gin's default panic handler behaviour when this happens.

ps: I was not able to reproduce the bug, nor was the user

