### PR TITLE
fix usage of regex.Match in cloudwatch module

### DIFF
--- a/pkg/acquisition/modules/cloudwatch/cloudwatch.go
+++ b/pkg/acquisition/modules/cloudwatch/cloudwatch.go
@@ -329,7 +329,7 @@ func (cw *CloudwatchSource) LogStreamManager(in chan LogStreamTailConfig, outCha
 			}
 
 			if cw.Config.StreamRegexp != nil {
-				match, err := regexp.Match(newStream.StreamName, []byte(*cw.Config.StreamRegexp))
+				match, err := regexp.Match(*cw.Config.StreamRegexp, []byte(newStream.StreamName))
 				if err != nil {
 					cw.logger.Warningf("invalid regexp : %s", err)
 				} else {


### PR DESCRIPTION
The parameters were inverted, which made the `stream_regexp` config parameter unusable.