### PR TITLE
FreeBSD changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+ROOT= $(shell git rev-parse --show-toplevel)
+SYSTEM = $(shell uname -s | tr '[A-Z]' '[a-z]')
+
+ifneq ("$(wildcard $(ROOT)/platform/$(SYSTEM).mk)", "")
+	include $(ROOT)/platform/$(SYSTEM).mk
+else
+	include $(ROOT)/platform/linux.mk
+endif
+
 PREFIX?="/tmp/crowdsec/"
 CFG_PREFIX = $(PREFIX)"/etc/crowdsec/"
 BIN_PREFIX = $(PREFIX)"/usr/local/bin/"
@@ -9,10 +18,8 @@ CSCLI_FOLDER = "./cmd/crowdsec-cli/"
 CROWDSEC_BIN = "crowdsec"
 CSCLI_BIN = "cscli"
 BUILD_CMD = "build"
-MAKE = "make"
 
 GOARCH=amd64
-GOOS=linux
 
 #Golang version info
 GO_MAJOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)

--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -99,7 +99,7 @@ func NewCapiCmd() *cobra.Command {
 				fmt.Printf("%s\n", string(apiConfigDump))
 			}
 
-			log.Warningf("Run 'sudo systemctl reload crowdsec' for the new configuration to be effective")
+			log.Warningf(ReloadMessage())
 		},
 	}
 	cmdCapiRegister.Flags().StringVarP(&outputFile, "file", "f", "", "output file destination")

--- a/cmd/crowdsec-cli/collections.go
+++ b/cmd/crowdsec-cli/collections.go
@@ -40,7 +40,7 @@ func NewCollectionsCmd() *cobra.Command {
 			if cmd.Name() == "inspect" || cmd.Name() == "list" {
 				return
 			}
-			log.Infof("Run 'sudo systemctl reload crowdsec' for the new configuration to be effective.")
+			log.Infof(ReloadMessage())
 		},
 	}
 

--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -115,7 +115,7 @@ Keep in mind the machine needs to be validated by an administrator on LAPI side 
 			} else {
 				fmt.Printf("%s\n", string(apiConfigDump))
 			}
-			log.Warningf("Run 'sudo systemctl reload crowdsec' for the new configuration to be effective")
+			log.Warningf(ReloadMessage())
 		},
 	}
 	cmdLapiRegister.Flags().StringVarP(&apiURL, "url", "u", "", "URL of the API (ie. http://127.0.0.1)")

--- a/cmd/crowdsec-cli/messages.go
+++ b/cmd/crowdsec-cli/messages.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+const (
+	ReloadMessageFormat = `Run '%s' for the new configuration to be effective.`
+	ReloadCmdLinux      = `sudo systemctl reload crowdsec`
+	ReloadCmdFreebsd    = `sudo service crowdsec reload`
+)
+
+func ReloadMessage() string {
+
+	var reloadCmd string
+
+	if runtime.GOOS == "freebsd" {
+		reloadCmd = ReloadCmdFreebsd
+	} else {
+		reloadCmd = ReloadCmdLinux
+	}
+
+	return fmt.Sprintf(ReloadMessageFormat, reloadCmd)
+}

--- a/cmd/crowdsec-cli/messages_test.go
+++ b/cmd/crowdsec-cli/messages_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+func TestMessages(t *testing.T) {
+
+	var inputWant string
+
+	if runtime.GOOS == "freebsd" {
+		inputWant = fmt.Sprintf(ReloadMessageFormat, ReloadCmdFreebsd)
+	} else {
+		inputWant = fmt.Sprintf(ReloadMessageFormat, ReloadCmdLinux)
+	}
+
+	inputGot := ReloadMessage()
+
+	if inputWant != inputGot {
+		t.Errorf("Want %s, Got %s", inputWant, inputGot)
+	}
+}

--- a/cmd/crowdsec-cli/parsers.go
+++ b/cmd/crowdsec-cli/parsers.go
@@ -43,7 +43,7 @@ cscli parsers remove crowdsecurity/sshd-logs
 			if cmd.Name() == "inspect" || cmd.Name() == "list" {
 				return
 			}
-			log.Infof("Run 'sudo systemctl reload crowdsec' for the new configuration to be effective.")
+			log.Infof(ReloadMessage())
 		},
 	}
 

--- a/cmd/crowdsec-cli/postoverflows.go
+++ b/cmd/crowdsec-cli/postoverflows.go
@@ -42,7 +42,7 @@ func NewPostOverflowsCmd() *cobra.Command {
 			if cmd.Name() == "inspect" || cmd.Name() == "list" {
 				return
 			}
-			log.Infof("Run 'sudo systemctl reload crowdsec' for the new configuration to be effective.")
+			log.Infof(ReloadMessage())
 		},
 	}
 

--- a/cmd/crowdsec-cli/scenarios.go
+++ b/cmd/crowdsec-cli/scenarios.go
@@ -43,7 +43,7 @@ cscli scenarios remove crowdsecurity/ssh-bf
 			if cmd.Name() == "inspect" || cmd.Name() == "list" {
 				return
 			}
-			log.Infof("Run 'sudo systemctl reload crowdsec' for the new configuration to be effective.")
+			log.Infof(ReloadMessage())
 		},
 	}
 

--- a/cmd/crowdsec-cli/simulation.go
+++ b/cmd/crowdsec-cli/simulation.go
@@ -118,7 +118,7 @@ cscli simulation disable crowdsecurity/ssh-bf`,
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
 			if cmd.Name() != "status" {
-				log.Infof("Run 'sudo systemctl reload crowdsec' for the new configuration to be effective.")
+				log.Infof(ReloadMessage())
 			}
 		},
 	}

--- a/platform/freebsd.mk
+++ b/platform/freebsd.mk
@@ -1,0 +1,7 @@
+# FreeBSD specific
+#
+
+Make=gmake
+GOOS=freebsd
+
+$(warning Building for freebsd)

--- a/platform/linux.mk
+++ b/platform/linux.mk
@@ -1,0 +1,6 @@
+# Linux specific
+
+MAKE=make
+GOOS=linux
+
+$(warning Building for linux)


### PR DESCRIPTION
This change contains the following:

* Update Makefile build definitions for other platforms, we can now build a fresh clone ootb using `gmake -f Makefile`
* Ensure we do not emit `systemctl` messages to the user and simple [do not repeat yourself](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)