### PR TITLE
Goroutine leak hunt

### DIFF
--- a/pkg/apiclient/client.go
+++ b/pkg/apiclient/client.go
@@ -119,7 +119,6 @@ func (e *ErrorResponse) Error() string {
 
 func newResponse(r *http.Response) *Response {
 	response := &Response{Response: r}
-	//response.populatePageValues()
 	return response
 }
 

--- a/pkg/apiclient/client_http.go
+++ b/pkg/apiclient/client_http.go
@@ -57,7 +57,9 @@ func (c *ApiClient) Do(ctx context.Context, req *http.Request, v interface{}) (*
 	}
 
 	resp, err := c.client.Do(req)
-
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		// If we got an error, and the context has been canceled,
 		// the context's error is probably more useful.
@@ -80,9 +82,7 @@ func (c *ApiClient) Do(ctx context.Context, req *http.Request, v interface{}) (*
 	}
 
 	response := newResponse(resp)
-	if resp.Body != nil {
-		defer resp.Body.Close()
-	}
+
 	err = CheckResponse(resp)
 	if err != nil {
 		return response, err

--- a/pkg/apiclient/client_http.go
+++ b/pkg/apiclient/client_http.go
@@ -80,7 +80,9 @@ func (c *ApiClient) Do(ctx context.Context, req *http.Request, v interface{}) (*
 	}
 
 	response := newResponse(resp)
-
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	err = CheckResponse(resp)
 	if err != nil {
 		return response, err

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -276,8 +276,12 @@ func (s *APIServer) Shutdown() error {
 	}
 
 	//close io.writer logger given to gin
-	gin.DefaultErrorWriter.(*io.PipeWriter).Close()
-	gin.DefaultWriter.(*io.PipeWriter).Close()
+	if pipe, ok := gin.DefaultErrorWriter.(*io.PipeWriter); ok {
+		pipe.Close()
+	}
+	if pipe, ok := gin.DefaultWriter.(*io.PipeWriter); ok {
+		pipe.Close()
+	}
 	s.httpServerTomb.Kill(nil)
 	s.httpServerTomb.Wait()
 	return nil

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -283,6 +283,8 @@ func (s *APIServer) Shutdown() error {
 		pipe.Close()
 	}
 	s.httpServerTomb.Kill(nil)
-	s.httpServerTomb.Wait()
+	if err := s.httpServerTomb.Wait(); err != nil {
+		return errors.Wrap(err, "while waiting on httpServerTomb")
+	}
 	return nil
 }


### PR DESCRIPTION
thanks @sbs2001 for spotting a leak of goroutines on reload :
 - ensure we're closing io.pipewriter given to gin
 - ensure we're always closing body from api client
 - ensure we're killing the remaining httpserver tomb

