### PR TITLE
Email notification plugin add sender_name option

### DIFF
--- a/plugins/notifications/email/email.yaml
+++ b/plugins/notifications/email/email.yaml
@@ -27,6 +27,7 @@ smtp_username:        # Replace with your actual username
 smtp_password:        # Replace with your actual password
 smtp_port:            # Common values are any of [25, 465, 587, 2525]
 auth_type:            # Valid choices are "none", "crammd5", "login", "plain"
+sender_name: "CrowdSec"
 sender_email:         # example: foo@gmail.com
 email_subject: "CrowdSec Notification"
 receiver_emails:

--- a/plugins/notifications/email/main.go
+++ b/plugins/notifications/email/main.go
@@ -40,6 +40,7 @@ type PluginConfig struct {
 	SMTPUsername   string   `yaml:"smtp_username"`
 	SMTPPassword   string   `yaml:"smtp_password"`
 	SenderEmail    string   `yaml:"sender_email"`
+	SenderName     string   `yaml:"sender_name"`
 	ReceiverEmails []string `yaml:"receiver_emails"`
 	EmailSubject   string   `yaml:"email_subject"`
 	EncryptionType string   `yaml:"encryption_type"`
@@ -88,7 +89,7 @@ func (n *EmailPlugin) Notify(ctx context.Context, notification *protobufs.Notifi
 	logger.Debug("smtp connection done")
 
 	email := mail.NewMSG()
-	email.SetFrom(fmt.Sprintf("From <%s>", cfg.SenderEmail)).
+	email.SetFrom(fmt.Sprintf("%s <%s>", cfg.SenderName, cfg.SenderEmail)).
 		AddTo(cfg.ReceiverEmails...).
 		SetSubject(cfg.EmailSubject)
 	email.SetBody(mail.TextHTML, notification.Text)

--- a/plugins/notifications/email/main.go
+++ b/plugins/notifications/email/main.go
@@ -52,10 +52,42 @@ type EmailPlugin struct {
 }
 
 func (n *EmailPlugin) Configure(ctx context.Context, config *protobufs.Config) (*protobufs.Empty, error) {
-	d := PluginConfig{}
+	d := PluginConfig{
+		SMTPPort:       587,
+		SenderName:     "Crowdsec",
+		EmailSubject:   "Crowdsec notification",
+		EncryptionType: "ssltls",
+		AuthType:       "login",
+	}
+
 	if err := yaml.Unmarshal(config.Config, &d); err != nil {
 		return nil, err
 	}
+
+	if d.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	if d.SMTPHost == "" {
+		return nil, fmt.Errorf("SMTP host is not set")
+	}
+
+	if d.SMTPUsername == "" {
+		return nil, fmt.Errorf("SMTP username is not set")
+	}
+
+	if d.SMTPPassword == "" {
+		return nil, fmt.Errorf("SMTP password is not set")
+	}
+
+	if d.SenderEmail == "" {
+		return nil, fmt.Errorf("Sender email is not set")
+	}
+
+	if d.ReceiverEmails == nil || len(d.ReceiverEmails) == 0 {
+		return nil, fmt.Errorf("Receiver emails are not set")
+	}
+
 	n.ConfigByName[d.Name] = d
 	return &protobufs.Empty{}, nil
 }


### PR DESCRIPTION
Ability to define sender_name for the email notification plugin
to fix issue email coming from `From` 