### PR TITLE
fix #781 - avoid unconsistent body : do not send NbDeleted on error

### DIFF
--- a/pkg/apiserver/controllers/v1/alerts.go
+++ b/pkg/apiserver/controllers/v1/alerts.go
@@ -196,12 +196,11 @@ func (c *Controller) DeleteAlerts(gctx *gin.Context) {
 	nbDeleted, err := c.DBClient.DeleteAlertWithFilter(gctx.Request.URL.Query())
 	if err != nil {
 		c.HandleDBErrors(gctx, err)
+		return
 	}
-
 	deleteAlertsResp := models.DeleteAlertsResponse{
 		NbDeleted: strconv.Itoa(nbDeleted),
 	}
-
 	gctx.JSON(http.StatusOK, deleteAlertsResp)
 	return
 }


### PR DESCRIPTION
fix #781 : now return only error and avoid confusing `cscli` when decoding body :

```
▶ ./cscli -c dev.yaml alerts delete --ip 1.2.3.5 
FATA[28-05-2021 11:08:51 AM] Unable to delete alerts : API error: event with alert ID '2': unable to delete 
```

