### PR TITLE
Fix unset environment variable

### DIFF
--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -46,7 +46,7 @@ if [ "$CONFIG_FILE" != "" ]; then
     ARGS="-c $CONFIG_FILE"
 fi
 if [ "$FILE_PATH" != "" ]; then
-    ARGS="$ARGS -file $FILE"
+    ARGS="$ARGS -file $FILE_PATH"
 fi
 if [ "$JOURNALCTL_FILTER" != "" ]; then
     ARGS="$ARGS -jfilter $JOURNALCTL_FILTER"


### PR DESCRIPTION
According to your instructions for running CrowdSec with Docker, the following environment variable must be set to process a single file: ```-e FILE_PATH="<file_path>"``` 
(see https://github.com/crowdsecurity/crowdsec/blob/master/docker/README.md#environment-variables)

But in the script docker_start.sh the environment variable FILE is expected, which is not described anywhere:
https://github.com/crowdsecurity/crowdsec/blob/b29730520f2119bd74f365beb603a5bd6d1b01ed/docker/docker_start.sh#L48-L49

I suggest to use the already set ```$FILE_PATH```