### PR TITLE
Check log level before dumping resp

### DIFF
--- a/pkg/apiclient/client_http.go
+++ b/pkg/apiclient/client_http.go
@@ -84,13 +84,15 @@ func (c *ApiClient) Do(ctx context.Context, req *http.Request, v interface{}) (*
 		return newResponse(resp), err
 	}
 
-	for k, v := range resp.Header {
-		log.Debugf("[headers] %s : %s", k, v)
-	}
+	if log.GetLevel() >= log.DebugLevel {
+		for k, v := range resp.Header {
+			log.Debugf("[headers] %s : %s", k, v)
+		}
 
-	dump, err := httputil.DumpResponse(resp, true)
-	if err == nil {
-		log.Debugf("Response: %s", string(dump))
+		dump, err := httputil.DumpResponse(resp, true)
+		if err == nil {
+			log.Debugf("Response: %s", string(dump))
+		}
 	}
 
 	response := newResponse(resp)

--- a/scripts/func_tests/tests_post-install_0base.sh
+++ b/scripts/func_tests/tests_post-install_0base.sh
@@ -38,7 +38,7 @@ ${CSCLI} version || fail "cannot run cscli version"
 
 ## alerts
 # alerts list at startup should just return one entry : community pull
-sleep 5
+sleep 40
 ${CSCLI} alerts list -ojson  | ${JQ} '. | length >= 1' || fail "expected at least one entry from cscli alerts list"
 ## capi
 ${CSCLI} capi status || fail "capi status should be ok"


### PR DESCRIPTION
The `httputil.DumpResponse` is expensive operation especially when the response is large. This PR invokes it only if required (only in debug mode)