### PR TITLE
Add option to print machine creds

### DIFF
--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -31,7 +31,6 @@ var apiURL string
 var outputFile string
 var forceAdd bool
 var autoAdd bool
-var print bool
 
 var (
 	passwordLength = 64

--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -31,6 +31,7 @@ var apiURL string
 var outputFile string
 var forceAdd bool
 var autoAdd bool
+var print bool
 
 var (
 	passwordLength = 64
@@ -256,7 +257,7 @@ cscli machines add MyTestMachine --password MyPassword
 			if err != nil {
 				log.Fatalf("unable to marshal api credentials: %s", err)
 			}
-			if dumpFile != "" {
+			if dumpFile != "" && dumpFile != "-" {
 				err = ioutil.WriteFile(dumpFile, apiConfigDump, 0644)
 				if err != nil {
 					log.Fatalf("write api credentials in '%s' failed: %s", dumpFile, err)


### PR DESCRIPTION
Fixes https://github.com/crowdsecurity/crowdsec/issues/1141

Prints creds to stdout if file is "-"

```
crowdsec-cli ) sudo ./crowdsec-cli machines add --auto -f -                                                                                   fix_1141 ⬆ ✭ ◼
INFO[06-01-2022 03:33:13 PM] Machine 'b436842423d302bb11cb6f1160d6cb30wnry4JBkDMFy44sD' successfully added to the local API 
url: http://127.0.0.1:8080
login: b436842423d302bb11cb6f1160d6cb30wnry4JBkDMFy44sD
password: WXLEoQ78FGoYdYM2BWn0fGvr208CirRfibgJFkrjSCNshv8O9YrM78Ymn4k5PzdV
```

**Note** The log is printed to stderr  and creds are printed to stdout allowing this in automations