### PR TITLE
[stale] add OpenBSD support for generating the machine id if /etc/machine-id …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CSCLI_FOLDER = "./cmd/crowdsec-cli/"
 CROWDSEC_BIN = "crowdsec"
 CSCLI_BIN = "cscli"
 BUILD_CMD = "build"
-MAKE = "make"
+MAKE ?= "make"
 
 GOARCH=amd64
 GOOS=linux

--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 	"runtime"
-	"syscall"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
@@ -23,6 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
+	"golang.org/x/sys/unix"
 )
 
 var machineID string
@@ -71,7 +71,7 @@ func generateID() (string, error) {
 		var bID []byte
 		switch runtime.GOOS {
 		case "openbsd":
-			id, err = syscall.Sysctl("hw.uuid")
+			id, err = unix.Sysctl("hw.uuid")
 		default:
 			bID, err = ioutil.ReadFile(uuid)
 			id = string(bID)


### PR DESCRIPTION
…is unavailable

use the hw.uuid sysctl on openbsd to get the hardware UUID in case /etc/machine-id
is not available because /proc is linux-only