### PR TITLE
Install core collection by default. 

### DIFF
--- a/wizard.sh
+++ b/wizard.sh
@@ -234,6 +234,11 @@ install_collection() {
         fi;
     fi;
 
+    in_array "crowdsecurity/core" "${COLLECTION_TO_INSTALL[@]}"
+    if [[ $? -ne 0 ]]; then
+        COLLECTION_TO_INSTALL+=("crowdsecurity/core")
+    fi;
+
     for collection in "${COLLECTION_TO_INSTALL[@]}"; do
         log_info "Installing collection '${collection}'"
         ${CSCLI_BIN_INSTALLED} collections install "${collection}" > /dev/null 2>&1 || log_err "fail to install collection ${collection}"


### PR DESCRIPTION
This fixes https://github.com/crowdsecurity/crowdsec/issues/106

To fix this, we need to  do the following :- 

- [x] Add a `core` collection . See https://github.com/crowdsecurity/hub/pull/151 
- [x] Make the wizard always install this collection. 
- [ ] Have checks at crowdsec, to spit warning if this collection is not installed . 
