### PR TITLE
PostgreSQL connection with 'sslmode=disable'

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -40,7 +40,7 @@ func NewClient(config *csconfig.DatabaseCfg) (*Client, error) {
 			return &Client{}, fmt.Errorf("failed opening connection to mysql: %v", err)
 		}
 	case "postgres", "postgresql":
-		client, err = ent.Open("postgres", fmt.Sprintf("host=%s port=%d user=%s dbname=%s password=%s", config.Host, config.Port, config.User, config.DbName, config.Password))
+		client, err = ent.Open("postgres", fmt.Sprintf("host=%s port=%d user=%s dbname=%s password=%s sslmode=disable", config.Host, config.Port, config.User, config.DbName, config.Password))
 		if err != nil {
 			return &Client{}, fmt.Errorf("failed opening connection to postgres: %v", err)
 		}


### PR DESCRIPTION
Most of the time you have PostgreSQL on the same device so using SSL on 127.0.0.1 connection is redundant, still hardcoding this to disabled pretty bad :|