### PR TITLE
improve systemd file

### DIFF
--- a/config/crowdsec.service
+++ b/config/crowdsec.service
@@ -1,6 +1,7 @@
 [Unit]
-Description=Crowdsec agent
+Description=Crowdsec agent. Log are stored in /var/log/crowdsec.log
 After=syslog.target network.target remote-fs.target nss-lookup.target
+Documentation=https://docs.crowdsec.net/
 
 [Service]
 Type=notify

--- a/config/crowdsec.service
+++ b/config/crowdsec.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Crowdsec agent. Log are stored in /var/log/crowdsec.log
+Description=Crowdsec agent. Logs are stored in /var/log/crowdsec.log
 After=syslog.target network.target remote-fs.target nss-lookup.target
 Documentation=https://docs.crowdsec.net/
 


### PR DESCRIPTION
Now it looks like:

(I don't know if its a good idea to write the `Logs are stored in /var/log/crowdsec.log`  in the description, but i didn't know where to write it to have it in the `systemctl status crowdsec`)

```
● crowdsec.service - Crowdsec agent. Logs are stored in /var/log/crowdsec.log
     Loaded: loaded (/etc/systemd/system/crowdsec.service; enabled; vendor preset: enabled)
     Active: active (running) since Sun 2021-01-17 15:39:25 CET; 5s ago
       Docs: https://docs.crowdsec.net/
    Process: 10812 ExecStartPre=/usr/local/bin/crowdsec -c /etc/crowdsec/config.yaml -t (code=exited, status=0/SUCCESS)
   Main PID: 10842 (crowdsec)
      Tasks: 16 (limit: 18910)
     Memory: 26.8M
     CGroup: /system.slice/crowdsec.service
             └─10842 /usr/local/bin/crowdsec -c /etc/crowdsec/config.yaml

Jan 17 15:39:24 sh systemd[1]: Starting Crowdsec agent. Log are stored in /var/log/crowdsec.log...
Jan 17 15:39:25 sh systemd[1]: Started Crowdsec agent. Log are stored in /var/log/crowdsec.log.
Jan 17 15:39:25 sh crowdsec[10842]: 127.0.0.1 - [Sun, 17 Jan 2021 15:39:25 CET] "POST /v1/watchers/login HTTP/1.1 200 77.61458ms "crowdsec/v1.0.3-8cff513fae78afb0c270ca25998e370dbe6f0e66" "
Jan 17 15:39:25 sh crowdsec[10842]: 127.0.0.1 - [Sun, 17 Jan 2021 15:39:25 CET] "POST /v1/watchers/login HTTP/1.1 200 66.04903ms "crowdsec/v1.0.3-8cff513fae78afb0c270ca25998e370dbe6f0e66" "

```