### PR TITLE
Fix 1314

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -89,9 +89,13 @@ if [ "$1" = configure ]; then
 
     systemctl --quiet is-enabled crowdsec || systemctl unmask crowdsec && systemctl enable crowdsec
 
-    cscli config show --key "Config.API.Server"|grep -q "<nil>" && LAPI=false
-    PORT=$(cscli config show --key "Config.API.Server.ListenURI"|cut -d ":" -f2)
-    if [ -z "$(ss -nlt "sport = ${PORT}" | grep -v ^State)" ] || [ "$LAPI" = false ]  ; then
+    API=$(cscli config show --key "Config.API.Server")
+    if [ "$API" = "<nil>" ] ; then
+        LAPI=false
+    else
+        PORT=$(cscli config show --key "Config.API.Server.ListenURI"|cut -d ":" -f2)
+    fi
+    if [ "$LAPI" = false ] || [ -z "$(ss -nlt "sport = ${PORT}" | grep -v ^State)" ]  ; then
         systemctl start crowdsec
     else
         echo "Not attempting to start crowdsec, port ${PORT} is already used or lapi was disabled"

--- a/debian/postinst
+++ b/debian/postinst
@@ -89,6 +89,7 @@ if [ "$1" = configure ]; then
 
     systemctl --quiet is-enabled crowdsec || systemctl unmask crowdsec && systemctl enable crowdsec
 
+    cscli config show --key "Config.API.Server"|grep -q "<nil>" && LAPI=false
     PORT=$(cscli config show --key "Config.API.Server.ListenURI"|cut -d ":" -f2)
     if [ -z "$(ss -nlt "sport = ${PORT}" | grep -v ^State)" ] || [ "$LAPI" = false ]  ; then
         systemctl start crowdsec

--- a/debian/rules
+++ b/debian/rules
@@ -22,7 +22,7 @@ override_dh_auto_install:
 # echo $($GOCMD version)
 # cd cmd/crowdsec && GOROOT=/tmp/go GO111MODULE=on $(GOBUILD) $(LD_OPTS) -o $(CROWDSEC_BIN) -v && cd ..
 # cd cmd/crowdsec-cli  && GOROOT=/tmp/go GO111MODULE=on $(GOBUILD) $(LD_OPTS) -o cscli -v && cd ..
-	make
+	make build
 	mkdir -p debian/crowdsec/usr/bin
 	mkdir -p debian/crowdsec/etc/crowdsec
 	mkdir -p debian/crowdsec/usr/share/crowdsec

--- a/rpm/SPECS/crowdsec.spec
+++ b/rpm/SPECS/crowdsec.spec
@@ -39,7 +39,7 @@ BuildRequires:  systemd
 %patch2
 
 %build
-BUILD_VERSION=%{local_version} make
+BUILD_VERSION=%{local_version} make build
 sed -i "s#/usr/local/lib/crowdsec/plugins/#%{_libdir}/%{name}/plugins/#g" config/config.yaml
 
 %install


### PR DESCRIPTION
fix bug #1314 in postinst : 
In the case of Crowdsec not serving a LAPI, `cscli config show --key Config.API.Server.ListenURI` returns an error. This PR prevents this to be run when `Config.API.Server` returns `<nil>` (ie when local API Server is disabled).

Tests show that it works on rpm as well. This has to be tested again before next release.