### PR TITLE
do not leak fd on reload

### DIFF
--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -73,6 +73,11 @@ func reloadHandler(sig os.Signal, cConfig *csconfig.Config) error {
 	apiTomb = tomb.Tomb{}
 	crowdsecTomb = tomb.Tomb{}
 
+	cConfig, err = csconfig.NewConfig(flags.ConfigFile, flags.DisableAgent, flags.DisableAPI)
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
 	if err := LoadConfig(cConfig); err != nil {
 		log.Fatalf(err.Error())
 	}


### PR DESCRIPTION
fix #744 : Do not leak file descriptors upon reload.

(performed tests to ensure that the FD leak is present *as well* on version 1.0.9 and before)
