### PR TITLE
Fix typo in apic.go logs

### DIFF
--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -260,7 +260,7 @@ func (a *apic) PullTop() error {
 	alertCreated, err := a.dbClient.Ent.Alert.
 		Create().
 		SetScenario(fmt.Sprintf("update : +%d/-%d IPs", len(data.New), len(data.Deleted))).
-		SetSourceScope("Comunity blocklist").
+		SetSourceScope("Community blocklist").
 		Save(a.dbClient.CTX)
 	if err != nil {
 		return errors.Wrap(err, "create alert from crowdsec-api")


### PR DESCRIPTION
This fixes the weird entries in  `cscli alerts list` .