### PR TITLE
add docker option to specify local timezone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN /bin/bash wizard.sh --docker-mode
 RUN cscli hub update && cscli collections install crowdsecurity/linux
 
 FROM alpine:latest
-RUN wget https://github.com/mikefarah/yq/releases/download/v4.4.1/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.4.1/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq && apk add tzdata
 COPY --from=build /etc/crowdsec /etc/crowdsec
 COPY --from=build /var/lib/crowdsec /var/lib/crowdsec
 COPY --from=build /usr/local/bin/crowdsec /usr/local/bin/crowdsec

--- a/docker/README.md
+++ b/docker/README.md
@@ -79,6 +79,7 @@ If you want to be able to restart/stop your container and keep the same DB `-v /
 * `JOURNALCTL_FILTER`       - Process a single journalctl output in time-machine : `-e JOURNALCTL_FILTER="<journalctl_filter>"`
 * `TYPE`                    - [`Labels.type`](https://docs.crowdsec.net/Crowdsec/v1/references/acquisition/) for file in time-machine : `-e TYPE="<type>"`
 * `TEST_MODE`               - Only test configs (default: `false`) : `-e TEST_MODE="<true|false>"`
+* `TZ`                      - Set the [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to ensure logs have a local timestamp.
 * `DISABLE_AGENT`           - Only test configs (default: `false`) : `-e DISABLE_AGENT="<true|false>"`
 * `DISABLE_LOCAL_API`       - Disable local API (default: `false`) : `-e DISABLE_API="<true|false>"`
 * `DISABLE_ONLINE_API`      - Disable Online API registration for signal sharing (default: `false`) : `-e DISABLE_ONLINE_API="<true|false>"`


### PR DESCRIPTION
This pull request allows to specify the timezone to use for the container, even if your operating system does not have the file `/etc/timezone` available. If you have for example a Synology NAS as docker host you do not have this file and can not send a proper timezone to the container.

The package `tzdate` allows to pass a timezone as docker argument to the container. This makes the console logs more readable as they print the timestamp as local timestamp. A list of the available time zones is available here and also linked in the related `docker/Readme.md` file: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

An example docker file which shows the usage with Europe/Berlin timezone looks like this:

```
version: "3.7"
services:
  crowdsec:
    image: crowdsecurity/crowdsec
    environment:
      - TZ=Europe/Berlin
      - COLLECTIONS=crowdsecurity/nginx
      - REGISTER_TO_ONLINE_API=true
    restart: unless-stopped
```