### PR TITLE
Rpm dep

### DIFF
--- a/rpm/SPECS/crowdsec.spec
+++ b/rpm/SPECS/crowdsec.spec
@@ -14,7 +14,6 @@ Patch2:         config.patch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:  git
-BuildRequires:  golang >= 1.14
 BuildRequires:  make
 BuildRequires:  jq
 BuildRequires:  systemd


### PR DESCRIPTION
remove golang dep in spec file as it's taken care of when building by using official golang source