### PR TITLE
Add use_forwarded_for_headers configuration option for LAPI

### DIFF
--- a/docs/v1.X/docs/references/crowdsec-config.md
+++ b/docs/v1.X/docs/references/crowdsec-config.md
@@ -50,6 +50,7 @@ api:
     log_level: info
     listen_uri: 127.0.0.1:8080
     profiles_path: /etc/crowdsec/profiles.yaml
+    use_forwarded_for_headers: false
     online_client: # Crowdsec API
       credentials_path: /etc/crowdsec/online_api_credentials.yaml
 #    tls:
@@ -132,6 +133,7 @@ api:
     log_level: (error|info|debug|trace>)
     listen_uri: <listen_uri> # host:port
     profiles_path: <path_to_profile_file>
+    use_forwarded_for_headers: <true|false>
     online_client:
       credentials_path: <path_to_crowdsec_api_client_credential_file>
     tls:
@@ -304,6 +306,7 @@ api:
     log_level: (error|info|debug|trace>)
     listen_uri: <listen_uri> # host:port
     profiles_path: <path_to_profile_file>
+    use_forwarded_for_headers: (true|false)
     online_client:
       credentials_path: <path_to_crowdsec_api_client_credential_file>
     tls:
@@ -340,6 +343,7 @@ server:
   log_level: (error|info|debug|trace)
   listen_uri: <listen_uri> # host:port
   profiles_path: <path_to_profile_file>
+  use_forwarded_for_headers: (true|false)
   online_client:
     credentials_path: <path_to_crowdsec_api_client_credential_file>
   tls:
@@ -356,6 +360,11 @@ Address and port listen configuration, the form `host:port`.
 > string
 
 The path to the {{v1X.profiles.htmlname}} configuration.
+
+#### `use_forwarded_for_headers`
+> string
+
+Allow the usage of `X-Forwarded-For` or `X-Real-IP` to get the client IP address. Do not enable if you are not running the LAPI behind a trusted reverse-proxy or LB.
 
 #### `online_client`
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -61,6 +61,12 @@ func NewServer(config *csconfig.LocalApiServerCfg) (*APIServer, error) {
 	}
 	log.Debugf("starting router, logging to %s", logFile)
 	router := gin.New()
+	/* See https://github.com/gin-gonic/gin/pull/2474:
+	Gin does not handle safely X-Forwarded-For or X-Real-IP.
+	We do not trust them by default, but the user can opt-in
+	if they host LAPI behind a trusted proxy which sanitize
+	X-Forwarded-For and X-Real-IP.
+	*/
 	router.ForwardedByClientIP = config.UseForwardedForHeaders
 
 	/*The logger that will be used by handlers*/

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -61,10 +61,7 @@ func NewServer(config *csconfig.LocalApiServerCfg) (*APIServer, error) {
 	}
 	log.Debugf("starting router, logging to %s", logFile)
 	router := gin.New()
-	/*related to https://github.com/gin-gonic/gin/pull/2474
-	Gin team doesn't seem to be willing to have a opt-in/opt-out on the trusted proxies.
-	For now, let's not trust that. 	*/
-	router.ForwardedByClientIP = false
+	router.ForwardedByClientIP = config.UseForwardedForHeaders
 
 	/*The logger that will be used by handlers*/
 	clog := log.New()

--- a/pkg/apiserver/machines_test.go
+++ b/pkg/apiserver/machines_test.go
@@ -52,6 +52,96 @@ func TestCreateMachine(t *testing.T) {
 
 }
 
+func TestCreateMachineWithForwardedFor(t *testing.T) {
+	router, err := NewAPITestForwardedFor()
+	if err != nil {
+		log.Fatalf("unable to run local API: %s", err)
+	}
+
+	// Create machine
+	b, err := json.Marshal(MachineTest)
+	if err != nil {
+		log.Fatalf("unable to marshal MachineTest")
+	}
+	body := string(b)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/watchers", strings.NewReader(body))
+	req.Header.Add("User-Agent", UserAgent)
+	req.Header.Add("X-Real-IP", "1.1.1.1")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 201, w.Code)
+	assert.Equal(t, "", w.Body.String())
+
+	ip, err := GetMachineIP(*MachineTest.MachineID)
+	if err != nil {
+		log.Fatalf("Could not get machine IP : %s", err)
+	}
+	assert.Equal(t, "1.1.1.1", ip)
+}
+
+func TestCreateMachineWithForwardedForNoConfig(t *testing.T) {
+	router, err := NewAPITest()
+	if err != nil {
+		log.Fatalf("unable to run local API: %s", err)
+	}
+
+	// Create machine
+	b, err := json.Marshal(MachineTest)
+	if err != nil {
+		log.Fatalf("unable to marshal MachineTest")
+	}
+	body := string(b)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/watchers", strings.NewReader(body))
+	req.Header.Add("User-Agent", UserAgent)
+	req.Header.Add("X-Real-IP", "1.1.1.1")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 201, w.Code)
+	assert.Equal(t, "", w.Body.String())
+
+	ip, err := GetMachineIP(*MachineTest.MachineID)
+	if err != nil {
+		log.Fatalf("Could not get machine IP : %s", err)
+	}
+	//For some reason, the IP is empty when running tests
+	//if no forwarded-for headers are present
+	assert.Equal(t, "", ip)
+}
+
+func TestCreateMachineWithoutForwardedFor(t *testing.T) {
+	router, err := NewAPITestForwardedFor()
+	if err != nil {
+		log.Fatalf("unable to run local API: %s", err)
+	}
+
+	// Create machine
+	b, err := json.Marshal(MachineTest)
+	if err != nil {
+		log.Fatalf("unable to marshal MachineTest")
+	}
+	body := string(b)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/watchers", strings.NewReader(body))
+	req.Header.Add("User-Agent", UserAgent)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 201, w.Code)
+	assert.Equal(t, "", w.Body.String())
+
+	ip, err := GetMachineIP(*MachineTest.MachineID)
+	if err != nil {
+		log.Fatalf("Could not get machine IP : %s", err)
+	}
+	//For some reason, the IP is empty when running tests
+	//if no forwarded-for headers are present
+	assert.Equal(t, "", ip)
+}
+
 func TestCreateMachineAlreadyExist(t *testing.T) {
 	router, err := NewAPITest()
 	if err != nil {

--- a/pkg/csconfig/api.go
+++ b/pkg/csconfig/api.go
@@ -28,14 +28,15 @@ type LocalApiClientCfg struct {
 
 /*local api service configuration*/
 type LocalApiServerCfg struct {
-	ListenURI    string              `yaml:"listen_uri,omitempty"` //127.0.0.1:8080
-	TLS          *TLSCfg             `yaml:"tls"`
-	DbConfig     *DatabaseCfg        `yaml:"-"`
-	LogDir       string              `yaml:"-"`
-	OnlineClient *OnlineApiClientCfg `yaml:"online_client"`
-	ProfilesPath string              `yaml:"profiles_path,omitempty"`
-	Profiles     []*ProfileCfg       `yaml:"-"`
-	LogLevel     *log.Level          `yaml:"log_level"`
+	ListenURI              string              `yaml:"listen_uri,omitempty"` //127.0.0.1:8080
+	TLS                    *TLSCfg             `yaml:"tls"`
+	DbConfig               *DatabaseCfg        `yaml:"-"`
+	LogDir                 string              `yaml:"-"`
+	OnlineClient           *OnlineApiClientCfg `yaml:"online_client"`
+	ProfilesPath           string              `yaml:"profiles_path,omitempty"`
+	Profiles               []*ProfileCfg       `yaml:"-"`
+	LogLevel               *log.Level          `yaml:"log_level"`
+	UseForwardedForHeaders bool                `yaml:"use_forwarded_for_headers,omitempty"`
 }
 
 type TLSCfg struct {

--- a/pkg/csconfig/config.go
+++ b/pkg/csconfig/config.go
@@ -229,7 +229,8 @@ func NewDefaultConfig() *GlobalConfig {
 			CredentialsFilePath: "/etc/crowdsec/config/lapi-secrets.yaml",
 		},
 		Server: &LocalApiServerCfg{
-			ListenURI: "127.0.0.1:8080",
+			ListenURI:              "127.0.0.1:8080",
+			UseForwardedForHeaders: false,
 			OnlineClient: &OnlineApiClientCfg{
 				CredentialsFilePath: "/etc/crowdsec/config/online-api-secrets.yaml",
 			},


### PR DESCRIPTION
This implements #609.
A new configuration option, `api.server.use_forwarded_for_headers`, is added to allow LAPI to use either the `X-Forwarded-For` or `X-Real-IP` headers to get the true client IP.
This is not enabled by default due to the security concerns if LAPI is not behind a trusted proxy/LB.