### PR TITLE
Use semicolon as delimiter for raw decision output

### DIFF
--- a/cmd/crowdsec-cli/decisions.go
+++ b/cmd/crowdsec-cli/decisions.go
@@ -54,6 +54,7 @@ func DecisionsToTable(alerts *models.GetAlertsResponse) error {
 	}
 	if csConfig.Cscli.Output == "raw" {
 		csvwriter := csv.NewWriter(os.Stdout)
+		csvwriter.Comma = ';'
 		err := csvwriter.Write([]string{"id", "source", "ip", "reason", "action", "country", "as", "events_count", "expiration", "simulated", "alert_id"})
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes https://github.com/crowdsecurity/crowdsec/issues/1124

Output:

```csv
id;source;ip;reason;action;country;as;events_count;expiration;simulated;alert_id
278909;cscli;AS:Amazon.com, Inc.;manual 'ban' from 'b436842423d302bb11cb6f1160d6cb30yQtfUHaUrWVyIrfz';ban;;" ";1;3h58m9.290502005s;false;352
278908;cscli;Ip:1.2.3.4;manual 'ban' from 'b436842423d302bb11cb6f1160d6cb30yQtfUHaUrWVyIrfz';ban;;" ";1;3h57m28.290494723s;false;351

```