### PR TITLE
Use override possibility in systemd file management in functional tests

### DIFF
--- a/scripts/func_tests/tests_base.sh
+++ b/scripts/func_tests/tests_base.sh
@@ -35,6 +35,8 @@ function wait_for_service {
         sleep 0.5
         ((count ++))
         if [[ $count == 21 ]]; then
+            systemctl status crowdsec
+            cat /var/log/crowdsec.log
             fail "$@"
         fi
     done

--- a/scripts/func_tests/tests_base.sh
+++ b/scripts/func_tests/tests_base.sh
@@ -35,8 +35,6 @@ function wait_for_service {
         sleep 0.5
         ((count ++))
         if [[ $count == 21 ]]; then
-            systemctl status crowdsec
-            sudo cat /var/log/crowdsec.log
             fail "$@"
         fi
     done

--- a/scripts/func_tests/tests_base.sh
+++ b/scripts/func_tests/tests_base.sh
@@ -36,7 +36,7 @@ function wait_for_service {
         ((count ++))
         if [[ $count == 21 ]]; then
             systemctl status crowdsec
-            cat /var/log/crowdsec.log
+            sudo cat /var/log/crowdsec.log
             fail "$@"
         fi
     done

--- a/scripts/func_tests/tests_post-install_0base.sh
+++ b/scripts/func_tests/tests_post-install_0base.sh
@@ -126,7 +126,8 @@ ${CSCLI_BIN} -c ./config/config_no_agent.yaml metrics || fail "failed to get met
 
 ${SYSTEMCTL} stop crowdsec
 sudo cp ./config/config.yaml /etc/crowdsec/config.yaml
-
+rm -f /etc/systemd/system/crowdsec.service.d/override.conf
+${SYSTEMCTL} daemon-reload
 
 #######################
 ## TEST WITHOUT CAPI ##

--- a/scripts/func_tests/tests_post-install_0base.sh
+++ b/scripts/func_tests/tests_post-install_0base.sh
@@ -99,7 +99,8 @@ echo "CROWDSEC (LAPI+CAPI)"
 echo -ne "[Service]\nExecStart=\nExecStart=/usr/bin/crowdsec -c /etc/crowdsec/config.yaml -no-cs" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
 
 ${SYSTEMCTL} daemon-reload
-${SYSTEMCTL} start crowdsec || systemctl status crowdsec && cat /var/log/crowdsec.log
+sudo rm -f /var/log/crowdsec.log
+${SYSTEMCTL} start crowdsec
 wait_for_service "crowdsec LAPI should run without agent (in flag)"
 ${SYSTEMCTL} stop crowdsec
 

--- a/scripts/func_tests/tests_post-install_0base.sh
+++ b/scripts/func_tests/tests_post-install_0base.sh
@@ -99,7 +99,7 @@ echo "CROWDSEC (LAPI+CAPI)"
 echo -ne "[Service]\nExecStart=\nExecStart=/usr/bin/crowdsec -c /etc/crowdsec/config.yaml -no-cs" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
 
 ${SYSTEMCTL} daemon-reload
-${SYSTEMCTL} start crowdsec || systemctl status crowdsec && journalctl -u crowdsec
+${SYSTEMCTL} start crowdsec || systemctl status crowdsec && cat /var/log/crowdsec.log
 wait_for_service "crowdsec LAPI should run without agent (in flag)"
 ${SYSTEMCTL} stop crowdsec
 

--- a/scripts/func_tests/tests_post-install_0base.sh
+++ b/scripts/func_tests/tests_post-install_0base.sh
@@ -7,6 +7,8 @@ echo $PATH
 
 sudo cp /etc/crowdsec/config.yaml ./config.yaml.backup
 
+CROWDSEC_PATH=$(which crowdsec)
+
 ##########################
 ## TEST AGENT/LAPI/CAPI ##
 echo "CROWDSEC (AGENT+LAPI+CAPI)"
@@ -59,7 +61,7 @@ sudo mkdir -p /etc/systemd/system/crowdsec.service.d/
 echo "CROWDSEC (AGENT)"
 
 # test with -no-api flag
-echo -ne "[Service]\nExecStart=\nExecStart=/usr/bin/crowdsec -c /etc/crowdsec/config.yaml -no-api\n" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
+echo -ne "[Service]\nExecStart=\nExecStart=${CROWDSEC_PATH} -c /etc/crowdsec/config.yaml -no-api\n" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
 
 ${SYSTEMCTL} daemon-reload
 ${SYSTEMCTL} start crowdsec
@@ -96,7 +98,7 @@ sudo cp ./config/config.yaml /etc/crowdsec/config.yaml
 echo "CROWDSEC (LAPI+CAPI)"
 
 # test with -no-cs flag
-echo -ne "[Service]\nExecStart=\nExecStart=/usr/bin/crowdsec -c /etc/crowdsec/config.yaml -no-cs" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
+echo -ne "[Service]\nExecStart=\nExecStart=${CROWDSEC_PATH} -c /etc/crowdsec/config.yaml -no-cs" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
 
 ${SYSTEMCTL} daemon-reload
 sudo rm -f /var/log/crowdsec.log
@@ -104,7 +106,7 @@ ${SYSTEMCTL} start crowdsec
 wait_for_service "crowdsec LAPI should run without agent (in flag)"
 ${SYSTEMCTL} stop crowdsec
 
-echo -ne "[service]\nExecStart=\nExecStart=/usr/bin/crowdsec -c /etc/crowdsec/config.yaml" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
+echo -ne "[service]\nExecStart=\nExecStart=${CROWDSEC_PATH} -c /etc/crowdsec/config.yaml" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
 
 ${SYSTEMCTL} daemon-reload
 

--- a/scripts/func_tests/tests_post-install_0base.sh
+++ b/scripts/func_tests/tests_post-install_0base.sh
@@ -99,7 +99,7 @@ echo "CROWDSEC (LAPI+CAPI)"
 echo -ne "[Service]\nExecStart=\nExecStart=/usr/bin/crowdsec -c /etc/crowdsec/config.yaml -no-cs" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
 
 ${SYSTEMCTL} daemon-reload
-${SYSTEMCTL} start crowdsec 
+${SYSTEMCTL} start crowdsec || systemctl status crowdsec && journalctl -u crowdsec
 wait_for_service "crowdsec LAPI should run without agent (in flag)"
 ${SYSTEMCTL} stop crowdsec
 

--- a/scripts/func_tests/tests_post-install_0base.sh
+++ b/scripts/func_tests/tests_post-install_0base.sh
@@ -59,7 +59,7 @@ sudo mkdir -p /etc/systemd/system/crowdsec.service.d/
 echo "CROWDSEC (AGENT)"
 
 # test with -no-api flag
-echo -ne "[service]\nExecStart=/usr/bin/crowdsec -c /etc/crowdsec/config.yaml -no-api" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
+echo -ne "[Service]\nExecStart=\nExecStart=/usr/bin/crowdsec -c /etc/crowdsec/config.yaml -no-api\n" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
 
 ${SYSTEMCTL} daemon-reload
 ${SYSTEMCTL} start crowdsec
@@ -96,14 +96,14 @@ sudo cp ./config/config.yaml /etc/crowdsec/config.yaml
 echo "CROWDSEC (LAPI+CAPI)"
 
 # test with -no-cs flag
-echo -ne "[service]\nExecStart=/usr/bin/crowdsec -c /etc/crowdsec/config.yaml -no-cs" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
+echo -ne "[Service]\nExecStart=\nExecStart=/usr/bin/crowdsec -c /etc/crowdsec/config.yaml -no-cs" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
 
 ${SYSTEMCTL} daemon-reload
 ${SYSTEMCTL} start crowdsec 
 wait_for_service "crowdsec LAPI should run without agent (in flag)"
 ${SYSTEMCTL} stop crowdsec
 
-echo -ne "[service]\nExecStart=/usr/bin/crowdsec -c /etc/crowdsec/config.yaml" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
+echo -ne "[service]\nExecStart=\nExecStart=/usr/bin/crowdsec -c /etc/crowdsec/config.yaml" | sudo tee /etc/systemd/system/crowdsec.service.d/override.conf
 
 ${SYSTEMCTL} daemon-reload
 


### PR DESCRIPTION
Use the override possibility of systemd instead of doing some magic with systemd files, which can fail on some distributions.