### PR TITLE
Makefile: add ENV VARIABLES to override configdir & datadir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ BUILD_GOVERSION="$(shell go version | cut -d " " -f3 | sed -E 's/[go]+//g')"
 BUILD_CODENAME=$(shell cat RELEASE.json | jq -r .CodeName)
 BUILD_TIMESTAMP=$(shell date +%F"_"%T)
 BUILD_TAG?="$(shell git rev-parse HEAD)"
+DEFAULT_CONFIGDIR ?= "/etc/crowdsec"
+DEFAULT_DATADIR ?= "/var/lib/crowdsec/data"
 
 export LD_OPTS=-ldflags "-s -w -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Version=$(BUILD_VERSION) \
 -X github.com/crowdsecurity/crowdsec/pkg/cwversion.System=$(SYSTEM) \
@@ -51,14 +53,16 @@ export LD_OPTS=-ldflags "-s -w -X github.com/crowdsecurity/crowdsec/pkg/cwversio
 -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Codename=$(BUILD_CODENAME)  \
 -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Tag=$(BUILD_TAG) \
 -X github.com/crowdsecurity/crowdsec/pkg/cwversion.GoVersion=$(BUILD_GOVERSION) \
--X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultConfigDir=/etc/crowdsec \
--X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultDataDir=/var/lib/crowdsec/data"
+-X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultConfigDir=$(DEFAULT_CONFIGDIR) \
+-X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultDataDir=$(DEFAULT_DATADIR)"
 
 export LD_OPTS_STATIC=-ldflags "-s -w -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Version=$(BUILD_VERSION) \
 -X github.com/crowdsecurity/crowdsec/pkg/cwversion.BuildDate=$(BUILD_TIMESTAMP) \
 -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Codename=$(BUILD_CODENAME)  \
 -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Tag=$(BUILD_TAG) \
 -X github.com/crowdsecurity/crowdsec/pkg/cwversion.GoVersion=$(BUILD_GOVERSION) \
+-X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultConfigDir=$(DEFAULT_CONFIGDIR) \
+-X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultDataDir=$(DEFAULT_DATADIR) \
 -extldflags '-static'"
 
 RELDIR = crowdsec-$(BUILD_VERSION)


### PR DESCRIPTION
Enhance:
https://github.com/crowdsecurity/crowdsec/commit/35eea39db7736e03030d2fd351f40e30207d808f

- add ENV VARIABLES to help defaults settings from script build (without hardcoded patch need)
- add override also in static build

Tests done: OK

Crowdsec-1.3.0
+ https://github.com/crowdsecurity/crowdsec/commit/35eea39db7736e03030d2fd351f40e30207d808f
+ https://github.com/crowdsecurity/crowdsec/commit/8fabf0cf69cc1c2445cf0a06c00065d1fcad7302
+ build (cross build for arm64):
```
DEFAULT_CONFIGDIR="/usr/local/etc/crowdsec"
DEFAULT_DATADIR="/usr/local/var/lib/crowdsec/data"
```
get `cscli` working now without error and without defining `-c`

Also tested without defining DEFAULT_CONFIGDIR and DEFAULT_DATADIR (outside the Makefile).
defaults are correctly sets and cscli working as usual.

Signed-off-by: Kerma Gérald <gandalf@gk2.net>