### PR TITLE
Upgrade download datafiles if doesn't exist

### DIFF
--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -262,7 +262,10 @@ func UpgradeConfig(itemType string, name string, force bool) {
 			if err = cwhub.DownloadDataIfNeeded(csConfig.Hub, v, force); err != nil {
 				log.Fatalf("%s : download failed : %v", v.Name, err)
 			}
-			continue
+
+			if !force {
+				continue
+			}
 		}
 		v, err = cwhub.DownloadLatest(csConfig.Hub, v, force, true)
 		if err != nil {

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -259,7 +259,7 @@ func UpgradeConfig(itemType string, name string, force bool) {
 		if v.UpToDate {
 			log.Infof("%s : up-to-date", v.Name)
 
-			if err = cwhub.DownloadDataIfNeeded(csConfig.Hub, v, false); err != nil {
+			if err = cwhub.DownloadDataIfNeeded(csConfig.Hub, v, force); err != nil {
 				log.Fatalf("%s : download failed : %v", v.Name, err)
 			}
 			continue

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -259,12 +259,10 @@ func UpgradeConfig(itemType string, name string, force bool) {
 		if v.UpToDate {
 			log.Infof("%s : up-to-date", v.Name)
 
-			if !force {
-				if err = cwhub.DownloadDataIfNeeded(csConfig.Hub, v, false); err != nil {
-					log.Fatalf("%s : download failed : %v", v.Name, err)
-				}
-				continue
+			if err = cwhub.DownloadDataIfNeeded(csConfig.Hub, v, false); err != nil {
+				log.Fatalf("%s : download failed : %v", v.Name, err)
 			}
+			continue
 		}
 		v, err = cwhub.DownloadLatest(csConfig.Hub, v, force, true)
 		if err != nil {

--- a/pkg/cwhub/download.go
+++ b/pkg/cwhub/download.go
@@ -253,11 +253,9 @@ func downloadData(dataFolder string, force bool, reader io.Reader) error {
 		}
 
 		download := false
-		if !force {
-			for _, dataS := range data.Data {
-				if _, err := os.Stat(path.Join(dataFolder, dataS.DestPath)); os.IsNotExist(err) {
-					download = true
-				}
+		for _, dataS := range data.Data {
+			if _, err := os.Stat(path.Join(dataFolder, dataS.DestPath)); os.IsNotExist(err) {
+				download = true
 			}
 		}
 		if download || force {


### PR DESCRIPTION
If we change a datafile in an existing parser/scenario, cscli will not download the new datafile when running `cscli <parsers|scenarios> upgrade` . This PR fix this issue.