### PR TITLE
refactor: use runtime rather than ldflags for go details

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,9 @@ DEFAULT_DATADIR ?= "/var/lib/crowdsec/data"
 
 LD_OPTS_VARS= \
 -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Version=$(BUILD_VERSION) \
--X github.com/crowdsecurity/crowdsec/pkg/cwversion.System=$(SYSTEM) \
 -X github.com/crowdsecurity/crowdsec/pkg/cwversion.BuildDate=$(BUILD_TIMESTAMP) \
--X github.com/crowdsecurity/crowdsec/pkg/cwversion.Codename=$(BUILD_CODENAME)  \
+-X github.com/crowdsecurity/crowdsec/pkg/cwversion.Codename=$(BUILD_CODENAME) \
 -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Tag=$(BUILD_TAG) \
--X github.com/crowdsecurity/crowdsec/pkg/cwversion.GoVersion=$(BUILD_GOVERSION) \
 -X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultConfigDir=$(DEFAULT_CONFIGDIR) \
 -X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultDataDir=$(DEFAULT_DATADIR)
 

--- a/pkg/cwversion/version.go
+++ b/pkg/cwversion/version.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"runtime"
 	"strings"
 
 	version "github.com/hashicorp/go-version"
@@ -23,12 +24,12 @@ Additional labels for pre-release and build metadata are available as extensions
 */
 
 var (
-	Version             string // = "v0.0.0"
-	Codename            string // = "SoumSoum"
-	BuildDate           string // = "I don't remember exactly"
-	Tag                 string // = "dev"
-	GoVersion           string // = "1.13"
-	System              string // = "linux"
+	Version             string                  // = "v0.0.0"
+	Codename            string                  // = "SoumSoum"
+	BuildDate           string                  // = "0000-00-00_00:00:00"
+	Tag                 string                  // = "dev"
+	GoVersion           = runtime.Version()[2:] // = "1.13"
+	System              = runtime.GOOS          // = "linux"
 	Constraint_parser   = ">= 1.0, <= 2.0"
 	Constraint_scenario = ">= 1.0, < 3.0"
 	Constraint_api      = "v1"


### PR DESCRIPTION
Moved to using `runtime` to grab the GoVersion and System


Are there any opinions on removing `RELEASE.json` and moving that into `pkgs/cwversion/version.go`?


```
λ ./cmd/crowdsec/crowdsec -version
2022/03/03 08:18:45 version: v1.3.1-1-g07f2b64f-07f2b64f63ed339bc7f7664192452060929ccd2b
2022/03/03 08:18:45 Codename: alphaga
2022/03/03 08:18:45 BuildDate: 2022-03-03_08:17:10
2022/03/03 08:18:45 GoVersion: 1.17.7
2022/03/03 08:18:45 Platform: linux
2022/03/03 08:18:45 Constraint_parser: >= 1.0, <= 2.0
2022/03/03 08:18:45 Constraint_scenario: >= 1.0, < 3.0
2022/03/03 08:18:45 Constraint_api: v1
2022/03/03 08:18:45 Constraint_acquis: >= 1.0, < 2.0
λ ./cmd/crowdsec-cli/cscli version
FATA[03-03-2022 08:19:05 AM] failed to read config file: open /etc/crowdsec/config.yaml: no such file or directory
λ ./cmd/crowdsec-cli/cscli version --config ./config/config.yaml
2022/03/03 08:19:12 version: v1.3.1-1-g07f2b64f-07f2b64f63ed339bc7f7664192452060929ccd2b
2022/03/03 08:19:12 Codename: alphaga
2022/03/03 08:19:12 BuildDate: 2022-03-03_08:17:13
2022/03/03 08:19:12 GoVersion: 1.17.7
2022/03/03 08:19:12 Platform: linux
2022/03/03 08:19:12 Constraint_parser: >= 1.0, <= 2.0
2022/03/03 08:19:12 Constraint_scenario: >= 1.0, < 3.0
2022/03/03 08:19:12 Constraint_api: v1
2022/03/03 08:19:12 Constraint_acquis: >= 1.0, < 2.0
```

---

I ran make on tag `v1.3.0` just to compare the output:

(as a note it's pulled in some freebsd stuff from the wrong commit but that looks fixed in master by #1265)

```
λ git checkout v1.3.0
Note: switching to 'v1.3.0'.

HEAD is now at 715c32ef clean up hub dir on rpm remove (#1205)

λ git status
HEAD detached at v1.3.0
nothing to commit, working tree clean

λ git branch
* (HEAD detached at v1.3.0)
  master
  reduce_ldflags

λ git log -1
commit 715c32ef9c4ca6b152b68aac3d5c407fb3d3b7ac (HEAD, tag: v1.3.0-rc5, tag: v1.3.0)
Author: Manuel Sabban <github@sabban.eu>
Date:   Mon Jan 24 18:16:51 2022 +0100

    clean up hub dir on rpm remove (#1205)

    Co-authored-by: sabban <15465465+sabban@users.noreply.github.com>

# should probably use git describe --tags `git rev-parse HEAD` instead
λ git describe --tags `git rev-list --tags --max-count=1`
v1.3.1-freebsd
λ git describe --tags
v1.3.0
λ git rev-list --tags --max-count=1
5e297ef4dd59e9814f18e51858cc055c6d521d4a

λ make
/home/jk/projects/personal/crowdsec/platform/linux.mk:5: Building for linux
rm -f crowdsec
go test -ldflags "-s -w -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Version="v1.3.1-freebsd" -X github.com/crowdsecurity/crowdsec/pkg/cwversion.System=linux -X github.com/crowdsecurity/crowdsec/pkg/cwversion.BuildDate=2022-03-03_08:25:37 -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Codename=alphaga -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Tag="715c32ef9c4ca6b152b68aac3d5c407fb3d3b7ac" -X github.com/crowdsecurity/crowdsec/pkg/cwversion.GoVersion="1.17.7"" -v ./...
go: downloading entgo.io/ent v0.9.1
go: downloading github.com/go-sql-driver/mysql v1.5.1-0.20200311113236-681ffa848bae
go: downloading github.com/lib/pq v1.10.2
?   	github.com/crowdsecurity/crowdsec/cmd/crowdsec	[no test files]
rm -f crowdsec
go build -ldflags "-s -w -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Version="v1.3.1-freebsd" -X github.com/crowdsecurity/crowdsec/pkg/cwversion.System=linux -X github.com/crowdsecurity/crowdsec/pkg/cwversion.BuildDate=2022-03-03_08:26:24 -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Codename=alphaga -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Tag="715c32ef9c4ca6b152b68aac3d5c407fb3d3b7ac" -X github.com/crowdsecurity/crowdsec/pkg/cwversion.GoVersion="1.17.7"" -o crowdsec -v
github.com/mgutz/ansi
github.com/cpuguy83/go-md2man/v2/md2man
github.com/spf13/cobra
github.com/crowdsecurity/crowdsec/pkg/metabase
github.com/crowdsecurity/crowdsec/pkg/cstest
github.com/AlecAivazis/survey/v2/core
github.com/spf13/cobra/doc
github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli
github.com/crowdsecurity/email-plugin

λ ./cmd/crowdsec/crowdsec -version
2022/03/03 08:27:24 version: v1.3.1-freebsd-715c32ef9c4ca6b152b68aac3d5c407fb3d3b7ac
2022/03/03 08:27:24 Codename: alphaga
2022/03/03 08:27:24 BuildDate: 2022-03-03_08:26:24
2022/03/03 08:27:24 GoVersion: 1.17.7
2022/03/03 08:27:24 Constraint_parser: >= 1.0, <= 2.0
2022/03/03 08:27:24 Constraint_scenario: >= 1.0, < 3.0
2022/03/03 08:27:24 Constraint_api: v1
2022/03/03 08:27:24 Constraint_acquis: >= 1.0, < 2.0

λ ./cmd/crowdsec-cli/cscli version --config ./config/config.yaml
2022/03/03 08:29:05 version: v1.3.1-freebsd-715c32ef9c4ca6b152b68aac3d5c407fb3d3b7ac
2022/03/03 08:29:05 Codename: alphaga
2022/03/03 08:29:05 BuildDate: 2022-03-03_08:26:26
2022/03/03 08:29:05 GoVersion: 1.17.7
2022/03/03 08:29:05 Constraint_parser: >= 1.0, <= 2.0
2022/03/03 08:29:05 Constraint_scenario: >= 1.0, < 3.0
2022/03/03 08:29:05 Constraint_api: v1
2022/03/03 08:29:05 Constraint_acquis: >= 1.0, < 2.0