### PR TITLE
[wip/dead] Local config dir support

### DIFF
--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -201,6 +201,10 @@ func UpgradeConfig(itemType string, name string, force bool) {
 		if name != "" && name != v.Name {
 			continue
 		}
+		if v.LocalHub {
+			log.Infof("%v %s is local", emoji.Prohibited, v.Name)
+			continue
+		}
 		if !v.Installed {
 			log.Tracef("skip %s, not installed", v.Name)
 			if !force {

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -629,8 +629,10 @@ func BackupHub(dirPath string) error {
 					continue
 				}
 
-				//for the local/tainted ones, we backup the full file
-				if v.Tainted || v.Local || !v.UpToDate {
+				if v.LocalHub { //don't interact with local hub
+					clog.Debugf("[%s] : in local hub, skip", k)
+					continue
+				} else if v.Tainted || v.Local || !v.UpToDate { //for the local/tainted ones, we backup the full file
 					//we need to backup stages for parsers
 					if itemType == cwhub.PARSERS || itemType == cwhub.PARSERS_OVFLW {
 						fstagedir := fmt.Sprintf("%s%s", itemDirectory, v.Stage)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,6 +10,7 @@ config_paths:
   data_dir: /var/lib/crowdsec/data/
   simulation_path: /etc/crowdsec/simulation.yaml
   hub_dir: /etc/crowdsec/hub/
+  #local_hub_dir: /tmp/myhub
   index_path: /etc/crowdsec/hub/.index.json
 crowdsec_service:
   acquisition_path: /etc/crowdsec/acquis.yaml

--- a/pkg/csconfig/config.go
+++ b/pkg/csconfig/config.go
@@ -107,6 +107,7 @@ func (c *GlobalConfig) LoadConfiguration() error {
 		c.Cscli.ConfigDir = c.ConfigPaths.ConfigDir
 		c.Cscli.DataDir = c.ConfigPaths.DataDir
 		c.Cscli.HubDir = c.ConfigPaths.HubDir
+		c.Cscli.LocalHubDir = c.ConfigPaths.LocalHubDir
 		c.Cscli.HubIndexFile = c.ConfigPaths.HubIndexFile
 	}
 

--- a/pkg/csconfig/config_paths.go
+++ b/pkg/csconfig/config_paths.go
@@ -6,4 +6,5 @@ type ConfigurationPaths struct {
 	SimulationFilePath string `yaml:"simulation_path,omitempty"`
 	HubIndexFile       string `yaml:"index_path,omitempty"` //path of the .index.json
 	HubDir             string `yaml:"hub_dir,omitempty"`
+	LocalHubDir        string `yaml:"local_hub_dir,omitempty"`
 }

--- a/pkg/csconfig/cscli.go
+++ b/pkg/csconfig/cscli.go
@@ -7,6 +7,7 @@ type CscliCfg struct {
 	SimulationConfig   *SimulationConfig `yaml:"-"`
 	DbConfig           *DatabaseCfg      `yaml:"-"`
 	HubDir             string            `yaml:"-"`
+	LocalHubDir        string            `yaml:"-"`
 	DataDir            string            `yaml:"-"`
 	ConfigDir          string            `yaml:"-"`
 	HubIndexFile       string            `yaml:"-"`

--- a/pkg/cwhub/cwhub.go
+++ b/pkg/cwhub/cwhub.go
@@ -54,15 +54,19 @@ type Item struct {
 	Versions   map[string]ItemVersion `json:"versions" yaml:"-"`                 //the list of existing versions
 
 	/*local (deployed) infos*/
-	LocalPath string `yaml:"local_path,omitempty"` //the local path relative to ${CFG_DIR}
-	//LocalHubPath string
+	LocalPath    string `yaml:"local_path,omitempty"` //the local path relative to ${CFG_DIR}
 	LocalVersion string
 	LocalHash    string //the local meow
 	Installed    bool
 	Downloaded   bool
 	UpToDate     bool
 	Tainted      bool //has it been locally modified
-	Local        bool //if it's a non versioned control one
+	/*user can have its own local files in the installation directory,
+		and they are dealt with during config save/restore (upgrade process)
+	 people suggested (https://github.com/crowdsecurity/crowdsec/issues/334)
+	 	having unmanaged directory, which makes sense. */
+	Local    bool //if it's a non versioned control one
+	LocalHub bool //if the file is in user's local hub
 
 	/*if it's a collection, it not a single file*/
 	Parsers       []string `yaml:"parsers,omitempty"`
@@ -260,8 +264,10 @@ func HubStatus(itemType string, name string, all bool) []map[string]string {
 		tmp["local_version"] = item.LocalVersion
 		tmp["local_path"] = item.LocalPath
 		tmp["description"] = item.Description
-		if !managed || !item.Installed {
+		if !item.Installed {
 			tmp["utf8_status"] = fmt.Sprintf("%v  %s", emoji.Prohibited, status)
+		} else if !managed {
+			tmp["utf8_status"] = fmt.Sprintf("%v  %s", emoji.ComputerDisk, status)
 		} else if warning {
 			tmp["utf8_status"] = fmt.Sprintf("%v  %s", emoji.Warning, status)
 		} else if ok {

--- a/pkg/cwhub/loader.go
+++ b/pkg/cwhub/loader.go
@@ -20,7 +20,7 @@ import (
 )
 
 /*the walk/parser_visit function can't receive extra args*/
-var hubdir, installdir, indexpath string
+var hubdir, localhubdir, installdir, indexpath string
 
 func parser_visit(path string, f os.FileInfo, err error) error {
 
@@ -72,6 +72,20 @@ func parser_visit(path string, f os.FileInfo, err error) error {
 		///.../config/postoverflow/stage/file.yaml
 		///.../config/scenarios/scenar.yaml
 		///.../config/collections/linux.yaml //file is empty
+		fname = subs[len(subs)-1]
+		stage = subs[len(subs)-2]
+		ftype = subs[len(subs)-3]
+		fauthor = ""
+	} else if strings.HasPrefix(path, localhubdir) { /*we're in user local/unmanaged hub, read-only for us*/
+		log.Tracef("in localhub dir")
+		target.LocalHub = true
+		if len(subs) < 3 {
+			log.Fatalf("path is too short : %s (%d)", path, len(subs))
+		}
+		///.../localhub/parser/stage/file.yaml
+		///.../localhub/postoverflow/stage/file.yaml
+		///.../localhub/scenarios/scenar.yaml
+		///.../localhub/collections/linux.yaml //file is empty
 		fname = subs[len(subs)-1]
 		stage = subs[len(subs)-2]
 		ftype = subs[len(subs)-3]
@@ -296,6 +310,7 @@ func CollecDepsCheck(v *Item) error {
 
 func SyncDir(cscli *csconfig.CscliCfg, dir string) error {
 	hubdir = cscli.HubDir
+	localhubdir = cscli.LocalHubDir
 	installdir = cscli.ConfigDir
 	indexpath = cscli.HubIndexFile
 
@@ -326,7 +341,7 @@ func LocalSync(cscli *csconfig.CscliCfg) error {
 	skippedLocal = 0
 	skippedTainted = 0
 
-	for _, dir := range []string{cscli.ConfigDir, cscli.HubDir} {
+	for _, dir := range []string{cscli.ConfigDir, cscli.HubDir, cscli.LocalHubDir} {
 		log.Debugf("scanning %s", dir)
 		if err := SyncDir(cscli, dir); err != nil {
 			return fmt.Errorf("failed to scan %s : %s", dir, err)


### PR DESCRIPTION
cf. https://github.com/crowdsecurity/crowdsec/issues/334 

Add a `local_hub_dir` directive pointing to a directory managed by user.  This directory has the same layout as `/etc/crowdsec/` and allows to have local parsers/scenarios etc that `cscli` won't try to mess with.

 - [ ] Update documentation
 - [ ] find a better name for `local_hub_dir` 