### PR TITLE
fix #1083 : do not update/overwrite 'not installed' collections sub-items on 'cscli XX upgrade'

### DIFF
--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -149,7 +149,7 @@ func InstallItem(name string, obtype string, force bool) {
 			return
 		}
 	}
-	item, err := cwhub.DownloadLatest(csConfig.Hub, item, force)
+	item, err := cwhub.DownloadLatest(csConfig.Hub, item, force, false)
 	if err != nil {
 		log.Fatalf("error while downloading %s : %v", item.Name, err)
 	}
@@ -230,7 +230,7 @@ func UpgradeConfig(itemType string, name string, force bool) {
 				continue
 			}
 		}
-		v, err = cwhub.DownloadLatest(csConfig.Hub, v, force)
+		v, err = cwhub.DownloadLatest(csConfig.Hub, v, force, true)
 		if err != nil {
 			log.Fatalf("%s : download failed : %v", v.Name, err)
 		}
@@ -515,7 +515,7 @@ func silenceInstallItem(name string, obtype string) (string, error) {
 	if downloadOnly && it.Downloaded && it.UpToDate {
 		return fmt.Sprintf("%s is already downloaded and up-to-date", it.Name), nil
 	}
-	it, err := cwhub.DownloadLatest(csConfig.Hub, it, forceAction)
+	it, err := cwhub.DownloadLatest(csConfig.Hub, it, forceAction, false)
 	if err != nil {
 		return "", fmt.Errorf("error while downloading %s : %v", it.Name, err)
 	}

--- a/pkg/cwhub/cwhub_test.go
+++ b/pkg/cwhub/cwhub_test.go
@@ -189,7 +189,7 @@ func test_prepenv() *csconfig.Config {
 func testInstallItem(cfg *csconfig.Hub, t *testing.T, item Item) {
 
 	//Install the parser
-	item, err := DownloadLatest(cfg, item, false)
+	item, err := DownloadLatest(cfg, item, false, false)
 	if err != nil {
 		t.Fatalf("error while downloading %s : %v", item.Name, err)
 	}
@@ -246,7 +246,7 @@ func testUpdateItem(cfg *csconfig.Hub, t *testing.T, item Item) {
 		t.Fatalf("update: %s should NOT be up-to-date", item.Name)
 	}
 	//Update it + check status
-	item, err := DownloadLatest(cfg, item, true)
+	item, err := DownloadLatest(cfg, item, true, true)
 	if err != nil {
 		t.Fatalf("failed to update %s : %s", item.Name, err)
 	}

--- a/pkg/cwhub/download.go
+++ b/pkg/cwhub/download.go
@@ -76,7 +76,7 @@ func DownloadHubIdx(hub *csconfig.Hub) ([]byte, error) {
 }
 
 //DownloadLatest will download the latest version of Item to the tdir directory
-func DownloadLatest(hub *csconfig.Hub, target Item, overwrite bool) (Item, error) {
+func DownloadLatest(hub *csconfig.Hub, target Item, overwrite bool, updateOnly bool) (Item, error) {
 	var err error
 
 	log.Debugf("Downloading %s %s", target.Type, target.Name)
@@ -86,11 +86,15 @@ func DownloadLatest(hub *csconfig.Hub, target Item, overwrite bool) (Item, error
 			ptrtype := ItemTypes[idx]
 			for _, p := range ptr {
 				if val, ok := hubIdx[ptrtype][p]; ok {
-					log.Debugf("Download %s sub-item : %s %s", target.Name, ptrtype, p)
+					if val.Installed == false && updateOnly == true {
+						log.Debugf("skipping upgrade of %s : not installed", target.Name)
+						continue
+					}
+					log.Debugf("Download %s sub-item : %s %s (%t -> %t)", target.Name, ptrtype, p, target.Installed, updateOnly)
 					//recurse as it's a collection
 					if ptrtype == COLLECTIONS {
 						log.Tracef("collection, recurse")
-						hubIdx[ptrtype][p], err = DownloadLatest(hub, val, overwrite)
+						hubIdx[ptrtype][p], err = DownloadLatest(hub, val, overwrite, updateOnly)
 						if err != nil {
 							return target, errors.Wrap(err, fmt.Sprintf("while downloading %s", val.Name))
 						}
@@ -118,6 +122,10 @@ func DownloadLatest(hub *csconfig.Hub, target Item, overwrite bool) (Item, error
 			return target, fmt.Errorf("failed to download item : %s", err)
 		}
 	} else {
+		if target.Installed == false && updateOnly == true {
+			log.Debugf("skipping upgrade of %s : not installed", target.Name)
+			return target, nil
+		}
 		return DownloadItem(hub, target, overwrite)
 	}
 	return target, nil

--- a/pkg/cwhub/download.go
+++ b/pkg/cwhub/download.go
@@ -86,7 +86,7 @@ func DownloadLatest(hub *csconfig.Hub, target Item, overwrite bool, updateOnly b
 			ptrtype := ItemTypes[idx]
 			for _, p := range ptr {
 				if val, ok := hubIdx[ptrtype][p]; ok {
-					if val.Installed == false && updateOnly == true {
+					if !val.Installed && updateOnly {
 						log.Debugf("skipping upgrade of %s : not installed", target.Name)
 						continue
 					}
@@ -122,7 +122,7 @@ func DownloadLatest(hub *csconfig.Hub, target Item, overwrite bool, updateOnly b
 			return target, fmt.Errorf("failed to download item : %s", err)
 		}
 	} else {
-		if target.Installed == false && updateOnly == true {
+		if !target.Installed && updateOnly {
 			log.Debugf("skipping upgrade of %s : not installed", target.Name)
 			return target, nil
 		}


### PR DESCRIPTION
 - fix #1083 
 