### PR TITLE
check if api:client is present

### DIFF
--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -195,7 +195,7 @@ cscli machines add MyTestMachine --password MyPassword
 			/*check if file already exists*/
 			if outputFile != "" {
 				dumpFile = outputFile
-			} else if csConfig.API.Client.CredentialsFilePath != "" {
+			} else if csConfig.API.Client != nil && csConfig.API.Client.CredentialsFilePath != "" {
 				dumpFile = csConfig.API.Client.CredentialsFilePath
 			}
 


### PR DESCRIPTION
avoid crash when using `cscli machines add -a` while config `api:client` section is missing
