### PR TITLE
WIP: Create debian docker package with journalctl

### DIFF
--- a/.github/workflows/release_publish_docker-image.yml
+++ b/.github/workflows/release_publish_docker-image.yml
@@ -9,7 +9,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
-      - 
+      -
         name: Check out the repo
         uses: actions/checkout@v2
       -
@@ -32,10 +32,10 @@ jobs:
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-      - 
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-      - 
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
@@ -52,6 +52,19 @@ jobs:
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+      -
+        name: Build and push debian image with journalctl
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.debian
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}-debian
           platforms: linux/amd64,linux/arm64
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}

--- a/.github/workflows/update_docker_hub_doc.yml
+++ b/.github/workflows/update_docker_hub_doc.yml
@@ -1,6 +1,6 @@
 name: Update Docker Hub README
 
-on: 
+on:
   push:
     branches:
       - master
@@ -11,7 +11,7 @@ jobs:
   update-docker-hub-readme:
     runs-on: ubuntu-latest
     steps:
-      - 
+      -
         name: Check out the repo
         uses: actions/checkout@v2
       -

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,25 +1,35 @@
-ARG GOVERSION=1.17
+FROM debian:bullseye-slim AS build
 
-FROM golang:${GOVERSION}-alpine AS build
+RUN apt-get update
+RUN apt-get install -y -q --install-recommends --no-install-suggests \
+        gettext \
+        wget \
+        bash
 
-WORKDIR /go/src/crowdsec
+ADD https://github.com/crowdsecurity/crowdsec/releases/latest/download/crowdsec-release.tgz /crowdsec-release.tgz
+ADD https://github.com/mikefarah/yq/releases/download/v4.18.1/yq_linux_amd64 /usr/bin/yq
+RUN tar xzvf crowdsec-release.tgz
+RUN cd crowdsec-v* && ./wizard.sh --docker-mode
+RUN chmod +x /usr/bin/yq
 
-# wizard.sh requires GNU coreutils
-RUN apk add --no-cache git jq gcc libc-dev make bash gettext binutils-gold coreutils
+FROM debian:bullseye-slim
+RUN apt-get update
+RUN apt-get install -y -q --install-recommends --no-install-suggests \
+    procps \
+    systemd \
+    iproute2 \
+    ca-certificates \
+    tzdata
 
-COPY . .
+COPY --from=build /usr/bin/yq /usr/bin/yq
+COPY --from=build /bin/bash /bin/bash
 
-RUN SYSTEM="docker" make release
-RUN cd crowdsec-v* && ./wizard.sh --docker-mode && cd -
-RUN cscli hub update && cscli collections install crowdsecurity/linux && cscli parsers install crowdsecurity/whitelists
-FROM alpine:latest
-RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community tzdata yq bash
 COPY --from=build /etc/crowdsec /etc/crowdsec
 COPY --from=build /var/lib/crowdsec /var/lib/crowdsec
 COPY --from=build /usr/local/bin/crowdsec /usr/local/bin/crowdsec
 COPY --from=build /usr/local/bin/cscli /usr/local/bin/cscli
 COPY --from=build /go/src/crowdsec/docker/docker_start.sh /
-COPY --from=build /go/src/crowdsec/docker/config.yaml /etc/crowdsec/config.yaml
+COPY --from=build /go/src/crowdsec/config/config.yaml /etc/crowdsec/config.yaml
 #Due to the wizard using cp -n, we have to copy the config files directly from the source as -n does not exist in busybox cp
 #The files are here for reference, as users will need to mount a new version to be actually able to use notifications
 COPY --from=build /go/src/crowdsec/plugins/notifications/http/http.yaml /etc/crowdsec/notifications/http.yaml
@@ -27,4 +37,6 @@ COPY --from=build /go/src/crowdsec/plugins/notifications/slack/slack.yaml /etc/c
 COPY --from=build /go/src/crowdsec/plugins/notifications/splunk/splunk.yaml /etc/crowdsec/notifications/splunk.yaml
 COPY --from=build /usr/local/lib/crowdsec/plugins /usr/local/lib/crowdsec/plugins
 
-ENTRYPOINT /bin/sh docker_start.sh
+COPY bin/docker_start.sh /docker_start.sh
+
+CMD ["/docker_start.sh"]

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Set the crowdsec config file
 CS_CONFIG_FILE="/etc/crowdsec/config.yaml"
@@ -64,6 +64,9 @@ if [ "$SCENARIOS" != "" ]; then
 fi
 if [ "$POSTOVERFLOWS" != "" ]; then
     cscli -c "$CS_CONFIG_FILE" postoverflows install $POSTOVERFLOWS
+fi
+if [ "$DISABLE_SCENARIOS" != "" ]; then
+    cscli -c "$CS_CONFIG_FILE" scenarios uninstall $DISABLE_SCENARIOS
 fi
 
 ARGS=""


### PR DESCRIPTION
This PR will add a build step to crowdsec to release a Debian-based docker container that contains systemd, which will include journalctl.

This is used if you want to stream journalctl log files inside the docker container to do collections on.

For this to work, we will need to use `bash` instead of `sh` in the docker start script but should have minimal impact on the alpine container.

It will also add a new ENV variable to disable scenarios. Usecase for this is:

You enable the Nginx collection. It has the scenarios in it. When the container starts, it will re-enable all scenarios in the collection even though you have disabled some of them.