### PR TITLE
Update output plugins

### DIFF
--- a/config/profiles.yaml
+++ b/config/profiles.yaml
@@ -5,4 +5,8 @@ filters:
 decisions:
  - type: ban
    duration: 4h
+# notifications:
+#   - slack_default  # Set the webhook in /etc/crowdsec/notifications/slack.yaml before enabling this.
+#   - splunk_default # Set the splunk url and token in /etc/crowdsec/notifications/splunk.yaml  before enabling this.
+#   - http_default # Set the required http parameters in  /etc/crowdsec/notifications/http.yaml before enabling this.
 on_success: break

--- a/pkg/csprofiles/csprofiles.go
+++ b/pkg/csprofiles/csprofiles.go
@@ -71,9 +71,6 @@ func EvaluateProfile(profile *csconfig.ProfileCfg, Alert *models.Alert) ([]*mode
 		})
 	}
 	matched := false
-	if !Alert.Remediation {
-		return nil, matched, nil
-	}
 	for eIdx, expression := range profile.RuntimeFilters {
 		output, err := expr.Run(expression, exprhelpers.GetExprEnv(map[string]interface{}{"Alert": Alert}))
 		if err != nil {

--- a/plugins/notifications/http/http.yaml
+++ b/plugins/notifications/http/http.yaml
@@ -1,7 +1,7 @@
 # Don't change this
 type: http
 
-name: <NAME> # this must match with the registered plugin in the profile
+name: http_default # this must match with the registered plugin in the profile
 
 format: |  # This template receives list of models.Alert objects. The request body would contain this. 
   CrowdSec detected {{len .}} attacks

--- a/plugins/notifications/http/http.yaml
+++ b/plugins/notifications/http/http.yaml
@@ -1,9 +1,15 @@
 # Don't change this
 type: http
 
-name: <NAME>
+name: <NAME> # this must match with the registered plugin in the profile
 
-format: <GO_TEMPLATE>  # http payload would contain the formatted text. 
+format: |  # This template receives list of models.Alert objects. The request body would contain this. 
+  CrowdSec detected {{len .}} attacks
+  {{range .}}
+    {{range .Decisions}}
+      Malicious IPs are {{.Value}}
+    {{end}}
+  {{end}}
 
 url: <HTTP_url> # plugin will make requests to this url. Eg value https://www.example.com/
 

--- a/plugins/notifications/slack/slack.yaml
+++ b/plugins/notifications/slack/slack.yaml
@@ -1,9 +1,15 @@
 # Don't change this
 type: slack
 
-name: <NAME>
+name: <NAME> # this must match with the registered plugin in the profile
 
-format: <GO_TEMPLATE> 
+format: |  # This template receives list of models.Alert objects
+  CrowdSec detected {{len .}} attacks
+  {{range .}}
+    {{range .Decisions}}
+      Malicious IPs are {{.Value}}
+    {{end}}
+  {{end}}
 
 webhook: <WEBHOOK_URL>
 

--- a/plugins/notifications/slack/slack.yaml
+++ b/plugins/notifications/slack/slack.yaml
@@ -1,7 +1,7 @@
 # Don't change this
 type: slack
 
-name: <NAME> # this must match with the registered plugin in the profile
+name: slack_default # this must match with the registered plugin in the profile
 
 format: |  # This template receives list of models.Alert objects
   CrowdSec detected {{len .}} attacks

--- a/plugins/notifications/splunk/splunk.yaml
+++ b/plugins/notifications/splunk/splunk.yaml
@@ -1,7 +1,7 @@
 # Don't change this
 type: splunk
 
-name: <NAME> # this must match with the registered plugin in the profile
+name: splunk_default # this must match with the registered plugin in the profile
 
 format: |  # This template receives list of models.Alert objects
   CrowdSec detected {{len .}} attacks

--- a/plugins/notifications/splunk/splunk.yaml
+++ b/plugins/notifications/splunk/splunk.yaml
@@ -1,9 +1,15 @@
 # Don't change this
 type: splunk
 
-name: <NAME>
+name: <NAME> # this must match with the registered plugin in the profile
 
-format: <GO_TEMPLATE>  # splunk event value
+format: |  # This template receives list of models.Alert objects
+  CrowdSec detected {{len .}} attacks
+  {{range .}}
+    {{range .Decisions}}
+      Malicious IPs are {{.Value}}
+    {{end}}
+  {{end}}
 
 url: <SPLUNK_HTTP_URL>
 


### PR DESCRIPTION
Implements @AlteredCoder 's suggestions : 

- In the plugins configuration file, let everything by default, only the webhook (for slack for example) will have to be edited by the user 
- Add log.Infof() when a plugin has been registered
- Have a working format message for the slack plugin, actually the one in the pull request doesn't work