### PR TITLE
update listen_uri in config.yaml

### DIFF
--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -226,7 +226,13 @@ cscli machines add MyTestMachine --password MyPassword
 				if csConfig.API.Client != nil && csConfig.API.Client.Credentials != nil && csConfig.API.Client.Credentials.URL != "" {
 					apiURL = csConfig.API.Client.Credentials.URL
 				} else if csConfig.API.Server != nil && csConfig.API.Server.ListenURI != "" {
-					apiURL = "http://" + csConfig.API.Server.ListenURI
+					if !strings.HasPrefix(csConfig.API.Server.ListenURI, "http") {
+						if csConfig.API.Server.TLS == nil {
+							apiURL = "http://" + csConfig.API.Server.ListenURI
+						} else {
+							apiURL = "https://" + csConfig.API.Server.ListenURI
+						}
+					}
 				} else {
 					log.Fatalf("unable to dump an api URL. Please provide it in your configuration or with the -u parameter")
 				}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -34,7 +34,7 @@ api:
     credentials_path: /etc/crowdsec/local_api_credentials.yaml
   server:
     log_level: info
-    listen_uri: 127.0.0.1:8080
+    listen_uri: http://127.0.0.1:8080
     profiles_path: /etc/crowdsec/profiles.yaml
     online_client: # Crowdsec API credentials (to push signals and receive bad IPs)
       credentials_path: /etc/crowdsec/online_api_credentials.yaml

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -31,7 +31,7 @@ api:
     credentials_path: ./config/local_api_credentials.yaml
   server:
     #insecure_skip_verify: true
-    listen_uri: 127.0.0.1:8081
+    listen_uri: http://127.0.0.1:8081
     profiles_path: ./config/profiles.yaml
     tls:
       #cert_file: ./cert.pem

--- a/config/user.yaml
+++ b/config/user.yaml
@@ -31,7 +31,7 @@ api:
     credentials_path: /etc/crowdsec/local_api_credentials.yaml
   server:
     #log_level: info
-    listen_uri: 127.0.0.1:8080
+    listen_uri: http://127.0.0.1:8080
     profiles_path: /etc/crowdsec/profiles.yaml
     online_client: # Crowdsec API
       credentials_path: /etc/crowdsec/online_api_credentials.yaml

--- a/docs/v1.X/docs/references/crowdsec-config.md
+++ b/docs/v1.X/docs/references/crowdsec-config.md
@@ -49,7 +49,7 @@ api:
     credentials_path: /etc/crowdsec/local_api_credentials.yaml
   server:
     log_level: info
-    listen_uri: 127.0.0.1:8080
+    listen_uri: http://127.0.0.1:8080
     profiles_path: /etc/crowdsec/profiles.yaml
     use_forwarded_for_headers: false
     online_client: # Crowdsec API
@@ -134,7 +134,7 @@ api:
     credentials_path: <path_to_local_api_client_credential_file>
   server:
     log_level: (error|info|debug|trace>)
-    listen_uri: <listen_uri> # host:port
+    listen_uri: <listen_uri> # http(s)://host:port
     profiles_path: <path_to_profile_file>
     use_forwarded_for_headers: <true|false>
     online_client:
@@ -319,7 +319,7 @@ api:
     credentials_path: <path_to_local_api_client_credential_file>
   server:
     log_level: (error|info|debug|trace>)
-    listen_uri: <listen_uri> # host:port
+    listen_uri: <listen_uri> # http(s)://host:port
     profiles_path: <path_to_profile_file>
     use_forwarded_for_headers: (true|false)
     online_client:
@@ -369,7 +369,7 @@ server:
 #### `listen_uri`
 > string
 
-Address and port listen configuration, the form `host:port`.
+URI for LAPI server on the form `http(s)://host:port`. 
 
 #### `profiles_path`
 > string

--- a/pkg/acquisition/tests/test.log
+++ b/pkg/acquisition/tests/test.log
@@ -1,1 +1,6 @@
 one log line
+ratata0
+ratata1
+ratata2
+ratata3
+ratata4

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -189,8 +189,15 @@ func NewServer(config *csconfig.LocalApiServerCfg) (*APIServer, error) {
 		return &APIServer{}, err
 	}
 
+	var url string
+	if strings.HasPrefix(config.ListenURI, "https://") && config.TLS != nil {
+		log.Fatalf("Trying to start LAPI on https with no TLS config")
+	}
+	url = strings.TrimPrefix(config.ListenURI, "http://")
+	url = strings.TrimPrefix(config.ListenURI, "https://")
+
 	return &APIServer{
-		URL:            config.ListenURI,
+		URL:            url,
 		TLS:            config.TLS,
 		logFile:        logFile,
 		dbClient:       dbClient,

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -246,7 +246,7 @@ func TestLoggingDebugToFileConfig(t *testing.T) {
 		Flush:  &flushConfig,
 	}
 	cfg := csconfig.LocalApiServerCfg{
-		ListenURI: "127.0.0.1:8080",
+		ListenURI: "http://127.0.0.1:8080",
 		LogMedia:  "file",
 		LogDir:    ".",
 		DbConfig:  &dbconfig,
@@ -309,7 +309,7 @@ func TestLoggingErrorToFileConfig(t *testing.T) {
 		Flush:  &flushConfig,
 	}
 	cfg := csconfig.LocalApiServerCfg{
-		ListenURI: "127.0.0.1:8080",
+		ListenURI: "http://127.0.0.1:8080",
 		LogMedia:  "file",
 		LogDir:    ".",
 		DbConfig:  &dbconfig,

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -220,7 +220,7 @@ func TestUnknownPath(t *testing.T) {
 
 /*
 
-ListenURI              string              `yaml:"listen_uri,omitempty"` //127.0.0.1:8080
+ListenURI              string              `yaml:"listen_uri,omitempty"` //http://127.0.0.1:8080
 	TLS                    *TLSCfg             `yaml:"tls"`
 	DbConfig               *DatabaseCfg        `yaml:"-"`
 	LogDir                 string              `yaml:"-"`


### PR DESCRIPTION
update listen_uri in config.yaml to `http(s)://host:port`. Update the documentation accordingly. The old way still (secretly) works.