### PR TITLE
add a hook on fatal/panic to ensure we're logging to stderr as well

### DIFF
--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/writer"
 
 	"gopkg.in/tomb.v2"
 )
@@ -241,6 +242,13 @@ func main() {
 		cwversion.Show()
 		os.Exit(0)
 	}
+	log.AddHook(&writer.Hook{ // Send logs with level higher than warning to stderr
+		Writer: os.Stderr,
+		LogLevels: []log.Level{
+			log.PanicLevel,
+			log.FatalLevel,
+		},
+	})
 
 	cConfig, err = csconfig.NewConfig(flags.ConfigFile, flags.DisableAgent, flags.DisableAPI)
 	if err != nil {


### PR DESCRIPTION
the goal of this MR is to ensure that when we're failing during startup, the fatal log will show in `systemctl status crowdsec` :

```
● crowdsec.service - Crowdsec agent
     Loaded: loaded (/etc/systemd/system/crowdsec.service; enabled; vendor preset: enabled)
     Active: failed (Result: exit-code) since Wed 2021-08-04 19:11:04 CEST; 9ms ago
    Process: 84006 ExecStartPre=/usr/local/bin/crowdsec -c /etc/crowdsec/config.yaml -t (code=exited, status=0/SUCCESS)
    Process: 84040 ExecStart=/usr/local/bin/crowdsec -c /etc/crowdsec/config.yaml (code=exited, status=1/FAILURE)
   Main PID: 84040 (code=exited, status=1/FAILURE)

Aug 04 19:11:03 zeroed systemd[1]: Starting Crowdsec agent...
Aug 04 19:11:04 zeroed crowdsec[84040]: time="04-08-2021 19:11:04" level=fatal msg="listen tcp 127.0.0.1:8080: bind: address already in use"
Aug 04 19:11:04 zeroed systemd[1]: crowdsec.service: Main process exited, code=exited, status=1/FAILURE
Aug 04 19:11:04 zeroed systemd[1]: crowdsec.service: Failed with result 'exit-code'.
Aug 04 19:11:04 zeroed systemd[1]: Failed to start Crowdsec agent.

```