### PR TITLE
fix wizard.sh errors in docker and alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM golang:${GOVERSION}-alpine AS build
 
 WORKDIR /go/src/crowdsec
 
-RUN apk update && apk add --no-cache git jq gcc libc-dev make bash gettext binutils-gold
+# wizard.sh requires GNU coreutils
+RUN apk update && apk add --no-cache git jq gcc libc-dev make bash gettext binutils-gold coreutils
 
 COPY . .
 

--- a/wizard.sh
+++ b/wizard.sh
@@ -460,7 +460,7 @@ install_bins() {
     log_dbg "Installing crowdsec binaries"
     install -v -m 755 -D "${CROWDSEC_BIN}" "${CROWDSEC_BIN_INSTALLED}" 1> /dev/null || exit
     install -v -m 755 -D "${CSCLI_BIN}" "${CSCLI_BIN_INSTALLED}" 1> /dev/null || exit
-    systemctl is-active --quiet crowdsec
+    which systemctl && systemctl is-active --quiet crowdsec
     if [ $? -eq 0 ]; then
         systemctl stop crowdsec 
     fi
@@ -492,13 +492,14 @@ install_plugins(){
     mkdir -p /etc/crowdsec/notifications
 
     cp ${SLACK_PLUGIN_BINARY} ${CROWDSEC_PLUGIN_DIR}
-    cp -n ${SLACK_PLUGIN_CONFIG} /etc/crowdsec/notifications
-
     cp ${SPLUNK_PLUGIN_BINARY} ${CROWDSEC_PLUGIN_DIR}
-    cp -n ${SPLUNK_PLUGIN_CONFIG} /etc/crowdsec/notifications
-
     cp ${HTTP_PLUGIN_BINARY} ${CROWDSEC_PLUGIN_DIR}
-    cp -n ${HTTP_PLUGIN_CONFIG} /etc/crowdsec/notifications
+
+    if [[ ${DOCKER_MODE} == "false" ]]; then
+        cp -n ${SLACK_PLUGIN_CONFIG} /etc/crowdsec/notifications/
+        cp -n ${SPLUNK_PLUGIN_CONFIG} /etc/crowdsec/notifications/
+        cp -n ${HTTP_PLUGIN_CONFIG} /etc/crowdsec/notifications/
+    fi
 }
 
 check_running_bouncers() {


### PR DESCRIPTION
install coreutils under alpine; do not copy notification configuration under Docker; assume systemctl is not running if it does not exist