### PR TITLE
`cscli machines|bouncers|dashboard` error message clarification

### DIFF
--- a/cmd/crowdsec-cli/bouncers.go
+++ b/cmd/crowdsec-cli/bouncers.go
@@ -29,8 +29,7 @@ Note: This command requires database direct access, so is intended to be run on 
 		Args: cobra.MinimumNArgs(1),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			var err error
-			csConfig.LoadAPIServer()
-			if csConfig.DisableAPI {
+			if err := csConfig.LoadAPIServer(); err != nil || csConfig.DisableAPI {
 				log.Fatal("Local API is disabled, please run this command on the local API machine")
 			}
 			if err := csConfig.LoadDBConfig(); err != nil {

--- a/cmd/crowdsec-cli/bouncers.go
+++ b/cmd/crowdsec-cli/bouncers.go
@@ -22,15 +22,17 @@ func NewBouncersCmd() *cobra.Command {
 	/* ---- DECISIONS COMMAND */
 	var cmdBouncers = &cobra.Command{
 		Use:   "bouncers [action]",
-		Short: "Manage bouncers",
-		Long: `
-Bouncers Management.
-
-To list/add/delete bouncers
+		Short: "Manage bouncers [requires local API]",
+		Long: `To list/add/delete bouncers.
+Note: This command requires database direct access, so is intended to be run on Local API/master.
 `,
 		Args: cobra.MinimumNArgs(1),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			var err error
+			csConfig.LoadAPIServer()
+			if csConfig.DisableAPI {
+				log.Fatal("Local API is disabled, please run this command on the local API machine")
+			}
 			if err := csConfig.LoadDBConfig(); err != nil {
 				log.Fatalf(err.Error())
 			}
@@ -119,7 +121,7 @@ cscli bouncers add MyBouncerName -l 24`,
 			if csConfig.Cscli.Output == "human" {
 				fmt.Printf("Api key for '%s':\n\n", keyName)
 				fmt.Printf("   %s\n\n", apiKey)
-				fmt.Print("Please keep this key since you will not be able to retrive it!\n")
+				fmt.Print("Please keep this key since you will not be able to retrieve it!\n")
 			} else if csConfig.Cscli.Output == "raw" {
 				fmt.Printf("%s", apiKey)
 			} else if csConfig.Cscli.Output == "json" {

--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -28,11 +28,8 @@ func NewCapiCmd() *cobra.Command {
 		Short: "Manage interaction with Central API (CAPI)",
 		Args:  cobra.MinimumNArgs(1),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := csConfig.LoadAPIServer(); err != nil {
-				log.Fatalf(err.Error())
-			}
-			if csConfig.API.Server == nil {
-				log.Fatalln("There is no API->server configuration")
+			if err := csConfig.LoadAPIServer(); err != nil || csConfig.DisableAPI {
+				log.Fatal("Local API is disabled, please run this command on the local API machine")
 			}
 			if csConfig.API.Server.OnlineClient == nil {
 				log.Fatalf("no configuration for crowdsec API in '%s'", *csConfig.FilePath)

--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -52,8 +52,7 @@ cscli dashboard stop
 cscli dashboard remove
 `,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			csConfig.LoadAPIServer()
-			if csConfig.DisableAPI {
+			if err := csConfig.LoadAPIServer(); err != nil || csConfig.DisableAPI {
 				log.Fatal("Local API is disabled, please run this command on the local API machine")
 			}
 

--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -40,9 +40,11 @@ func NewDashboardCmd() *cobra.Command {
 	/* ---- UPDATE COMMAND */
 	var cmdDashboard = &cobra.Command{
 		Use:   "dashboard [command]",
-		Short: "Manage your metabase dashboard container",
-		Long:  `Install/Start/Stop/Remove a metabase container exposing dashboard and metrics.`,
-		Args:  cobra.ExactArgs(1),
+		Short: "Manage your metabase dashboard container [requires local API]",
+		Long: `Install/Start/Stop/Remove a metabase container exposing dashboard and metrics.
+Note: This command requires database direct access, so is intended to be run on Local API/master.
+		`,
+		Args: cobra.ExactArgs(1),
 		Example: `
 cscli dashboard setup
 cscli dashboard start
@@ -50,6 +52,11 @@ cscli dashboard stop
 cscli dashboard remove
 `,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			csConfig.LoadAPIServer()
+			if csConfig.DisableAPI {
+				log.Fatal("Local API is disabled, please run this command on the local API machine")
+			}
+
 			metabaseConfigFolderPath := filepath.Join(csConfig.ConfigPaths.ConfigDir, metabaseConfigFolder)
 			metabaseConfigPath = filepath.Join(metabaseConfigFolderPath, metabaseConfigFile)
 			if err := os.MkdirAll(metabaseConfigFolderPath, os.ModePerm); err != nil {

--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -63,6 +63,7 @@ cscli dashboard remove
 				log.Fatalf(err.Error())
 			}
 			if err := csConfig.LoadDBConfig(); err != nil {
+				log.Errorf("This command requires direct database access (must be run on the local API machine)")
 				log.Fatalf(err.Error())
 			}
 

--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -86,8 +86,7 @@ Note: This command requires database direct access, so is intended to be run on 
 `,
 		Example: `cscli machines [action]`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			csConfig.LoadAPIServer()
-			if csConfig.DisableAPI {
+			if err := csConfig.LoadAPIServer(); err != nil || csConfig.DisableAPI {
 				log.Fatal("Local API is disabled, please run this command on the local API machine")
 			}
 			if err := csConfig.LoadDBConfig(); err != nil {

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -132,7 +132,7 @@ func ListItem(itemType string, args []string) {
 func InstallItem(name string, obtype string, force bool) {
 	it := cwhub.GetItem(obtype, name)
 	if it == nil {
-		log.Fatalf("unable to retrive item : %s", name)
+		log.Fatalf("unable to retrieve item : %s", name)
 	}
 	item := *it
 	if downloadOnly && item.Downloaded && item.UpToDate {

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,6 +15,18 @@ If you spotted some mistakes in the documentation or have improvement suggestion
 Let us as well know if you have some improvement suggestions !
 
 
+<details>
+  <summary>Preview your documentation changes locally</summary>
+
+```bash
+python3 -m venv cs-env
+source cs-env/bin/activate
+pip install -r docs/requirements.txt
+mkdocs serve
+```
+
+</details>
+
 
 ## Contributing to the code
 

--- a/docs/v1.X/docs/cscli/cscli.md
+++ b/docs/v1.X/docs/cscli/cscli.md
@@ -23,16 +23,16 @@ It is meant to allow you to manage bans, parsers/scenarios/etc, api and generall
 ### SEE ALSO
 
 * [cscli alerts](cscli_alerts.md)	 - Manage alerts
-* [cscli bouncers](cscli_bouncers.md)	 - Manage bouncers
+* [cscli bouncers](cscli_bouncers.md)	 - Manage bouncers [requires local API]
 * [cscli capi](cscli_capi.md)	 - Manage interaction with Central API (CAPI)
 * [cscli collections](cscli_collections.md)	 - Manage collections from hub
 * [cscli completion](cscli_completion.md)	 - Generate completion script
 * [cscli config](cscli_config.md)	 - Allows to view current config
-* [cscli dashboard](cscli_dashboard.md)	 - Manage your metabase dashboard container
+* [cscli dashboard](cscli_dashboard.md)	 - Manage your metabase dashboard container [requires local API]
 * [cscli decisions](cscli_decisions.md)	 - Manage decisions
 * [cscli hub](cscli_hub.md)	 - Manage Hub
 * [cscli lapi](cscli_lapi.md)	 - Manage interaction with Local API (LAPI)
-* [cscli machines](cscli_machines.md)	 - Manage local API machines
+* [cscli machines](cscli_machines.md)	 - Manage local API machines [requires local API]
 * [cscli metrics](cscli_metrics.md)	 - Display crowdsec prometheus metrics.
 * [cscli parsers](cscli_parsers.md)	 - Install/Remove/Upgrade/Inspect parser(s) from hub
 * [cscli postoverflows](cscli_postoverflows.md)	 - Install/Remove/Upgrade/Inspect postoverflow(s) from hub

--- a/docs/v1.X/docs/cscli/cscli_bouncers.md
+++ b/docs/v1.X/docs/cscli/cscli_bouncers.md
@@ -1,13 +1,11 @@
 ## cscli bouncers
 
-Manage bouncers
+Manage bouncers [requires local API]
 
 ### Synopsis
 
-
-Bouncers Management.
-
-To list/add/delete bouncers
+To list/add/delete bouncers.
+Note: This command requires database direct access, so is intended to be run on Local API/master.
 
 
 ### Options

--- a/docs/v1.X/docs/cscli/cscli_bouncers_add.md
+++ b/docs/v1.X/docs/cscli/cscli_bouncers_add.md
@@ -38,6 +38,6 @@ cscli bouncers add MyBouncerName -l 24
 
 ### SEE ALSO
 
-* [cscli bouncers](cscli_bouncers.md)	 - Manage bouncers
+* [cscli bouncers](cscli_bouncers.md)	 - Manage bouncers [requires local API]
 
 

--- a/docs/v1.X/docs/cscli/cscli_bouncers_delete.md
+++ b/docs/v1.X/docs/cscli/cscli_bouncers_delete.md
@@ -26,6 +26,6 @@ cscli bouncers delete MyBouncerName [flags]
 
 ### SEE ALSO
 
-* [cscli bouncers](cscli_bouncers.md)	 - Manage bouncers
+* [cscli bouncers](cscli_bouncers.md)	 - Manage bouncers [requires local API]
 
 

--- a/docs/v1.X/docs/cscli/cscli_bouncers_list.md
+++ b/docs/v1.X/docs/cscli/cscli_bouncers_list.md
@@ -36,6 +36,6 @@ cscli bouncers list
 
 ### SEE ALSO
 
-* [cscli bouncers](cscli_bouncers.md)	 - Manage bouncers
+* [cscli bouncers](cscli_bouncers.md)	 - Manage bouncers [requires local API]
 
 

--- a/docs/v1.X/docs/cscli/cscli_dashboard.md
+++ b/docs/v1.X/docs/cscli/cscli_dashboard.md
@@ -1,10 +1,12 @@
 ## cscli dashboard
 
-Manage your metabase dashboard container
+Manage your metabase dashboard container [requires local API]
 
 ### Synopsis
 
 Install/Start/Stop/Remove a metabase container exposing dashboard and metrics.
+Note: This command requires database direct access, so is intended to be run on Local API/master.
+		
 
 ### Examples
 

--- a/docs/v1.X/docs/cscli/cscli_dashboard_remove.md
+++ b/docs/v1.X/docs/cscli/cscli_dashboard_remove.md
@@ -41,6 +41,6 @@ cscli dashboard remove --force
 
 ### SEE ALSO
 
-* [cscli dashboard](cscli_dashboard.md)	 - Manage your metabase dashboard container
+* [cscli dashboard](cscli_dashboard.md)	 - Manage your metabase dashboard container [requires local API]
 
 

--- a/docs/v1.X/docs/cscli/cscli_dashboard_setup.md
+++ b/docs/v1.X/docs/cscli/cscli_dashboard_setup.md
@@ -46,6 +46,6 @@ cscli dashboard setup -l 0.0.0.0 -p 443 --password <password>
 
 ### SEE ALSO
 
-* [cscli dashboard](cscli_dashboard.md)	 - Manage your metabase dashboard container
+* [cscli dashboard](cscli_dashboard.md)	 - Manage your metabase dashboard container [requires local API]
 
 

--- a/docs/v1.X/docs/cscli/cscli_dashboard_start.md
+++ b/docs/v1.X/docs/cscli/cscli_dashboard_start.md
@@ -30,6 +30,6 @@ cscli dashboard start [flags]
 
 ### SEE ALSO
 
-* [cscli dashboard](cscli_dashboard.md)	 - Manage your metabase dashboard container
+* [cscli dashboard](cscli_dashboard.md)	 - Manage your metabase dashboard container [requires local API]
 
 

--- a/docs/v1.X/docs/cscli/cscli_dashboard_stop.md
+++ b/docs/v1.X/docs/cscli/cscli_dashboard_stop.md
@@ -30,6 +30,6 @@ cscli dashboard stop [flags]
 
 ### SEE ALSO
 
-* [cscli dashboard](cscli_dashboard.md)	 - Manage your metabase dashboard container
+* [cscli dashboard](cscli_dashboard.md)	 - Manage your metabase dashboard container [requires local API]
 
 

--- a/docs/v1.X/docs/cscli/cscli_machines.md
+++ b/docs/v1.X/docs/cscli/cscli_machines.md
@@ -1,13 +1,11 @@
 ## cscli machines
 
-Manage local API machines
+Manage local API machines [requires local API]
 
 ### Synopsis
 
-
-Machines Management.
-
-To list/add/delete/validate machines
+To list/add/delete/validate machines.
+Note: This command requires database direct access, so is intended to be run on the local API machine.
 
 
 ### Examples

--- a/docs/v1.X/docs/cscli/cscli_machines_add.md
+++ b/docs/v1.X/docs/cscli/cscli_machines_add.md
@@ -46,6 +46,6 @@ cscli machines add MyTestMachine --password MyPassword
 
 ### SEE ALSO
 
-* [cscli machines](cscli_machines.md)	 - Manage local API machines
+* [cscli machines](cscli_machines.md)	 - Manage local API machines [requires local API]
 
 

--- a/docs/v1.X/docs/cscli/cscli_machines_delete.md
+++ b/docs/v1.X/docs/cscli/cscli_machines_delete.md
@@ -33,6 +33,6 @@ cscli machines delete <machine_name>
 
 ### SEE ALSO
 
-* [cscli machines](cscli_machines.md)	 - Manage local API machines
+* [cscli machines](cscli_machines.md)	 - Manage local API machines [requires local API]
 
 

--- a/docs/v1.X/docs/cscli/cscli_machines_list.md
+++ b/docs/v1.X/docs/cscli/cscli_machines_list.md
@@ -36,6 +36,6 @@ cscli machines list
 
 ### SEE ALSO
 
-* [cscli machines](cscli_machines.md)	 - Manage local API machines
+* [cscli machines](cscli_machines.md)	 - Manage local API machines [requires local API]
 
 

--- a/docs/v1.X/docs/cscli/cscli_machines_validate.md
+++ b/docs/v1.X/docs/cscli/cscli_machines_validate.md
@@ -36,6 +36,6 @@ cscli machines validate <machine_name>
 
 ### SEE ALSO
 
-* [cscli machines](cscli_machines.md)	 - Manage local API machines
+* [cscli machines](cscli_machines.md)	 - Manage local API machines [requires local API]
 
 


### PR DESCRIPTION
 - fix #753  : provide user with clear & explicit messages when trying to run `cscli machines|bouncers|dashboard` on a machine that is not running local API
 - refresh cscli documentation
 - document how to preview documentation locally with mkdocs