### PR TITLE
update prometheus default exporter port

### DIFF
--- a/cmd/crowdsec/metrics.go
+++ b/cmd/crowdsec/metrics.go
@@ -68,12 +68,12 @@ func registerPrometheus(config *csconfig.PrometheusCfg) {
 		return
 	}
 	if config.ListenAddr == "" {
-		log.Warningf("prometheus is enabled, but the listen address is empty, using '127.0.0.1'")
 		config.ListenAddr = "127.0.0.1"
+		log.Warningf("prometheus is enabled, but the listen address is empty, using '%s'", config.ListenAddr)
 	}
 	if config.ListenPort == 0 {
-		log.Warningf("prometheus is enabled, but the listen port is empty, using '6060'")
-		config.ListenPort = 6060
+		config.ListenPort = 9810
+		log.Warningf("prometheus is enabled, but the listen port is empty, using '%s'", config.ListenPort)
 	}
 
 	defer types.CatchPanic("crowdsec/registerPrometheus")

--- a/cmd/crowdsec/metrics.go
+++ b/cmd/crowdsec/metrics.go
@@ -73,7 +73,7 @@ func registerPrometheus(config *csconfig.PrometheusCfg) {
 	}
 	if config.ListenPort == 0 {
 		config.ListenPort = 9810
-		log.Warningf("prometheus is enabled, but the listen port is empty, using '%s'", config.ListenPort)
+		log.Warningf("prometheus is enabled, but the listen port is empty, using '%d'", config.ListenPort)
 	}
 
 	defer types.CatchPanic("crowdsec/registerPrometheus")

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -46,4 +46,4 @@ prometheus:
   enabled: true
   level: full
   listen_addr: 127.0.0.1
-  listen_port: 6060
+  listen_port: 9810

--- a/docker/README.md
+++ b/docker/README.md
@@ -69,7 +69,7 @@ So, I want to run crowdsec with :
 * Ingested my path logs specified in acquis.yaml
 * Share the crowdsec sqlite database with my host (You need to create empty file first, otherwise docker will create a directory instead of simple file)
 * Expose local API through host (listen by default on `8080`)
-* Expose prometheus handler through host (listen by default on `6060`)
+* Expose prometheus handler through host (listen by default on `9810`)
 
 ```shell
 touch /path/myDatabase.db
@@ -80,7 +80,7 @@ docker run -d -v config.yaml:/etc/crowdsec/config.yaml \
     -v /var/log/apache:/logs/apache \
     -v /path/myDatabase.db:/var/lib/crowdsec/data/crowdsec.db \
     -e COLLECTIONS="crowdsecurity/apache2 crowdsecurity/sshd" \
-    -p 8080:8080 -p 6060:6060 \
+    -p 8080:8080 -p 9810:9810 \
     --name crowdsec crowdsecurity/crowdsec
 ```
 

--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -46,4 +46,4 @@ prometheus:
   enabled: true
   level: full
   listen_addr: 0.0.0.0
-  listen_port: 6060
+  listen_port: 9810

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -185,7 +185,7 @@ $ sudo HTTP_PROXY=socks5://127.0.0.1:9050 HTTPS_PROXY=socks5://127.0.0.1:9050 cs
 
 ## Why prometheus exporter default port change from 6060 to 9810
 
-We didn't notice that there is a exporter port to choose to avoid collision with others exporters. So we follow [prometheus guideline](https://github.com/prometheus/prometheus/wiki/Default-port-allocations) and we select our default port in available ports list.
+We didn't notice that there is a exporter port to choose to avoid collision with other exporters. So we followed [prometheus guideline](https://github.com/prometheus/prometheus/wiki/Default-port-allocations) and selected our default port in available ports list.
 
 
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -183,6 +183,9 @@ Environment="HTTP_PROXY=socks5://127.0.0.1:9050"
 $ sudo HTTP_PROXY=socks5://127.0.0.1:9050 HTTPS_PROXY=socks5://127.0.0.1:9050 cscli capi register
 ```
 
+## Why prometheus exporter default port change from 6060 to 9810
+
+We didn't notice that there is a exporter port to choose to avoid collision with others exporters. So we follow [prometheus guideline](https://github.com/prometheus/prometheus/wiki/Default-port-allocations) and we select our default port in available ports list.
 
 
 

--- a/docs/v1.X/docs/docker/README.md
+++ b/docs/v1.X/docs/docker/README.md
@@ -69,7 +69,7 @@ So, I want to run crowdsec with :
 * Ingested my path logs specified in acquis.yaml
 * Share the crowdsec sqlite database with my host (You need to create empty file first, otherwise docker will create a directory instead of simple file)
 * Expose local API through host (listen by default on `8080`)
-* Expose prometheus handler through host (listen by default on `6060`)
+* Expose prometheus handler through host (listen by default on `9810`)
 
 ```shell
 touch /path/myDatabase.db
@@ -80,7 +80,7 @@ docker run -d -v config.yaml:/etc/crowdsec/config.yaml \
     -v /var/log/apache:/logs/apache \
     -v /path/myDatabase.db:/var/lib/crowdsec/data/crowdsec.db \
     -e COLLECTIONS="crowdsecurity/apache2 crowdsecurity/sshd" \
-    -p 8080:8080 -p 6060:6060 \
+    -p 8080:8080 -p 9810:9810 \
     --name crowdsec crowdsecurity/crowdsec
 ```
 

--- a/docs/v1.X/docs/observability/prometheus.md
+++ b/docs/v1.X/docs/observability/prometheus.md
@@ -1,4 +1,4 @@
-{{v1X.crowdsec.name}} can expose a {{v1X.prometheus.htmlname}} endpoint for collection (on `http://127.0.0.1:6060/metrics` by default).
+{{v1X.crowdsec.name}} can expose a {{v1X.prometheus.htmlname}} endpoint for collection (on `http://127.0.0.1:9810/metrics` by default).
 
 The goal of this endpoint, besides the usual resources consumption monitoring, aims at offering a view of {{v1X.crowdsec.name}} "applicative" behavior :
 

--- a/docs/v1.X/docs/references/crowdsec-config.md
+++ b/docs/v1.X/docs/references/crowdsec-config.md
@@ -61,7 +61,7 @@ prometheus:
   enabled: true
   level: full
   listen_addr: 127.0.0.1
-  listen_port: 6060
+  listen_port: 9810
 ```
 
 </details>
@@ -301,7 +301,7 @@ The git branch on which `cscli` is going to fetch configurations.
 #### `prometheus_uri`
 > uri
 
-(>1.0.7) An uri (without the trailing `/metrics`) that will be used by `cscli metrics` command, ie. `http://127.0.0.1:6060/`
+(>1.0.7) An uri (without the trailing `/metrics`) that will be used by `cscli metrics` command, ie. `http://127.0.0.1:9810/`
 
 ## `db_config`
 

--- a/pkg/csconfig/config.go
+++ b/pkg/csconfig/config.go
@@ -128,7 +128,7 @@ func (c *GlobalConfig) LoadConfiguration() error {
 		c.Cscli.HubDir = c.ConfigPaths.HubDir
 		c.Cscli.HubIndexFile = c.ConfigPaths.HubIndexFile
 		if c.Cscli.PrometheusUrl == "" {
-			port := 6060
+			port := 9810
 			if c.Prometheus.ListenPort != 0 {
 				port = c.Prometheus.ListenPort
 			}


### PR DESCRIPTION
Fix #632 
Actually, we should choose default **exporter** port and not the **prometheus server** port. There is a maintained defaults ports list : https://github.com/prometheus/prometheus/wiki/Default-port-allocations. I just added the selected port in this list (CTRL+F 'crowdsec').