### PR TITLE
[WIP] Sync data files with hub index (#1153)

### DIFF
--- a/cmd/crowdsec-cli/hub.go
+++ b/cmd/crowdsec-cli/hub.go
@@ -56,7 +56,7 @@ cscli hub update # Download list of available configurations from the hub
 				log.Info(v)
 			}
 			cwhub.DisplaySummary()
-			ListItems([]string{cwhub.PARSERS, cwhub.COLLECTIONS, cwhub.SCENARIOS, cwhub.PARSERS_OVFLW}, args, true, false)
+			ListItems([]string{cwhub.PARSERS, cwhub.COLLECTIONS, cwhub.SCENARIOS, cwhub.PARSERS_OVFLW, cwhub.DATA_FILES}, args, true, false)
 		},
 	}
 	cmdHubList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List disabled items as well")

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -250,22 +250,21 @@ func UpgradeConfig(itemType string, name string, force bool) {
 			continue
 		}
 
+		found = true
+		if v.UpToDate || v.Tainted {
+			if v.UpToDate {
+				log.Infof("%s : up-to-date", v.Name)
+			}
+			if err = cwhub.DownloadDataIfNeeded(csConfig.Hub, v, force); err != nil {
+				log.Fatalf("%s : download failed : %v", v.Name, err)
+			}
+		}
+
 		if !v.Downloaded {
 			log.Warningf("%s : not downloaded, please install.", v.Name)
 			continue
 		}
 
-		found = true
-		if v.UpToDate {
-			log.Infof("%s : up-to-date", v.Name)
-
-			if !force {
-				if err = cwhub.DownloadDataIfNeeded(csConfig.Hub, v, false); err != nil {
-					log.Fatalf("%s : download failed : %v", v.Name, err)
-				}
-				continue
-			}
-		}
 		v, err = cwhub.DownloadLatest(csConfig.Hub, v, force, true)
 		if err != nil {
 			log.Fatalf("%s : download failed : %v", v.Name, err)

--- a/pkg/cwhub/cwhub.go
+++ b/pkg/cwhub/cwhub.go
@@ -22,11 +22,12 @@ var PARSERS = "parsers"
 var PARSERS_OVFLW = "postoverflows"
 var SCENARIOS = "scenarios"
 var COLLECTIONS = "collections"
-var ItemTypes = []string{PARSERS, PARSERS_OVFLW, SCENARIOS, COLLECTIONS}
+var DATA_FILES = "data_files"
+var ItemTypes = []string{PARSERS, PARSERS_OVFLW, SCENARIOS, COLLECTIONS, DATA_FILES}
 
 var hubIdx map[string]map[string]Item
 
-var RawFileURLTemplate = "https://hub-cdn.crowdsec.net/%s/%s"
+var RawFileURLTemplate = "https://raw.githubusercontent.com/sbs2001/hub/%s/%s"
 var HubBranch = "master"
 var HubIndexFile = ".index.json"
 
@@ -57,11 +58,10 @@ type Item struct {
 	BelongsToCollections []string `yaml:"belongs_to_collections,omitempty" json:"belongs_to_collections,omitempty"` /*if it's part of collections, track name here*/
 
 	/*remote (hub) infos*/
-	RemoteURL  string                 `yaml:"remoteURL,omitempty" json:"remoteURL,omitempty"` //the full remote uri of file in http
-	RemotePath string                 `json:"path,omitempty" yaml:"remote_path,omitempty"`    //the path relative to git ie. /parsers/stage/author/file.yaml
-	RemoteHash string                 `yaml:"hash,omitempty" json:"hash,omitempty"`           //the meow
-	Version    string                 `json:"version,omitempty"`                              //the last version
-	Versions   map[string]ItemVersion `json:"versions,omitempty" yaml:"-"`                    //the list of existing versions
+	RemotePath string                 `json:"path,omitempty" yaml:"remote_path,omitempty"` //the path relative to git ie. /parsers/stage/author/file.yaml
+	RemoteHash string                 `yaml:"hash,omitempty" json:"hash,omitempty"`        //the meow
+	Version    string                 `json:"version,omitempty"`                           //the last version
+	Versions   map[string]ItemVersion `json:"versions,omitempty" yaml:"-"`                 //the list of existing versions
 
 	/*local (deployed) infos*/
 	LocalPath string `yaml:"local_path,omitempty" json:"local_path,omitempty"` //the local path relative to ${CFG_DIR}

--- a/pkg/cwhub/cwhub_test.go
+++ b/pkg/cwhub/cwhub_test.go
@@ -383,8 +383,9 @@ func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	responseBody := ""
 	log.Printf("---> %s", req.URL.Path)
 
+
 	/*FAKE PARSER*/
-	if req.URL.Path == "/master/parsers/s01-parse/crowdsecurity/foobar_parser.yaml" {
+	if strings.HasSuffix(req.URL.Path, "/master/parsers/s01-parse/crowdsecurity/foobar_parser.yaml") {
 		responseBody = `onsuccess: next_stage
 filter: evt.Parsed.program == 'foobar_parser'
 name: crowdsecurity/foobar_parser
@@ -395,7 +396,7 @@ grok:
   apply_on: message
 `
 
-	} else if req.URL.Path == "/master/parsers/s01-parse/crowdsecurity/foobar_subparser.yaml" {
+	} else if strings.HasSuffix(req.URL.Path, "/master/parsers/s01-parse/crowdsecurity/foobar_subparser.yaml") {
 		responseBody = `onsuccess: next_stage
 filter: evt.Parsed.program == 'foobar_parser'
 name: crowdsecurity/foobar_parser
@@ -407,19 +408,19 @@ grok:
 `
 		/*FAKE SCENARIO*/
 
-	} else if req.URL.Path == "/master/scenarios/crowdsecurity/foobar_scenario.yaml" {
+	} else if strings.HasSuffix(req.URL.Path, "/master/scenarios/crowdsecurity/foobar_scenario.yaml") {
 		responseBody = `filter: true
 name: crowdsecurity/foobar_scenario`
 		/*FAKE COLLECTIONS*/
-	} else if req.URL.Path == "/master/collections/crowdsecurity/foobar.yaml" {
+	} else if strings.HasSuffix(req.URL.Path, "/master/collections/crowdsecurity/foobar.yaml") {
 		responseBody = `
 blah: blalala
 qwe: jejwejejw`
-	} else if req.URL.Path == "/master/collections/crowdsecurity/foobar_subcollection.yaml" {
+	} else if strings.HasSuffix(req.URL.Path, "/master/collections/crowdsecurity/foobar_subcollection.yaml") {
 		responseBody = `
 blah: blalala
 qwe: jejwejejw`
-	} else if req.URL.Path == "/master/.index.json" {
+	} else if strings.HasSuffix(req.URL.Path, "/master/.index.json") {
 		responseBody =
 			`{
 				"collections": {

--- a/pkg/cwhub/download_test.go
+++ b/pkg/cwhub/download_test.go
@@ -40,3 +40,29 @@ func TestDownloadHubIdx(t *testing.T) {
 	RawFileURLTemplate = back
 	fmt.Printf("->%+v", ret)
 }
+
+func TestDataFileIsLatest(t *testing.T) {
+	dataFileName := "crowdsecurity/sensitive-files"
+	hubIdx = map[string]map[string]Item{
+		"data_files": {
+			"crowdsecurity/sensitive-files": {
+				Versions: map[string]ItemVersion{
+					"0.1": {Digest: "1"},
+					"0.2": {Digest: "2"},
+				},
+			},
+		},
+	}
+	if dataFileHasUpdates("1", dataFileName) {
+		log.Errorf(`expected dataFileIsLatest("1", %s) = true found false `, dataFileName)
+	}
+
+	if !dataFileHasUpdates("2", dataFileName) {
+		log.Errorf(`expected dataFileIsLatest("2", %s) = false found true `, dataFileName)
+	}
+
+	// data file is tainted
+	if dataFileHasUpdates("3", dataFileName) {
+		log.Errorf(`expected dataFileIsLatest("3", %s) = false found true `, dataFileName)
+	}
+}

--- a/pkg/types/dataset.go
+++ b/pkg/types/dataset.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -42,6 +43,10 @@ func downloadFile(url string, destPath string) error {
 		return fmt.Errorf("download response 'HTTP %d' : %s", resp.StatusCode, string(body))
 	}
 
+	if err := os.MkdirAll(filepath.Dir(destPath), 0666); err != nil {
+		return err
+	}
+
 	file, err := os.OpenFile(destPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
@@ -60,14 +65,12 @@ func downloadFile(url string, destPath string) error {
 	return nil
 }
 
-func GetData(data []*DataSource, dataDir string) error {
-	for _, dataS := range data {
-		destPath := path.Join(dataDir, dataS.DestPath)
-		log.Infof("downloading data '%s' in '%s'", dataS.SourceURL, destPath)
-		err := downloadFile(dataS.SourceURL, destPath)
-		if err != nil {
-			return err
-		}
+func GetData(dataS *DataSource, dataDir string) error {
+	destPath := path.Join(dataDir, dataS.DestPath)
+	log.Infof("downloading data '%s' in '%s'", dataS.SourceURL, destPath)
+	err := downloadFile(dataS.SourceURL, destPath)
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
This PR currently uses my fork as hub. Note the introduction of "data_files" section in  the [.index.json ](https://github.com/sbs2001/hub/blob/3a2b6888670d21f64dfb905bbc11b6f2ff42a9a2/.index.json#L652) at my fork. 

1. Status of data files installed via hub can be tracked via `cscli hub list` (Is it latest, tainted, version etc?)
![image](https://user-images.githubusercontent.com/28975399/148924041-b0517284-17b6-4426-b4b7-9b6da0485ed6.png)

2. When new version of data file in  pushed on hub, `cscli hub update` and `cscli hub upgrade` will update to the new data file given that : The data file wasn't tainted. This is checked by checking the hash of local data file and comparing it with hash of all versions of the corresponding file in the .index.json . If hash matches with some version then file is not tainted.
3. Data file which are present in hub are not downloaded from `source_url`. Rather the url is calculated by looking at the index and downloaded from [data_files dir from hub](https://github.com/sbs2001/hub/tree/master/data_files)

On the hub side, the CI binary is modified to do the following while creating index. See the [PR](https://github.com/crowdsecurity/hub/pull/341) here
1. While going through each config file, check if it references to some data file if yes then (2)
2. Download the file and put it in data_files/<author_of_config>/<dest_file>
3. As with other configs, new version entry would be created if the downloaded file's hash doesn't match with current version.
