### PR TITLE
Add TLS functionality from env variables

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -123,6 +123,9 @@ Using binds rather than named volumes ([more explanation here](https://docs.dock
 * `LEVEL_TRACE`             - Trace-level (VERY verbose) on stdout (default: `false`) : `-e LEVEL_TRACE="<true|false>"`
 * `LEVEL_DEBUG`             - Debug-level on stdout (default: `false`) : `-e LEVEL_DEBUG="<true|false>"`
 * `LEVEL_INFO`              - Info-level on stdout (default: `false`) : `-e LEVEL_INFO="<true|false>"`
+* `USE_TLS`                 - Enable TLS on the API Server (default: `false`) : `-e USE_TLS="<true|false>"`
+* `CERT_FILE`               - TLS Certificate file (default: `/etc/ssl/cert.pem`) : `-e CERT_FILE="<file_path>"`
+* `KEY_FILE`                - TLS Key file (default: `/etc/ssl/key.pem`) : `-e KEY_FILE="<file_path>"`
 
 ## Volumes
 

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -6,6 +6,10 @@ if [ "$CONFIG_FILE" != "" ]; then
     CS_CONFIG_FILE="$CONFIG_FILE"
 fi
 
+# TLS defaults
+CERT_FILE="${CERT_FILE:-/etc/ssl/cert.pem}"
+KEY_FILE="${KEY_FILE:-/etc/ssl/key.pem}"
+
 #Check & prestage databases
 if [ ! -e "/var/lib/data/GeoLite2-ASN.mmdb" ] && [ ! -e "/var/lib/data/GeoLite2-City.mmdb" ]; then
     mkdir -p /var/lib/crowdsec/data
@@ -58,6 +62,12 @@ if [ "$GID" != "" ]; then
         chown :$GID $DB_PATH
         echo "sqlite database permissions updated"
     fi
+fi
+
+if [ "$USE_TLS" != "" ]; then
+   yq -i eval ".api.server.tls.cert_file = \"$CERT_FILE\"" "$CS_CONFIG_FILE"
+   yq -i eval ".api.server.tls.key_file = \"$KEY_FILE\"" "$CS_CONFIG_FILE"
+   yq -i eval '... comments=""' "$CS_CONFIG_FILE"
 fi
 
 ## Install collections, parsers & scenarios


### PR DESCRIPTION
Add the option to use TLS and set certificate and key path for the API server to enable HTTPS support on the docker container at the startup time.