### PR TITLE
`cscli` hub mgmt improvements

### DIFF
--- a/cmd/crowdsec-cli/collections.go
+++ b/cmd/crowdsec-cli/collections.go
@@ -102,6 +102,9 @@ func NewCollectionsCmd() *cobra.Command {
 			if all {
 				UpgradeConfig(cwhub.COLLECTIONS, "", forceAction)
 			} else {
+				if len(args) == 0 {
+					log.Fatalf("no target collection to upgrade")
+				}
 				for _, name := range args {
 					UpgradeConfig(cwhub.COLLECTIONS, name, forceAction)
 				}

--- a/cmd/crowdsec-cli/hub.go
+++ b/cmd/crowdsec-cli/hub.go
@@ -41,10 +41,14 @@ cscli hub update # Download list of available configurations from the hub
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cwhub.GetHubIdx(csConfig.Cscli); err != nil {
-				log.Fatalf("Failed to get Hub index : %v", err)
 				log.Infoln("Run 'sudo cscli hub update' to get the hub index")
+				log.Fatalf("Failed to get Hub index : %v", err)
 			}
-
+			//use LocalSync to get warnings about tainted / outdated items
+			_, warn := cwhub.LocalSync(csConfig.Cscli)
+			for _, v := range warn {
+				log.Info(v)
+			}
 			cwhub.DisplaySummary()
 			log.Printf("PARSERS:")
 			ListItem(cwhub.PARSERS, args)
@@ -80,6 +84,11 @@ Fetches the [.index.json](https://github.com/crowdsecurity/hub/blob/master/.inde
 			if err := cwhub.UpdateHubIdx(csConfig.Cscli); err != nil {
 				log.Fatalf("Failed to get Hub index : %v", err)
 			}
+			//use LocalSync to get warnings about tainted / outdated items
+			_, warn := cwhub.LocalSync(csConfig.Cscli)
+			for _, v := range warn {
+				log.Info(v)
+			}
 		},
 	}
 	cmdHub.AddCommand(cmdHubUpdate)
@@ -106,6 +115,7 @@ Upgrade all configs installed from Crowdsec Hub. Run 'sudo cscli hub update' if 
 				log.Fatalf("Failed to get Hub index : %v", err)
 				log.Infoln("Run 'sudo cscli hub update' to get the hub index")
 			}
+
 			log.Infof("Upgrading collections")
 			UpgradeConfig(cwhub.COLLECTIONS, "", forceAction)
 			log.Infof("Upgrading parsers")

--- a/cmd/crowdsec-cli/hub.go
+++ b/cmd/crowdsec-cli/hub.go
@@ -49,7 +49,7 @@ cscli hub update # Download list of available configurations from the hub
 				log.Infoln("Run 'sudo cscli hub update' to get the hub index")
 			}
 			//use LocalSync to get warnings about tainted / outdated items
-			_, warn := cwhub.LocalSync(csConfig.Cscli)
+			_, warn := cwhub.LocalSync(csConfig.Hub)
 			for _, v := range warn {
 				log.Info(v)
 			}
@@ -92,7 +92,7 @@ Fetches the [.index.json](https://github.com/crowdsecurity/hub/blob/master/.inde
 				log.Fatalf("Failed to get Hub index : %v", err)
 			}
 			//use LocalSync to get warnings about tainted / outdated items
-			_, warn := cwhub.LocalSync(csConfig.Cscli)
+			_, warn := cwhub.LocalSync(csConfig.Hub)
 			for _, v := range warn {
 				log.Info(v)
 			}

--- a/cmd/crowdsec-cli/parsers.go
+++ b/cmd/crowdsec-cli/parsers.go
@@ -98,6 +98,9 @@ cscli parsers remove crowdsecurity/sshd-logs
 			if all {
 				UpgradeConfig(cwhub.PARSERS, "", forceAction)
 			} else {
+				if len(args) == 0 {
+					log.Fatalf("no target parser to upgrade")
+				}
 				for _, name := range args {
 					UpgradeConfig(cwhub.PARSERS, name, forceAction)
 				}

--- a/cmd/crowdsec-cli/postoverflows.go
+++ b/cmd/crowdsec-cli/postoverflows.go
@@ -97,6 +97,9 @@ func NewPostOverflowsCmd() *cobra.Command {
 			if all {
 				UpgradeConfig(cwhub.PARSERS_OVFLW, "", forceAction)
 			} else {
+				if len(args) == 0 {
+					log.Fatalf("no target postoverflow to upgrade")
+				}
 				for _, name := range args {
 					UpgradeConfig(cwhub.PARSERS_OVFLW, name, forceAction)
 				}

--- a/cmd/crowdsec-cli/scenarios.go
+++ b/cmd/crowdsec-cli/scenarios.go
@@ -98,6 +98,9 @@ cscli scenarios remove crowdsecurity/ssh-bf
 			if all {
 				UpgradeConfig(cwhub.SCENARIOS, "", forceAction)
 			} else {
+				if len(args) == 0 {
+					log.Fatalf("no target scenario to upgrade")
+				}
 				for _, name := range args {
 					UpgradeConfig(cwhub.SCENARIOS, name, forceAction)
 				}

--- a/pkg/cwhub/cwhub.go
+++ b/pkg/cwhub/cwhub.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/enescakir/emoji"
 	"github.com/pkg/errors"
+	"golang.org/x/mod/semver"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -77,6 +78,11 @@ var skippedTainted = 0
 /*To be used when reference(s) (is/are) missing in a collection*/
 var ReferenceMissingError = errors.New("Reference(s) missing in collection")
 var MissingHubIndex = errors.New("hub index can't be found")
+
+//GetVersionStatus : semver requires 'v' prefix
+func GetVersionStatus(v *Item) int {
+	return semver.Compare("v"+v.Version, "v"+v.LocalVersion)
+}
 
 // calculate sha256 of a file
 func getSHA256(filepath string) (string, error) {

--- a/pkg/cwhub/cwhub_test.go
+++ b/pkg/cwhub/cwhub_test.go
@@ -193,7 +193,7 @@ func testInstallItem(cfg *csconfig.CscliCfg, t *testing.T, item Item) {
 	if err != nil {
 		t.Fatalf("error while downloading %s : %v", item.Name, err)
 	}
-	if err := LocalSync(cfg); err != nil {
+	if err, _ := LocalSync(cfg); err != nil {
 		t.Fatalf("taint: failed to run localSync : %s", err)
 	}
 	if !hubIdx[item.Type][item.Name].UpToDate {
@@ -210,7 +210,7 @@ func testInstallItem(cfg *csconfig.CscliCfg, t *testing.T, item Item) {
 	if err != nil {
 		t.Fatalf("error while enabled %s : %v.", item.Name, err)
 	}
-	if err := LocalSync(cfg); err != nil {
+	if err, _ := LocalSync(cfg); err != nil {
 		t.Fatalf("taint: failed to run localSync : %s", err)
 	}
 	if !hubIdx[item.Type][item.Name].Installed {
@@ -232,7 +232,7 @@ func testTaintItem(cfg *csconfig.CscliCfg, t *testing.T, item Item) {
 	}
 	f.Close()
 	//Local sync and check status
-	if err := LocalSync(cfg); err != nil {
+	if err, _ := LocalSync(cfg); err != nil {
 		t.Fatalf("taint: failed to run localSync : %s", err)
 	}
 	if !hubIdx[item.Type][item.Name].Tainted {
@@ -251,7 +251,7 @@ func testUpdateItem(cfg *csconfig.CscliCfg, t *testing.T, item Item) {
 		t.Fatalf("failed to update %s : %s", item.Name, err)
 	}
 	//Local sync and check status
-	if err := LocalSync(cfg); err != nil {
+	if err, _ := LocalSync(cfg); err != nil {
 		t.Fatalf("failed to run localSync : %s", err)
 	}
 	if !hubIdx[item.Type][item.Name].UpToDate {
@@ -272,8 +272,8 @@ func testDisableItem(cfg *csconfig.CscliCfg, t *testing.T, item Item) {
 		t.Fatalf("failed to disable item : %v", err)
 	}
 	//Local sync and check status
-	if err := LocalSync(cfg); err != nil {
-		t.Fatalf("failed to run localSync : %s", err)
+	if err, warns := LocalSync(cfg); err != nil || len(warns) > 0 {
+		t.Fatalf("failed to run localSync : %s (%+v)", err, warns)
 	}
 	if hubIdx[item.Type][item.Name].Tainted {
 		t.Fatalf("disable: %s should not be tainted anymore", item.Name)
@@ -290,8 +290,8 @@ func testDisableItem(cfg *csconfig.CscliCfg, t *testing.T, item Item) {
 		t.Fatalf("failed to purge item : %v", err)
 	}
 	//Local sync and check status
-	if err := LocalSync(cfg); err != nil {
-		t.Fatalf("failed to run localSync : %s", err)
+	if err, warns := LocalSync(cfg); err != nil || len(warns) > 0 {
+		t.Fatalf("failed to run localSync : %s (%+v)", err, warns)
 	}
 	if hubIdx[item.Type][item.Name].Installed {
 		t.Fatalf("disable: %s should not be installed anymore", item.Name)

--- a/pkg/cwhub/download.go
+++ b/pkg/cwhub/download.go
@@ -35,7 +35,7 @@ func UpdateHubIdx(cscli *csconfig.CscliCfg) error {
 		}
 	}
 	hubIdx = ret
-	if err := LocalSync(cscli); err != nil {
+	if err, _ := LocalSync(cscli); err != nil {
 		return errors.Wrap(err, "failed to sync")
 	}
 	return nil

--- a/pkg/cwhub/download.go
+++ b/pkg/cwhub/download.go
@@ -35,7 +35,7 @@ func UpdateHubIdx(hub *csconfig.Hub) error {
 		}
 	}
 	hubIdx = ret
-	if err, _ := LocalSync(cscli); err != nil {
+	if err, _ := LocalSync(hub); err != nil {
 		return errors.Wrap(err, "failed to sync")
 	}
 	return nil

--- a/pkg/cwhub/loader.go
+++ b/pkg/cwhub/loader.go
@@ -300,10 +300,10 @@ func CollecDepsCheck(v *Item) error {
 	return nil
 }
 
-func SyncDir(cscli *csconfig.CscliCfg, dir string) (error, []string) {
-	hubdir = cscli.HubDir
-	installdir = cscli.ConfigDir
-	indexpath = cscli.HubIndexFile
+func SyncDir(hub *csconfig.Hub, dir string) (error, []string) {
+	hubdir = hub.HubDir
+	installdir = hub.ConfigDir
+	indexpath = hub.HubIndexFile
 	warnings := []string{}
 
 	/*For each, scan PARSERS, PARSERS_OVFLW, SCENARIOS and COLLECTIONS last*/
@@ -339,17 +339,17 @@ func SyncDir(cscli *csconfig.CscliCfg, dir string) (error, []string) {
 }
 
 /* Updates the infos from HubInit() with the local state */
-func LocalSync(cscli *csconfig.CscliCfg) (error, []string) {
+func LocalSync(hub *csconfig.Hub) (error, []string) {
 	skippedLocal = 0
 	skippedTainted = 0
 
-	err, warnings := SyncDir(cscli, cscli.ConfigDir)
+	err, warnings := SyncDir(hub, hub.ConfigDir)
 	if err != nil {
-		return fmt.Errorf("failed to scan %s : %s", cscli.ConfigDir, err), warnings
+		return fmt.Errorf("failed to scan %s : %s", hub.ConfigDir, err), warnings
 	}
-	err, _ = SyncDir(cscli, cscli.HubDir)
+	err, _ = SyncDir(hub, hub.HubDir)
 	if err != nil {
-		return fmt.Errorf("failed to scan %s : %s", cscli.HubDir, err), warnings
+		return fmt.Errorf("failed to scan %s : %s", hub.HubDir, err), warnings
 	}
 	return nil, warnings
 }
@@ -371,7 +371,7 @@ func GetHubIdx(hub *csconfig.Hub) error {
 		return err
 	}
 	hubIdx = ret
-	err, _ = LocalSync(cscli)
+	err, _ = LocalSync(hub)
 	if err != nil {
 		log.Fatalf("Failed to sync Hub index with local deployment : %v", err)
 	}


### PR DESCRIPTION
 - do not try to check dependencies on out-of-date collection (avoid spamming user with confusing messages)
 - do not repeat the messages to the user : function returns warnings rather than display them (GetHubIdx can be called multiple times)
 - `cscli parsers/scenarios/collections/... upgrade` : if no item name if provided, warn the user
 - fix #704 
 - [x] fix tests