### PR TITLE
Exit syslog acquis only after server is dead

### DIFF
--- a/pkg/acquisition/modules/syslog/internal/syslogserver.go
+++ b/pkg/acquisition/modules/syslog/internal/syslogserver.go
@@ -61,7 +61,7 @@ func (s *SyslogServer) StartServer() *tomb.Tomb {
 		for {
 			select {
 			case <-t.Dying():
-				s.Logger.Info("syslog server tomb is dying")
+				s.Logger.Info("Syslog server tomb is dying")
 				err := s.KillServer()
 				return err
 			default:
@@ -92,5 +92,6 @@ func (s *SyslogServer) KillServer() error {
 	if err != nil {
 		return errors.Wrap(err, "could not close UDP connection")
 	}
+	close(s.channel)
 	return nil
 }

--- a/pkg/acquisition/modules/syslog/syslog.go
+++ b/pkg/acquisition/modules/syslog/syslog.go
@@ -180,11 +180,15 @@ func (s *SyslogSource) buildLogFromSyslog(ts *time.Time, hostname *string,
 }
 
 func (s *SyslogSource) handleSyslogMsg(out chan types.Event, t *tomb.Tomb, c chan syslogserver.SyslogMessage) error {
+	killed := false
 	for {
 		select {
 		case <-t.Dying():
-			s.logger.Info("Syslog datasource is dying")
-			s.serverTomb.Kill(nil)
+			if !killed {
+				s.logger.Info("Syslog datasource is dying")
+				s.serverTomb.Kill(nil)
+				killed = true
+			}
 		case <-s.serverTomb.Dead():
 			s.logger.Info("Syslog server has exited")
 			return nil

--- a/pkg/acquisition/modules/syslog/syslog.go
+++ b/pkg/acquisition/modules/syslog/syslog.go
@@ -185,10 +185,6 @@ func (s *SyslogSource) handleSyslogMsg(out chan types.Event, t *tomb.Tomb, c cha
 		case <-t.Dying():
 			s.logger.Info("Syslog datasource is dying")
 			s.serverTomb.Kill(nil)
-			return s.serverTomb.Wait()
-		case <-s.serverTomb.Dying():
-			s.logger.Info("Syslog server is dying, exiting")
-			return nil
 		case <-s.serverTomb.Dead():
 			s.logger.Info("Syslog server has exited")
 			return nil


### PR DESCRIPTION
Fixes https://github.com/crowdsecurity/crowdsec/issues/1169

To reproduce the above issue, syslog server needs decent traffic. This can be simulated by running the following python script :
```python
import subprocess
while True:
	subprocess.Popen(['logger', '"asdaad"', '-d', '-n', '127.0.0.1', '-P', '514'])
```

The issue is caused because:
The server tomb wait call at https://github.com/crowdsecurity/crowdsec/blob/9a42190e13b26a39182125caebb301b132ec39ae/pkg/acquisition/modules/syslog/syslog.go#L188 never finishes . This is because it is blocked at https://github.com/crowdsecurity/crowdsec/blob/9a42190e13b26a39182125caebb301b132ec39ae/pkg/acquisition/modules/syslog/internal/syslogserver.go#L78 . This channel is being listened to at https://github.com/crowdsecurity/crowdsec/blob/9a42190e13b26a39182125caebb301b132ec39ae/pkg/acquisition/modules/syslog/syslog.go#L195 but it never get "selected" because the select is stuck at the wait. 

The stuff for s.serverTomb.Dying() is removed because it's harmful to exit before the server is really dead (port isn't freed).