### PR TITLE
allow environment variable in configuration file

### DIFF
--- a/docs/v1.X/docs/references/crowdsec-config.md
+++ b/docs/v1.X/docs/references/crowdsec-config.md
@@ -4,10 +4,6 @@
 
 ## Configuration example
 
-!!! tips "Environement variables"
-    You can set a configuration value based on an enrivonement variables
-
-    **Note**: you need to be `root` or put the environment variable in `/etc/environement`
 
 <details>
   <summary>Default configuration</summary>
@@ -68,6 +64,30 @@ prometheus:
 
 </details>
 
+## Environment variable
+
+It is possible to set a configuration value based on an enrivonement variables.
+
+For example, if you don't want to store your database password in the configuration file, you can do this:
+
+```yaml
+db_config:
+  type:     mysql
+  user:     database_user
+  password: ${DB_PASSWORD}  
+  db_name:  db_name
+  host:     192.168.0.2   
+  port:     3306 
+```
+
+And export the environment variable such as:
+
+```bash
+export DB_PASSWORD="<db_password>"
+```
+
+!!! warning 
+    **Note**: you need to be `root` or put the environment variable in `/etc/environement`
 
 ## Configuration format
 

--- a/docs/v1.X/docs/references/crowdsec-config.md
+++ b/docs/v1.X/docs/references/crowdsec-config.md
@@ -4,6 +4,11 @@
 
 ## Configuration example
 
+!!! tips "Environement variables"
+    You can set a configuration value based on an enrivonement variables
+
+    **Note**: you need to be `root` or put the environment variable in `/etc/environement`
+
 <details>
   <summary>Default configuration</summary>
 

--- a/pkg/csconfig/config.go
+++ b/pkg/csconfig/config.go
@@ -3,6 +3,7 @@ package csconfig
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -40,7 +41,8 @@ func (c *GlobalConfig) LoadConfigurationFile(path string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to read config file")
 	}
-	err = yaml.UnmarshalStrict(fcontent, c)
+	configData := os.ExpandEnv(string(fcontent))
+	err = yaml.UnmarshalStrict([]byte(configData), c)
 	if err != nil {
 		return errors.Wrap(err, "failed unmarshaling config")
 	}


### PR DESCRIPTION
Note: you need to be `root` when exporting the environment variable or write it in `/etc/environement` since crowdsec run as root.