### PR TITLE
Ensure LAPI logs respect `log_media`

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -86,7 +86,7 @@ func NewServer(config *csconfig.LocalApiServerCfg) (*APIServer, error) {
 		if err != nil {
 			return &APIServer{}, errors.Wrapf(err, "creating api access log file: %s", logFile)
 		}
-		gin.DefaultWriter = io.MultiWriter(file, os.Stdout)
+		gin.DefaultWriter = io.MultiWriter(file)
 	}
 
 	router.Use(gin.LoggerWithFormatter(func(param gin.LogFormatterParams) string {

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -52,7 +52,7 @@ func NewServer(config *csconfig.LocalApiServerCfg) (*APIServer, error) {
 	}
 
 	logFile := ""
-	if config.LogDir != "" && config.LogMedia == "file" {
+	if config.LogMedia == "file" {
 		logFile = fmt.Sprintf("%s/crowdsec_api.log", config.LogDir)
 	}
 


### PR DESCRIPTION
 - Fix #702 : prevent when LAPI from writing logs to stdout when log_media is stdout
