### PR TITLE
add LD_OPTS to "go test"

### DIFF
--- a/cmd/crowdsec/Makefile
+++ b/cmd/crowdsec/Makefile
@@ -23,7 +23,7 @@ static: clean
 	$(GOBUILD) $(LD_OPTS_STATIC) -o $(CROWDSEC_BIN) -v -a -tags netgo
 
 test:
-	$(GOTEST) -v ./...
+	$(GOTEST) $(LD_OPTS) -v ./...
 
 clean:
 	rm -f $(CROWDSEC_BIN)


### PR DESCRIPTION
This is required when adding `-mod vendor` for example