### PR TITLE
ignore CI when it concern documentation

### DIFF
--- a/.github/workflows/ci_functests-install.yml
+++ b/.github/workflows/ci_functests-install.yml
@@ -4,9 +4,17 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
 
 jobs:
   build:

--- a/.github/workflows/ci_go-test.yml
+++ b/.github/workflows/ci_go-test.yml
@@ -3,8 +3,16 @@ name: tests
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
 
 jobs:
 

--- a/.github/workflows/ci_golangci-lint.yml
+++ b/.github/workflows/ci_golangci-lint.yml
@@ -5,7 +5,15 @@ on:
       - v*
     branches:
       - master
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/ci_hub-tests.yml
+++ b/.github/workflows/ci_hub-tests.yml
@@ -3,8 +3,16 @@ name: Hub-CI
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
 
 jobs:
   build:

--- a/.github/workflows/dispatch_test_debpkg.yaml
+++ b/.github/workflows/dispatch_test_debpkg.yaml
@@ -3,8 +3,16 @@ name: Dispatch to deb pkg repo for tests
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
 
 jobs:
   dispatch:


### PR DESCRIPTION
Ignore some workflows on : 
- `docs/**`
- `mkdocs.yml`
- `README.md`