### PR TITLE
pkg/metabase: fix dropped error

### DIFF
--- a/pkg/metabase/metabase.go
+++ b/pkg/metabase/metabase.go
@@ -70,7 +70,9 @@ func (m *Metabase) Init() error {
 		return err
 	}
 	m.Database, err = NewDatabase(m.Config.Database, m.Client, remoteDBAddr)
-
+	if err != nil {
+		return err
+	}
 	m.Container, err = NewContainer(m.Config.ListenAddr, m.Config.ListenPort, m.Config.DBPath, containerName, metabaseImage, DBConnectionURI, m.Config.DockerGroupID)
 	if err != nil {
 		return errors.Wrap(err, "container init")


### PR DESCRIPTION
This fixes a dropped `err` variable in `pkg/metabase`.