### PR TITLE
Copy changes to NGINXACCESS pattern from parser

### DIFF
--- a/config/patterns/nginx
+++ b/config/patterns/nginx
@@ -13,7 +13,7 @@ DAY2 \d{2}
 #NGINXERRTIME %{YEAR:year}/%{MONTHNUM2:month}/%{DAY2:day} %{HOUR:hour}:%{MINUTE:minute}:%{SECOND:second}
 NGINXERRTIME %{YEAR}/%{MONTHNUM2}/%{DAY2} %{HOUR}:%{MINUTE}:%{SECOND}
 
-NGINXACCESS %{IPORHOST:remote_addr} - %{NGUSER:remote_user} \[%{HTTPDATE:time_local}\] "%{WORD:method} %{URIPATHPARAM:request} HTTP/%{NUMBER:http_version}" %{NUMBER:status} %{NUMBER:body_bytes_sent} "%{NOTDQUOTE:http_referer}" "%{NOTDQUOTE:http_user_agent}"
+NGINXACCESS %{IPORHOST:remote_addr} - %{NGUSER:remote_user} \[%{HTTPDATE:time_local}\] "%{WORD:verb} %{DATA:request} HTTP/%{NUMBER:http_version}" %{NUMBER:status} %{NUMBER:body_bytes_sent} "%{NOTDQUOTE:http_referer}" "%{NOTDQUOTE:http_user_agent}"
 
 # YYYY/MM/DD HH:MM:SS [LEVEL] PID#TID: *CID MESSAGE
 NGINXERROR %{NGINXERRTIME:time} \[%{LOGLEVEL:loglevel}\] %{NONNEGINT:pid}#%{NONNEGINT:tid}: (\*%{NONNEGINT:cid} )?%{GREEDYDATA:message}


### PR DESCRIPTION
fix crowdsecurity/hub#394
The grok line in the nginx-logs parser got changed, but these changes got not reflected to this pattern.
The traefik parser uses this pattern, which leads to missed http-events because of the missing http verb/method.
The traefik, apache2 and nginx parsers, and http-scenarios all use the field 'verb' instead of the field 'method'.

The hubtest will fail with this PR, as afterwards I need to create an PR with the correct parsers.assert for traefik-logs.yaml.