### PR TITLE
clarify doc on onsuccess in parsers + add new date formats for dateparse

### DIFF
--- a/docs/v1.X/docs/references/parsers.md
+++ b/docs/v1.X/docs/references/parsers.md
@@ -243,7 +243,7 @@ onsuccess: next_stage|continue
 
 _default: continue_
 
-if set to `next_stage` and the node is considered successful, the {{v1X.event.name}} will be moved directly to next stage without processing other nodes in the current stage.
+if set to `next_stage` and the node is considered successful, the {{v1X.event.name}} will be moved directly to the next stage without processing other nodes in the current stage. _note: if it's a parser tree, and a "leaf" node succeeds, it is the parent's "onsuccess" that is evaluated._
 
 ### `pattern_syntax`
 

--- a/pkg/parser/enrich.go
+++ b/pkg/parser/enrich.go
@@ -66,6 +66,8 @@ func GenDateParse(date string) (string, time.Time) {
 		"2006/01/02 15:04",
 		"2006-01-02",
 		"2006-01-02 15:04",
+		"2006/01/02 15:04:05",
+		"2006-01-02 15:04:05",
 	}
 
 	for _, dateFormat := range layouts {


### PR DESCRIPTION
 - clarify `onsuccess` behaviour when it's a parser tree
 - add two new date formats : `2006/01/02 15:04:05` `2006-01-02 15:04:05`

