### PR TITLE
Remove additional `apk update` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:${GOVERSION}-alpine AS build
 WORKDIR /go/src/crowdsec
 
 # wizard.sh requires GNU coreutils
-RUN apk update && apk add --no-cache git jq gcc libc-dev make bash gettext binutils-gold coreutils
+RUN apk add --no-cache git jq gcc libc-dev make bash gettext binutils-gold coreutils
 
 COPY . .
 
@@ -13,7 +13,7 @@ RUN SYSTEM="docker" make release
 RUN cd crowdsec-v* && ./wizard.sh --docker-mode && cd -
 RUN cscli hub update && cscli collections install crowdsecurity/linux && cscli parsers install crowdsecurity/whitelists
 FROM alpine:latest
-RUN apk update --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community && apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community tzdata yq
+RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community tzdata yq
 COPY --from=build /etc/crowdsec /etc/crowdsec
 COPY --from=build /var/lib/crowdsec /var/lib/crowdsec
 COPY --from=build /usr/local/bin/crowdsec /usr/local/bin/crowdsec


### PR DESCRIPTION
There is no need to use `apk update` with `apk add --no-cache` when using `apk` on Alpine Linux, as using `--no-cache` will fetch the index every time and leave no local cache, so the index will always be the latest without temporary files remains in the image.

BTW, this was done in #689 before, but seemed to be reverted in #829 by unknown reason, I guess it's just accident?