### PR TITLE
pkg/apiclient: pick up dropped errors

### DIFF
--- a/pkg/apiclient/alerts_service_test.go
+++ b/pkg/apiclient/alerts_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAlertsListAsMachine(t *testing.T) {
@@ -388,7 +389,7 @@ func TestAlertsGetAsMachine(t *testing.T) {
 	}
 
 	alerts, resp, err := client.Alerts.GetByID(context.Background(), 1)
-
+	require.NoError(t, err)
 	if resp.Response.StatusCode != http.StatusOK {
 		t.Errorf("Alerts.List returned status: %d, want %d", resp.Response.StatusCode, http.StatusOK)
 	}
@@ -436,6 +437,7 @@ func TestAlertsCreateAsMachine(t *testing.T) {
 	defer teardown()
 	alert := models.AddAlertsRequest{}
 	alerts, resp, err := client.Alerts.Add(context.Background(), alert)
+	require.NoError(t, err)
 	expected := &models.AddAlertsResponse{"3"}
 	if resp.Response.StatusCode != http.StatusOK {
 		t.Errorf("Alerts.List returned status: %d, want %d", resp.Response.StatusCode, http.StatusOK)
@@ -480,6 +482,8 @@ func TestAlertsDeleteAsMachine(t *testing.T) {
 	alert := AlertsDeleteOpts{IPEquals: new(string)}
 	*alert.IPEquals = "1.2.3.4"
 	alerts, resp, err := client.Alerts.Delete(context.Background(), alert)
+	require.NoError(t, err)
+
 	expected := &models.DeleteAlertsResponse{""}
 	if resp.Response.StatusCode != http.StatusOK {
 		t.Errorf("Alerts.List returned status: %d, want %d", resp.Response.StatusCode, http.StatusOK)

--- a/pkg/apiclient/auth_test.go
+++ b/pkg/apiclient/auth_test.go
@@ -8,6 +8,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestApiAuth(t *testing.T) {
@@ -46,6 +47,7 @@ func TestApiAuth(t *testing.T) {
 	alert := DecisionsListOpts{IPEquals: new(string)}
 	*alert.IPEquals = "1.2.3.4"
 	_, resp, err := newcli.Decisions.List(context.Background(), alert)
+	require.NoError(t, err)
 
 	if resp.Response.StatusCode != http.StatusOK {
 		t.Errorf("Alerts.List returned status: %d, want %d", resp.Response.StatusCode, http.StatusOK)
@@ -76,6 +78,7 @@ func TestApiAuth(t *testing.T) {
 	}
 
 	_, resp, err = newcli.Decisions.List(context.Background(), alert)
+	require.Error(t, err)
 
 	log.Infof("--> %s", err)
 	assert.Contains(t, err.Error(), "APIKey is empty")

--- a/pkg/apiclient/decisions_service_test.go
+++ b/pkg/apiclient/decisions_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDecisionsList(t *testing.T) {
@@ -86,6 +87,7 @@ func TestDecisionsList(t *testing.T) {
 	decisionsFilter = DecisionsListOpts{IPEquals: new(string)}
 	*decisionsFilter.IPEquals = "1.2.3.5"
 	decisions, resp, err = newcli.Decisions.List(context.Background(), decisionsFilter)
+	require.NoError(t, err)
 
 	if resp.Response.StatusCode != http.StatusOK {
 		t.Errorf("Alerts.List returned status: %d, want %d", resp.Response.StatusCode, http.StatusOK)
@@ -159,6 +161,7 @@ func TestDecisionsStream(t *testing.T) {
 	}
 
 	decisions, resp, err := newcli.Decisions.GetStream(context.Background(), true)
+	require.NoError(t, err)
 
 	if resp.Response.StatusCode != http.StatusOK {
 		t.Errorf("Alerts.List returned status: %d, want %d", resp.Response.StatusCode, http.StatusOK)
@@ -173,6 +176,7 @@ func TestDecisionsStream(t *testing.T) {
 
 	//and second call, we get empty lists
 	decisions, resp, err = newcli.Decisions.GetStream(context.Background(), false)
+	require.NoError(t, err)
 
 	if resp.Response.StatusCode != http.StatusOK {
 		t.Errorf("Alerts.List returned status: %d, want %d", resp.Response.StatusCode, http.StatusOK)
@@ -182,6 +186,7 @@ func TestDecisionsStream(t *testing.T) {
 
 	//delete stream
 	resp, err = newcli.Decisions.StopStream(context.Background())
+	require.NoError(t, err)
 
 	if resp.Response.StatusCode != http.StatusOK {
 		t.Errorf("Alerts.List returned status: %d, want %d", resp.Response.StatusCode, http.StatusOK)


### PR DESCRIPTION
This picks up dropped error variables in `pkg/apiclient`.