### PR TITLE
add TimeNow in the exprlib helpers

### DIFF
--- a/docs/v1.X/docs/references/expressions.md
+++ b/docs/v1.X/docs/references/expressions.md
@@ -60,3 +60,9 @@ Returns the uppercase version of the string
 Returns true if the IP `IPStr` is contained in the IP range `RangeStr` (uses `net.ParseCIDR`)
 
 > IpInRange("1.2.3.4", "1.2.3.0/24")
+
+## `TimeNow() string`
+
+Return RFC3339 formatted time 
+
+> TimeNow()

--- a/pkg/exprhelpers/exprlib.go
+++ b/pkg/exprhelpers/exprlib.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	log "github.com/sirupsen/logrus"
@@ -39,6 +40,7 @@ func GetExprEnv(ctx map[string]interface{}) map[string]interface{} {
 		"RegexpInFile":   RegexpInFile,
 		"Upper":          Upper,
 		"IpInRange":      IpInRange,
+		"TimeNow":        TimeNow,
 	}
 	for k, v := range ctx {
 		ExprLib[k] = v
@@ -133,4 +135,8 @@ func IpInRange(ip string, ipRange string) bool {
 		return true
 	}
 	return false
+}
+
+func TimeNow() string {
+	return time.Now().Format(time.RFC3339)
 }

--- a/pkg/exprhelpers/exprlib_test.go
+++ b/pkg/exprhelpers/exprlib_test.go
@@ -379,7 +379,8 @@ func TestTimeNow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error parsing the return value of TimeNow: %s", err)
 	}
-	if time.Until(ti) > -1*time.Second {
+
+	if -1*time.Until(ti) > time.Second {
 		t.Fatalf("TimeNow func should return time.Now()")
 	}
 	log.Printf("test 'TimeNow()' : OK")

--- a/pkg/exprhelpers/exprlib_test.go
+++ b/pkg/exprhelpers/exprlib_test.go
@@ -379,7 +379,7 @@ func TestTimeNow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error parsing the return value of TimeNow: %s", err)
 	}
-	if ti.Sub(time.Now()) > time.Second {
+	if time.Until(ti) > -1*time.Second {
 		t.Fatalf("TimeNow func should return time.Now()")
 	}
 	log.Printf("test 'TimeNow()' : OK")

--- a/pkg/exprhelpers/exprlib_test.go
+++ b/pkg/exprhelpers/exprlib_test.go
@@ -2,6 +2,7 @@ package exprhelpers
 
 import (
 	"fmt"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -367,8 +368,19 @@ func TestUpper(t *testing.T) {
 	expectedStr := "TEST"
 
 	if Upper(testStr) != expectedStr {
-		t.Fatalf("Upper() should returned 1.5 as a float")
+		t.Fatalf("Upper() should returned test in upper case")
 	}
 
 	log.Printf("test 'Upper()' : OK")
+}
+
+func TestTimeNow(t *testing.T) {
+	ti, err := time.Parse(time.RFC3339, TimeNow())
+	if err != nil {
+		t.Fatalf("Error parsing the return value of TimeNow: %s", err)
+	}
+	if ti.Sub(time.Now()) > time.Second {
+		t.Fatalf("TimeNow func should return time.Now()")
+	}
+	log.Printf("test 'TimeNow()' : OK")
 }

--- a/pkg/parser/enrich.go
+++ b/pkg/parser/enrich.go
@@ -50,25 +50,26 @@ func Loadplugin(path string) ([]EnricherCtx, error) {
 }
 
 func GenDateParse(date string) (string, time.Time) {
-	var retstr string
-	var layouts = [...]string{
-		time.RFC3339,
-		"02/Jan/2006:15:04:05 -0700",
-		"Mon Jan 2 15:04:05 2006",
-		"02-Jan-2006 15:04:05 europe/paris",
-		"01/02/2006 15:04:05",
-		"2006-01-02 15:04:05.999999999 -0700 MST",
-		//Jan  5 06:25:11
-		"Jan  2 15:04:05",
-		"Mon Jan 02 15:04:05.000000 2006",
-		"2006-01-02T15:04:05Z07:00",
-		"2006/01/02",
-		"2006/01/02 15:04",
-		"2006-01-02",
-		"2006-01-02 15:04",
-		"2006/01/02 15:04:05",
-		"2006-01-02 15:04:05",
-	}
+	var (
+		layouts = [...]string{
+			time.RFC3339,
+			"02/Jan/2006:15:04:05 -0700",
+			"Mon Jan 2 15:04:05 2006",
+			"02-Jan-2006 15:04:05 europe/paris",
+			"01/02/2006 15:04:05",
+			"2006-01-02 15:04:05.999999999 -0700 MST",
+			//Jan  5 06:25:11
+			"Jan  2 15:04:05",
+			"Mon Jan 02 15:04:05.000000 2006",
+			"2006-01-02T15:04:05Z07:00",
+			"2006/01/02",
+			"2006/01/02 15:04",
+			"2006-01-02",
+			"2006-01-02 15:04",
+			"2006/01/02 15:04:05",
+			"2006-01-02 15:04:05",
+		}
+	)
 
 	for _, dateFormat := range layouts {
 		t, err := time.Parse(dateFormat, date)
@@ -85,7 +86,14 @@ func GenDateParse(date string) (string, time.Time) {
 			return string(retstr), t
 		}
 	}
-	return retstr, time.Time{}
+
+	now := time.Now()
+	retstr, err := now.MarshalText()
+	if err != nil {
+		log.Warningf("Failed marshaling current time")
+		return "", time.Time{}
+	}
+	return string(retstr), now
 }
 
 func ParseDate(in string, p *types.Event, x interface{}) (map[string]string, error) {

--- a/pkg/parser/enrich.go
+++ b/pkg/parser/enrich.go
@@ -99,11 +99,14 @@ func GenDateParse(date string) (string, time.Time) {
 func ParseDate(in string, p *types.Event, x interface{}) (map[string]string, error) {
 
 	var ret map[string]string = make(map[string]string)
-
+	log.Printf("Prout")
 	tstr, tbin := GenDateParse(in)
 	if !tbin.IsZero() {
+		log.Printf("Here")
 		ret["MarshaledTime"] = string(tstr)
 		return ret, nil
 	}
+	log.Printf("not Here")
+
 	return nil, nil
 }

--- a/pkg/parser/enrich.go
+++ b/pkg/parser/enrich.go
@@ -99,14 +99,11 @@ func GenDateParse(date string) (string, time.Time) {
 func ParseDate(in string, p *types.Event, x interface{}) (map[string]string, error) {
 
 	var ret map[string]string = make(map[string]string)
-	log.Printf("Prout")
 	tstr, tbin := GenDateParse(in)
 	if !tbin.IsZero() {
-		log.Printf("Here")
 		ret["MarshaledTime"] = string(tstr)
 		return ret, nil
 	}
-	log.Printf("not Here")
 
 	return nil, nil
 }

--- a/pkg/parser/runtime.go
+++ b/pkg/parser/runtime.go
@@ -133,8 +133,11 @@ func (n *Node) ProcessStatics(statics []types.ExtraField, event *types.Event) er
 		}
 
 		if value == "" {
-			clog.Debugf("Empty value for %s, skip.", printStaticTarget(static))
-			continue
+			//allow ParseDate to have empty input
+			if static.Method != "ParseDate" {
+				clog.Debugf("Empty value for %s, skip.", printStaticTarget(static))
+				continue
+			}
 		}
 
 		if static.Method != "" {


### PR DESCRIPTION
* add an helper for getting the current time. Fixes https://github.com/crowdsecurity/crowdsec/issues/736.
* Improve ParseDate by not letting unknown date getting through. time.Now() is used when `evt.TimeStr` is not parseable. should fix https://github.com/crowdsecurity/crowdsec/issues/739

