### PR TITLE
gitignore the files generated while building the debian package

### DIFF
--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,0 +1,7 @@
+# Generated during the build
+/crowdsec
+/files
+/*.substvars
+/*.log
+/*.debhelper
+/*-stamp

--- a/debian/debhelper-build-stamp
+++ b/debian/debhelper-build-stamp
@@ -1,1 +1,0 @@
-crowdsec


### PR DESCRIPTION
also removed debhelper-build-stamp