### PR TITLE
add support for 'expression' (fix #822) in grok patterns

### DIFF
--- a/pkg/parser/tests/base-grok-expression/base-grok.yaml
+++ b/pkg/parser/tests/base-grok-expression/base-grok.yaml
@@ -1,0 +1,13 @@
+filter: "evt.Line.Labels.type == 'testlog'"
+debug: true
+onsuccess: next_stage
+name: tests/base-grok
+pattern_syntax:
+  MYCAP1: ".*"
+nodes:
+  - grok:
+      pattern: ^xxheader %{MYCAP1:extracted_value} trailing stuff$
+      expression: evt.Line.Raw
+statics:
+  - meta: log_type
+    value: parsed_testlog

--- a/pkg/parser/tests/base-grok-expression/parsers.yaml
+++ b/pkg/parser/tests/base-grok-expression/parsers.yaml
@@ -1,0 +1,2 @@
+ - filename: {{.TestDirectory}}/base-grok.yaml
+   stage: s00-raw

--- a/pkg/parser/tests/base-grok-expression/test.yaml
+++ b/pkg/parser/tests/base-grok-expression/test.yaml
@@ -1,0 +1,28 @@
+#these are the events we input into parser
+lines:
+  - Line:
+      Labels:
+        #this one will be checked by a filter
+        type: testlog
+      Raw: xxheader VALUE1 trailing stuff
+  - Line:
+  #see tricky case : first one is nginx via syslog, the second one is local nginx :)
+      Labels:
+        #this one will be checked by a filter
+        type: testlog
+      Raw: xxheader VALUE2 trailing stuff
+#these are the results we expect from the parser
+results:
+  - Meta:
+      log_type: parsed_testlog
+    Parsed:
+      extracted_value: VALUE1
+    Process: true
+    Stage: s00-raw
+  - Meta:
+      log_type: parsed_testlog
+    Parsed:
+      extracted_value: VALUE2
+    Process: true
+    Stage: s00-raw
+

--- a/pkg/types/grok_pattern.go
+++ b/pkg/types/grok_pattern.go
@@ -33,6 +33,9 @@ type GrokPattern struct {
 	RegexpValue string `yaml:"pattern,omitempty"`
 	//the runtime form of regexpname / regexpvalue
 	RunTimeRegexp *grokky.Pattern `json:"-"` //the actual regexp
+	//the output of the expression is going to be the source for regexp
+	ExpValue     string      `yaml:"expression,omitempty"`
+	RunTimeValue *vm.Program `json:"-"` //the actual compiled filter
 	//a grok can contain statics that apply if pattern is successfull
 	Statics []ExtraField `yaml:"statics,omitempty"`
 }


### PR DESCRIPTION
 - grok pattern can be fed either from a given field in `evt.Parsed` (as done with `apply_on`) or directly from the result of `expression` (that must be a string)

it would allow for parsers such as [GELF](https://discourse.crowdsec.net/t/nginx-logs-in-gelf-json-format/53) to be done in one parsing stage :

```yaml
filter: "evt.Line.Labels.type == 'nginx-gelp'"
onsuccess: next_stage
debug: true
name: crowdsecurity/nginx-logs
description: "Parse nginx access and error logs"
grok:
  pattern: '%{WORD:method} %{URIPATHPARAM:request} HTTP/%{NUMBER:http_version}'
  expression: JsonExtract(evt.Line.Raw, "request")
statics:
  - target: evt.StrTime
    expression: JsonExtract(evt.Line.Raw, "timestamp")
  - parsed: "logsource"
    value: "gelf-nginx"
  - parsed: remote_addr
    expression: JsonExtract(evt.Line.Raw, "remote_addr")   
  - parsed: remote_user
    expression: JsonExtract(evt.Line.Raw, "remote_user")   
  - meta: source_ip
    expression: JsonExtract(evt.Line.Raw, "remote_addr")
  - meta: http_status
    expression: JsonExtract(evt.Line.Raw, "response_status")
  - meta: http_path
    expression: JsonExtract(evt.Line.Raw, "request")
  - meta: log_type
    value: http_access-log
  - meta: service
    value: http
  - parsed: http_user_agent
    expression: JsonExtract(evt.Line.Raw, "http_user_agent")
  - parsed: http_referer
    expression: JsonExtract(evt.Line.Raw, "http_referrer")
  - parsed: target_fqdn
    expression: JsonExtract(evt.Line.Raw, "host")
  - parsed: method
    expression: JsonExtract(evt.Line.Raw, "request_method")
  - parsed: body_bytes_sent
    expression: JsonExtract(evt.Line.Raw, "body_bytes_sent")
  - parsed: http_version
    expression: JsonExtract(evt.Line.Raw, "http_version")   
  - parsed: status
    expression: JsonExtract(evt.Line.Raw, "response_status")
  - parsed: full_request
    expression: JsonExtract(evt.Line.Raw, "request")
```

