### PR TITLE
pkg/apiserver: fix dropped error

### DIFF
--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -131,7 +131,7 @@ func NewAPIC(config *csconfig.OnlineApiClientCfg, dbClient *database.Client) (*a
 		Scenarios:      ret.scenarioList,
 		UpdateScenario: ret.FetchScenariosListFromDB,
 	})
-	return ret, nil
+	return ret, err
 }
 
 func (a *apic) Push() error {

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -28,7 +28,6 @@ type APIServer struct {
 	TLS            *csconfig.TLSCfg
 	dbClient       *database.Client
 	logFile        string
-	ctx            context.Context
 	controller     *controllers.Controller
 	flushScheduler *gocron.Scheduler
 	router         *gin.Engine


### PR DESCRIPTION
This fixes a dropped error and prunes an unused `context.Context` from `pkg/apiserver`.

Even if the `Context` was being used, the Go documentation recommends against that. From `go doc context`:

> Do not store Contexts inside a struct type; instead, pass a Context
explicitly to each function that needs it. The Context should be the first
parameter, typically named ctx: