### PR TITLE
fix hubtest CI

### DIFF
--- a/.github/workflows/ci_hubtest.yml
+++ b/.github/workflows/ci_hubtest.yml
@@ -42,7 +42,6 @@ jobs:
     - name: "Run tests"
       run: |
           cd hub/
-          git checkout hub_tests
           cscli hubtest run --all --clean
           echo "PARSERS_COV=$(cscli hubtest coverage --parsers --percent | cut -d '=' -f2)" >> $GITHUB_ENV
           echo "SCENARIOS_COV=$(cscli hubtest coverage --scenarios --percent | cut -d '=' -f2)" >> $GITHUB_ENV


### PR DESCRIPTION
Don't checkout on branch `hub_tests` in the hub when running hubtest CI