### PR TITLE
fixed "help collections list" message

### DIFF
--- a/cmd/crowdsec-cli/collections.go
+++ b/cmd/crowdsec-cli/collections.go
@@ -136,8 +136,8 @@ func NewCollectionsCmd() *cobra.Command {
 
 	var cmdCollectionsList = &cobra.Command{
 		Use:               "list collection [-a]",
-		Short:             "List all collections or given one",
-		Long:              `List all collections or given one`,
+		Short:             "List all collections",
+		Long:              `List all collections`,
 		Example:           `cscli collections list`,
 		Args:              cobra.ExactArgs(0),
 		DisableAutoGenTag: true,
@@ -145,7 +145,7 @@ func NewCollectionsCmd() *cobra.Command {
 			ListItem(cwhub.COLLECTIONS, args, false, true)
 		},
 	}
-	cmdCollectionsList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List as well disabled items")
+	cmdCollectionsList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List disabled items as well")
 	cmdCollections.AddCommand(cmdCollectionsList)
 
 	return cmdCollections

--- a/cmd/crowdsec-cli/hub.go
+++ b/cmd/crowdsec-cli/hub.go
@@ -66,7 +66,7 @@ cscli hub update # Download list of available configurations from the hub
 			ListItem(cwhub.PARSERS_OVFLW, args, true, false)
 		},
 	}
-	cmdHubList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List as well disabled items")
+	cmdHubList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List disabled items as well")
 	cmdHub.AddCommand(cmdHubList)
 
 	var cmdHubUpdate = &cobra.Command{

--- a/cmd/crowdsec-cli/parsers.go
+++ b/cmd/crowdsec-cli/parsers.go
@@ -135,7 +135,7 @@ cscli parser list crowdsecurity/xxx`,
 			ListItem(cwhub.PARSERS, args, false, true)
 		},
 	}
-	cmdParsersList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List as well disabled items")
+	cmdParsersList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List disabled items as well")
 	cmdParsers.AddCommand(cmdParsersList)
 
 	return cmdParsers

--- a/cmd/crowdsec-cli/postoverflows.go
+++ b/cmd/crowdsec-cli/postoverflows.go
@@ -133,7 +133,7 @@ cscli postoverflows list crowdsecurity/xxx`,
 			ListItem(cwhub.PARSERS_OVFLW, args, false, true)
 		},
 	}
-	cmdPostOverflowsList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List as well disabled items")
+	cmdPostOverflowsList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List disabled items as well")
 	cmdPostOverflows.AddCommand(cmdPostOverflowsList)
 
 	return cmdPostOverflows

--- a/cmd/crowdsec-cli/scenarios.go
+++ b/cmd/crowdsec-cli/scenarios.go
@@ -135,7 +135,7 @@ cscli scenarios list crowdsecurity/xxx`,
 			ListItem(cwhub.SCENARIOS, args, false, true)
 		},
 	}
-	cmdScenariosList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List as well disabled items")
+	cmdScenariosList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List disabled items as well")
 	cmdScenarios.AddCommand(cmdScenariosList)
 
 	return cmdScenarios


### PR DESCRIPTION
The "collections list" does not accept a collection name as parameter, like "parsers list" and "scenarios list" do.