### PR TITLE
refuse to run the dashboard if not on amd64

### DIFF
--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"unicode"
@@ -53,6 +54,11 @@ cscli dashboard stop
 cscli dashboard remove
 `,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+
+			if runtime.GOARCH != "amd64" {
+				log.Fatalf("cscli dashboard is only available on amd64, but you are running %s", runtime.GOARCH)
+			}
+
 			if err := csConfig.LoadAPIServer(); err != nil || csConfig.DisableAPI {
 				log.Fatal("Local API is disabled, please run this command on the local API machine")
 			}


### PR DESCRIPTION
Metabase only provides an amd64 docker image, so detect if we are running on any other arch, and don't event attempt to start the container.