### PR TITLE
Trivial typo fix adresses -> addresses in msgbox

### DIFF
--- a/wizard.sh
+++ b/wizard.sh
@@ -251,7 +251,7 @@ install_collection() {
 
     ${CSCLI_BIN_INSTALLED} parsers install "crowdsecurity/whitelists" > /dev/null 2>&1 || log_err "fail to install collection crowdsec/whitelists"
     if [[ ${SILENT} == "false" ]]; then
-        whiptail --msgbox "Out of safety, I installed a parser called 'crowdsecurity/whitelists'. This one will prevent private IP adresses from being banned, feel free to remove it any time." 20 50
+        whiptail --msgbox "Out of safety, I installed a parser called 'crowdsecurity/whitelists'. This one will prevent private IP addresses from being banned, feel free to remove it any time." 20 50
     fi
 
     if [[ ${SILENT} == "false" ]]; then


### PR DESCRIPTION
A minor change to correct the spelling of the word addresses in a wizard message box during installation