### PR TITLE
Allow for acquisition files to be specified from a directory as well

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -11,7 +11,7 @@ config_paths:
   #hub_dir: /etc/crowdsec/hub/
   #index_path: ./config/hub/.index.json
 crowdsec_service:
-  #acquisition_path: ./config/acquis.yaml
+  acquisition_path: ./config/acquis.yaml
   parser_routines: 1
 cscli:
   output: human

--- a/docs/v1.X/docs/references/acquisition.md
+++ b/docs/v1.X/docs/references/acquisition.md
@@ -1,6 +1,6 @@
 # Acquisition format
 
-The `crowdsec_service` section of configuration supports `acquisition_path` and `acquisition_dir`.
+The `crowdsec_service` section of configuration supports `acquisition_path` and `acquisition_dir` (>1.0.7).
 
 The default setting is to have `acquisition_path` pointing to `/etc/crowdsec/acquis.yaml`.
 

--- a/docs/v1.X/docs/references/acquisition.md
+++ b/docs/v1.X/docs/references/acquisition.md
@@ -1,6 +1,14 @@
 # Acquisition format
 
-The `/etc/crowdsec/acquis.yaml` defines which files are read by crowdsec at runtime.
+The `crowdsec_service` section of configuration supports `acquisition_path` and `acquisition_dir`.
+
+The default setting is to have `acquisition_path` pointing to `/etc/crowdsec/acquis.yaml`.
+
+`acquisition_dir` can be set to point to a directory where every `.yaml` file is considered as a valid acquisition configuration file.
+
+
+
+The acquisition file(s) define which source of information (ie. files or journald streams) are read by crowdsec at runtime.
 The file is a list of object representing groups of files to read, with the following properties.
 
 A least one of :

--- a/docs/v1.X/docs/references/crowdsec-config.md
+++ b/docs/v1.X/docs/references/crowdsec-config.md
@@ -24,6 +24,7 @@ config_paths:
   index_path: /etc/crowdsec/hub/.index.json
 crowdsec_service:
   acquisition_path: /etc/crowdsec/acquis.yaml
+  #acquisition_dir: /etc/crowdsec/acquis/
   parser_routines: 1
   buckets_routines: 1
   output_routines: 1
@@ -108,6 +109,7 @@ config_paths:
   index_path: <path_to_hub_index_file>
 crowdsec_service:
   acquisition_path: <acqusition_file_path>
+  acquisition_dir: <acquisition_dir_path>
   parser_routines: <number_of_parser_routines>
   buckets_routines: <number_of_buckets_routines>
   output_routines: <number_of_output_routines>
@@ -242,6 +244,7 @@ This section is only used by crowdsec agent.
 ```yaml
 crowdsec_service:
   acquisition_path: <acqusition_file_path>
+  acquisition_dir: <acqusition_dir_path>
   parser_routines: <number_of_parser_routines>
   buckets_routines: <number_of_buckets_routines>
   output_routines: <number_of_output_routines>
@@ -267,6 +270,11 @@ Number of dedicated goroutines for pushing data to local api.
 > string
 
 Path to the yaml file containing logs that needs to be read.
+
+#### `acquisition_dir`
+> string
+
+Path to a directory where each yaml is considered as a acquisition configuration file containing logs that needs to be read.
 
 
 ### `cscli`

--- a/docs/v1.X/docs/references/crowdsec-config.md
+++ b/docs/v1.X/docs/references/crowdsec-config.md
@@ -274,7 +274,7 @@ Path to the yaml file containing logs that needs to be read.
 #### `acquisition_dir`
 > string
 
-Path to a directory where each yaml is considered as a acquisition configuration file containing logs that needs to be read.
+(>1.0.7) Path to a directory where each yaml is considered as a acquisition configuration file containing logs that needs to be read.
 
 
 ### `cscli`

--- a/pkg/acquisition/acquisition.go
+++ b/pkg/acquisition/acquisition.go
@@ -111,6 +111,7 @@ func LoadAcquisitionFromFile(config *csconfig.CrowdsecServiceCfg) ([]DataSource,
 	var acquisSources = config.AcquisitionFiles
 
 	for _, acquisFile := range acquisSources {
+		log.Infof("loading acquisition file : %s", acquisFile)
 		yamlFile, err := os.Open(acquisFile)
 		if err != nil {
 			return nil, errors.Wrapf(err, "can't open %s", acquisFile)

--- a/pkg/acquisition/acquisition.go
+++ b/pkg/acquisition/acquisition.go
@@ -108,30 +108,34 @@ func DataSourceConfigure(config DataSourceCfg) (DataSource, error) {
 func LoadAcquisitionFromFile(config *csconfig.CrowdsecServiceCfg) ([]DataSource, error) {
 
 	var sources []DataSource
+	var acquisSources = config.AcquisitionFiles
 
-	yamlFile, err := os.Open(config.AcquisitionFilePath)
-	if err != nil {
-		return nil, errors.Wrapf(err, "can't open %s", config.AcquisitionFilePath)
-	}
-	dec := yaml.NewDecoder(yamlFile)
-	dec.SetStrict(true)
-	for {
-		sub := DataSourceCfg{}
-		err = dec.Decode(&sub)
+	for _, acquisFile := range acquisSources {
+		yamlFile, err := os.Open(acquisFile)
 		if err != nil {
-			if err == io.EOF {
-				log.Tracef("End of yaml file")
-				break
+			return nil, errors.Wrapf(err, "can't open %s", acquisFile)
+		}
+		dec := yaml.NewDecoder(yamlFile)
+		dec.SetStrict(true)
+		for {
+			sub := DataSourceCfg{}
+			err = dec.Decode(&sub)
+			if err != nil {
+				if err == io.EOF {
+					log.Tracef("End of yaml file")
+					break
+				}
+				return nil, errors.Wrap(err, fmt.Sprintf("failed to yaml decode %s", acquisFile))
 			}
-			return nil, errors.Wrap(err, fmt.Sprintf("failed to yaml decode %s", config.AcquisitionFilePath))
+			src, err := DataSourceConfigure(sub)
+			if err != nil {
+				log.Warningf("while configuring datasource : %s", err)
+				continue
+			}
+			sources = append(sources, src)
 		}
-		src, err := DataSourceConfigure(sub)
-		if err != nil {
-			log.Warningf("while configuring datasource : %s", err)
-			continue
-		}
-		sources = append(sources, src)
 	}
+
 	return sources, nil
 }
 

--- a/pkg/acquisition/acquisition_test.go
+++ b/pkg/acquisition/acquisition_test.go
@@ -16,19 +16,19 @@ import (
 func TestConfigLoading(t *testing.T) {
 	//bad filename
 	cfg := csconfig.CrowdsecServiceCfg{
-		AcquisitionFilePath: "./tests/xxx.yaml",
+		AcquisitionFiles: []string{"./tests/xxx.yaml"},
 	}
 	_, err := LoadAcquisitionFromFile(&cfg)
 	assert.Contains(t, fmt.Sprintf("%s", err), "can't open ./tests/xxx.yaml: open ./tests/xxx.yaml: no such file or directory")
 	//bad config file
 	cfg = csconfig.CrowdsecServiceCfg{
-		AcquisitionFilePath: "./tests/test.log",
+		AcquisitionFiles: []string{"./tests/test.log"},
 	}
 	_, err = LoadAcquisitionFromFile(&cfg)
 	assert.Contains(t, fmt.Sprintf("%s", err), "failed to yaml decode ./tests/test.log: yaml: unmarshal errors")
 	//correct config file
 	cfg = csconfig.CrowdsecServiceCfg{
-		AcquisitionFilePath: "./tests/acquis_test.yaml",
+		AcquisitionFiles: []string{"./tests/acquis_test.yaml"},
 	}
 	srcs, err := LoadAcquisitionFromFile(&cfg)
 	if err != nil {

--- a/pkg/csconfig/config.go
+++ b/pkg/csconfig/config.go
@@ -90,13 +90,15 @@ func (c *GlobalConfig) LoadConfiguration() error {
 			}
 			c.Crowdsec.AcquisitionFiles = append(c.Crowdsec.AcquisitionFiles, c.Crowdsec.AcquisitionFilePath)
 		}
-
 		if c.Crowdsec.AcquisitionDirPath != "" {
 			files, err := filepath.Glob(c.Crowdsec.AcquisitionDirPath + "/*.yaml")
 			c.Crowdsec.AcquisitionFiles = append(c.Crowdsec.AcquisitionFiles, files...)
 			if err != nil {
 				return errors.Wrap(err, "while globing acquis_dir")
 			}
+		}
+		if c.Crowdsec.AcquisitionDirPath == "" && c.Crowdsec.AcquisitionFilePath == "" {
+			return fmt.Errorf("no acquisition_path nor acquisition_dir")
 		}
 
 		c.Crowdsec.ConfigDir = c.ConfigPaths.ConfigDir

--- a/pkg/csconfig/config.go
+++ b/pkg/csconfig/config.go
@@ -84,8 +84,22 @@ func (c *GlobalConfig) LoadConfiguration() error {
 
 	if c.Crowdsec != nil {
 		if c.Crowdsec.AcquisitionFilePath == "" {
-			c.Crowdsec.AcquisitionFilePath = filepath.Clean(c.ConfigPaths.ConfigDir + "/acquis.yaml")
+			defaultAcquis := filepath.Clean(c.ConfigPaths.ConfigDir + "/acquis.yaml")
+			if _, err := os.Stat(defaultAcquis); err == nil {
+				c.Crowdsec.AcquisitionFiles = append(c.Crowdsec.AcquisitionFiles, defaultAcquis)
+			}
+		} else {
+			c.Crowdsec.AcquisitionFiles = append(c.Crowdsec.AcquisitionFiles, c.Crowdsec.AcquisitionFilePath)
 		}
+
+		if c.Crowdsec.AcquisitionDirPath != "" {
+			files, err := filepath.Glob(c.Crowdsec.AcquisitionDirPath + "/*.yaml")
+			c.Crowdsec.AcquisitionFiles = append(c.Crowdsec.AcquisitionFiles, files...)
+			if err != nil {
+				return errors.Wrap(err, "while globing acquis_dir")
+			}
+		}
+
 		c.Crowdsec.ConfigDir = c.ConfigPaths.ConfigDir
 		c.Crowdsec.DataDir = c.ConfigPaths.DataDir
 		c.Crowdsec.HubDir = c.ConfigPaths.HubDir

--- a/pkg/csconfig/config.go
+++ b/pkg/csconfig/config.go
@@ -83,12 +83,11 @@ func (c *GlobalConfig) LoadConfiguration() error {
 	}
 
 	if c.Crowdsec != nil {
-		if c.Crowdsec.AcquisitionFilePath == "" {
-			defaultAcquis := filepath.Clean(c.ConfigPaths.ConfigDir + "/acquis.yaml")
-			if _, err := os.Stat(defaultAcquis); err == nil {
-				c.Crowdsec.AcquisitionFiles = append(c.Crowdsec.AcquisitionFiles, defaultAcquis)
+		if c.Crowdsec.AcquisitionFilePath != "" {
+			log.Infof("non-empty acquisition file path %s", c.Crowdsec.AcquisitionFilePath)
+			if _, err := os.Stat(c.Crowdsec.AcquisitionFilePath); err != nil {
+				return errors.Wrapf(err, "while checking acquisition path %s", c.Crowdsec.AcquisitionFilePath)
 			}
-		} else {
 			c.Crowdsec.AcquisitionFiles = append(c.Crowdsec.AcquisitionFiles, c.Crowdsec.AcquisitionFilePath)
 		}
 
@@ -283,6 +282,9 @@ func (c *GlobalConfig) CleanupPaths() error {
 			&c.Common.WorkingDir,
 		}
 		for _, k := range CommonCleanup {
+			if *k == "" {
+				continue
+			}
 			*k, err = filepath.Abs(*k)
 			if err != nil {
 				return errors.Wrap(err, "failed to clean path")
@@ -295,6 +297,9 @@ func (c *GlobalConfig) CleanupPaths() error {
 			&c.Crowdsec.AcquisitionFilePath,
 		}
 		for _, k := range crowdsecCleanup {
+			if *k == "" {
+				continue
+			}
 			*k, err = filepath.Abs(*k)
 			if err != nil {
 				return errors.Wrap(err, "failed to clean path")
@@ -311,6 +316,9 @@ func (c *GlobalConfig) CleanupPaths() error {
 			&c.ConfigPaths.SimulationFilePath,
 		}
 		for _, k := range configPathsCleanup {
+			if *k == "" {
+				continue
+			}
 			*k, err = filepath.Abs(*k)
 			if err != nil {
 				return errors.Wrap(err, "failed to clean path")

--- a/pkg/csconfig/crowdsec_service.go
+++ b/pkg/csconfig/crowdsec_service.go
@@ -2,7 +2,10 @@ package csconfig
 
 /*Configurations needed for crowdsec to load parser/scenarios/... + acquisition*/
 type CrowdsecServiceCfg struct {
-	AcquisitionFilePath  string            `yaml:"acquisition_path,omitempty"`
+	AcquisitionFilePath string `yaml:"acquisition_path,omitempty"`
+	AcquisitionDirPath  string `yaml:"acquisition_dir,omitempty"`
+
+	AcquisitionFiles     []string          `yaml:"-"`
 	ParserRoutinesCount  int               `yaml:"parser_routines"`
 	BucketsRoutinesCount int               `yaml:"buckets_routines"`
 	OutputRoutinesCount  int               `yaml:"output_routines"`

--- a/pkg/csconfig/tests/config.yaml
+++ b/pkg/csconfig/tests/config.yaml
@@ -8,7 +8,7 @@ prometheus:
   enabled: true
   level: full
 crowdsec_service:
-#  acquisition_path: ./config/acquis.yaml
+  acquisition_path: ./tests/acquis.yaml
   parser_routines: 1
 cscli:
   output: human


### PR DESCRIPTION
Fix #618 : improve the acquisition configuration


 - add an optional `acquisition_dir` to crowdsec service configuration : all `*.yaml` files in this directory will be treated as a acquisition configuration file.
 - don't kill `acquisition_pah` for backward compat, but I guess it should be ultimately removed
 - allow  `LoadAcquisitionFromFile` to work directly on a list of files
 - documentation update
 - `cscli config` backup/restore deal with new configuration layout

