### PR TITLE
Prestage files and copy on init to fix bind mount issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,18 +13,20 @@ RUN SYSTEM="docker" make release
 RUN cd crowdsec-v* && ./wizard.sh --docker-mode && cd -
 RUN cscli hub update && cscli collections install crowdsecurity/linux && cscli parsers install crowdsecurity/whitelists
 FROM alpine:latest
-RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community tzdata yq
-COPY --from=build /etc/crowdsec /etc/crowdsec
-COPY --from=build /var/lib/crowdsec /var/lib/crowdsec
+RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community tzdata yq && \
+  mkdir -p /staging/etc/crowdsec && \
+  mkdir -p /staging/var/lib/crowdsec
+COPY --from=build /etc/crowdsec /staging/etc/crowdsec
+COPY --from=build /var/lib/crowdsec /staging/var/lib/crowdsec
 COPY --from=build /usr/local/bin/crowdsec /usr/local/bin/crowdsec
 COPY --from=build /usr/local/bin/cscli /usr/local/bin/cscli
 COPY --from=build /go/src/crowdsec/docker/docker_start.sh /
-COPY --from=build /go/src/crowdsec/docker/config.yaml /etc/crowdsec/config.yaml
+COPY --from=build /go/src/crowdsec/docker/config.yaml /staging/etc/crowdsec/config.yaml
 #Due to the wizard using cp -n, we have to copy the config files directly from the source as -n does not exist in busybox cp
 #The files are here for reference, as users will need to mount a new version to be actually able to use notifications
-COPY --from=build /go/src/crowdsec/plugins/notifications/http/http.yaml /etc/crowdsec/notifications/http.yaml
-COPY --from=build /go/src/crowdsec/plugins/notifications/slack/slack.yaml /etc/crowdsec/notifications/slack.yaml
-COPY --from=build /go/src/crowdsec/plugins/notifications/splunk/splunk.yaml /etc/crowdsec/notifications/splunk.yaml
+COPY --from=build /go/src/crowdsec/plugins/notifications/http/http.yaml /staging/etc/crowdsec/notifications/http.yaml
+COPY --from=build /go/src/crowdsec/plugins/notifications/slack/slack.yaml /staging/etc/crowdsec/notifications/slack.yaml
+COPY --from=build /go/src/crowdsec/plugins/notifications/splunk/splunk.yaml /staging/etc/crowdsec/notifications/splunk.yaml
 COPY --from=build /usr/local/lib/crowdsec/plugins /usr/local/lib/crowdsec/plugins
 
 ENTRYPOINT /bin/sh docker_start.sh

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -6,6 +6,18 @@ if [ "$CONFIG_FILE" != "" ]; then
     CS_CONFIG_FILE="$CONFIG_FILE"
 fi
 
+#Check & prestage databases
+if [ ! -e "/var/lib/data/GeoLite2-ASN.mmdb" ] && [ ! -e "/var/lib/data/GeoLite2-City.mmdb" ]; then
+    mkdir -p /var/lib/crowdsec/data
+    cp /staging/var/lib/crowdsec/data/*.mmdb /var/lib/crowdsec/data/
+fi
+
+#Check & prestage /etc/crowdsec
+if [ ! -e "/etc/crowdsec/local_api_credentials.yaml" ] && [ ! -e "/etc/crowdsec/config.yaml" ]; then
+    mkdir -p /etc/crowdsec
+    cp -r /staging/etc/* /etc/
+fi
+
 # regenerate local agent credentials (ignore if agent is disabled)
 if [ "$DISABLE_AGENT" == "" ] ; then
     echo "Regenerate local agent credentials"


### PR DESCRIPTION
Currently if you try and init a new Crowdsec container using bind mounts (or tmpfs) rather than named volumes, it fails. This is due to [this](https://docs.docker.com/storage/volumes/#populate-a-volume-using-a-container) difference in behaviour between named volumes and bind mounts. In essence a named volume will copy the contents of the container directory into the volume on first run but a bind mount will instead mount the host directory to *replace* the container directory and its contents.

This change copies the built files for /etc/crowdsec and /var/lib/crowdsec into a /staging folder on build, and then on init it checks for the presence of files in the target location and copies them from /staging if they're not already present. That way anyone using a bind mount will still be able to init the container without having to take manual steps.

I've picked a lack of `config.yaml` and `local_api_credentials.yaml` as proxies for "is the container setup yet" but you're welcome to select other files, or even to individually check and copy every file in /etc/crowdsec (though I feel that would be overkill).

Tested as much as I can locally as everything seems to work as expected.