### PR TITLE
Sanitize id from either source

### DIFF
--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -71,9 +71,9 @@ func generateID() (string, error) {
 			return "", errors.Wrap(err, "generating machine id")
 		}
 		id = string(bID)
-		id = strings.ReplaceAll(id, "-", "")[:32]
 	}
 	id = fmt.Sprintf("%s%s", id, generatePassword(16))
+	id = strings.ReplaceAll(id, "-", "")[:32]
 	return id, nil
 }
 


### PR DESCRIPTION
On FreeBSD the uuid has dashes. So moved line 74 outside the if loop to have it sanitize either id source of dashes.