### PR TITLE
fix: deny copy folder to itself or subpath

### DIFF
--- a/pkg/cstest/utils_test.go
+++ b/pkg/cstest/utils_test.go
@@ -1,0 +1,18 @@
+package cstest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckPathNotContained(t *testing.T) {
+	assert.Nil(t, checkPathNotContained("/foo", "/bar"))
+	assert.Nil(t, checkPathNotContained("/foo/bar", "/foo"))
+	assert.Nil(t, checkPathNotContained("/foo/bar", "/"))
+	assert.Nil(t, checkPathNotContained("/path/to/somewhere", "/path/to/somewhere-else"))
+	assert.Nil(t, checkPathNotContained("~/.local/path/to/somewhere", "~/.local/path/to/somewhere-else"))
+	assert.NotNil(t, checkPathNotContained("/foo", "/foo/bar"))
+	assert.NotNil(t, checkPathNotContained("/", "/foo"))
+	assert.NotNil(t, checkPathNotContained("/", "/foo/bar/baz"))
+}


### PR DESCRIPTION
the existing test is missing boundary checks and fails in multiple cases