### PR TITLE
string comparison fix

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -18,7 +18,7 @@ if [ "$1" = configure ]; then
         /usr/bin/cscli hub upgrade
         systemctl start crowdsec
     fi
-    
+
     . /usr/share/crowdsec/wizard.sh -n
     if ! [[ -f /etc/crowdsec/acquis.yaml ]]; then
         echo Creating /etc/crowdsec/acquis.yaml
@@ -36,7 +36,7 @@ if [ "$1" = configure ]; then
     if [[ -f /etc/crowdsec/online_api_credentials.yaml ]]; then
         chmod 600 /etc/crowdsec/online_api_credentials.yaml
     fi
-    
+
     if [[ ! -f /etc/crowdsec/local_api_credentials.yaml ]] || [[ ! -f /etc/crowdsec/online_api_credentials.yaml ]]; then
         if [[ ! -f /etc/crowdsec/local_api_credentials.yaml ]] ; then
             install -m 600 /dev/null  /etc/crowdsec/local_api_credentials.yaml
@@ -47,41 +47,41 @@ if [ "$1" = configure ]; then
 
         db_input medium crowdsec/lapi || true
         db_go || true
-        
+
         db_get crowdsec/lapi
         LAPI=$RET
 
         if  [ "$LAPI" = true ]; then
             db_input medium crowdsec/capi || true
             db_go || true
-            
+
             db_get crowdsec/capi
             CAPI=$RET
-            
+
             cscli machines add -a
-        
+
             if [ "$CAPI" = true ]; then
                 cscli capi register
             fi
-           
+
         else
             db_input medium crowdsec/lapi_host || true
             db_go || true
-            
+
             db_get crowdsec/lapi_host
             LAPI_HOST=$RET
             sed -i "s/127.0.0.1:8080/$LAPI_HOST/g" /etc/crowdsec/config.yaml
         fi
     fi
+
     echo Updating hub
     /usr/bin/cscli hub update
-    if [ $COLLECTIONS=true ]; then
+    if [ "$COLLECTIONS" = true ]; then
         set +e
         CSCLI_BIN_INSTALLED="/usr/bin/cscli" SILENT=true install_collection
         set -e
-    fi   
-        
-    
+    fi
+
     if [[ -f /var/lib/crowdsec/data/crowdsec.db.backup ]]; then
         cp /var/lib/crowdsec/data/crowdsec.db.backup /var/lib/crowdsec/data/crowdsec.db
         rm -f /var/lib/crowdsec/data/crowdsec.db.backup
@@ -96,6 +96,5 @@ if [ "$1" = configure ]; then
         echo "This port is configured through /etc/crowdsec/config.yaml and /etc/crowdsec/local_api_credentials.yaml"
     fi
 fi
-
 
 echo "You can always run the configuration again interactively by using '/usr/share/crowdsec/wizard.sh -c"


### PR DESCRIPTION
This is definitely a bug:

`if [ false=true ]`

(without spaces around '=') always tests true
