### PR TITLE
Set custom hostname for local agent credentials

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -123,6 +123,7 @@ Using binds rather than named volumes ([more explanation here](https://docs.dock
 * `LEVEL_TRACE`             - Trace-level (VERY verbose) on stdout (default: `false`) : `-e LEVEL_TRACE="<true|false>"`
 * `LEVEL_DEBUG`             - Debug-level on stdout (default: `false`) : `-e LEVEL_DEBUG="<true|false>"`
 * `LEVEL_INFO`              - Info-level on stdout (default: `false`) : `-e LEVEL_INFO="<true|false>"`
+* `CUSTOM_HOSTNAME`         - Custom hostname for local api (default: `localhost`) : `-e CUSTOM_HOSTNAME="<hostname>"`
 
 ## Volumes
 

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -21,11 +21,11 @@ fi
 # regenerate local agent credentials (ignore if agent is disabled)
 if [ "$DISABLE_AGENT" == "" ] ; then
     echo "Regenerate local agent credentials"
-    cscli -c "$CS_CONFIG_FILE" machines delete localhost
+    cscli -c "$CS_CONFIG_FILE" machines delete ${CUSTOM_HOSTNAME:-localhost}
     if [ "$LOCAL_API_URL" != "" ] ; then
-        cscli -c "$CS_CONFIG_FILE" machines add localhost --auto --url $LOCAL_API_URL
+        cscli -c "$CS_CONFIG_FILE" machines add ${CUSTOM_HOSTNAME:-localhost} --auto --url $LOCAL_API_URL
     else
-        cscli -c "$CS_CONFIG_FILE" machines add localhost --auto
+        cscli -c "$CS_CONFIG_FILE" machines add ${CUSTOM_HOSTNAME:-localhost} --auto
     fi
     if [ "$AGENT_USERNAME" != "" ] && [ "$AGENT_PASSWORD" != "" ] && [ "$LOCAL_API_URL" != "" ] ; then
         echo "set up lapi credentials for agent"


### PR DESCRIPTION
Add a new environment variable to set custom hostname for the local API when regenerating the credentials