### PR TITLE
Register bouncers on container init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN SYSTEM="docker" make release
 RUN cd crowdsec-v* && ./wizard.sh --docker-mode && cd -
 RUN cscli hub update && cscli collections install crowdsecurity/linux && cscli parsers install crowdsecurity/whitelists
 FROM alpine:latest
-RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community tzdata yq bash && \
+RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community tzdata yq jq bash && \
   mkdir -p /staging/etc/crowdsec && \
   mkdir -p /staging/var/lib/crowdsec
 COPY --from=build /etc/crowdsec /staging/etc/crowdsec

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -23,6 +23,7 @@ RUN apt-get install -y -q --install-recommends --no-install-suggests \
     iproute2 \
     ca-certificates \
     bash \
+    jq \
     tzdata && \
     mkdir -p /staging/etc/crowdsec && \
     mkdir -p /staging/var/lib/crowdsec

--- a/docker/README.md
+++ b/docker/README.md
@@ -104,6 +104,16 @@ https://hub.crowdsec.net/browse/#bouncers
 
 https://docs.crowdsec.net/docs/user_guides/bouncers_configuration/
 
+### Automatic Bouncer Registration
+
+You can automatically register bouncers with the crowdsec container on startup using environment variables or Docker secrets. You cannot use this process to update an existing bouncer without first deleting it.
+
+To use environment variables, they should be in the format `BOUNCER_KEY_<name>=<key>`. e.g. `BOUNCER_KEY_nginx=mysecretkey12345`.
+
+To use Docker secrets, the secret should be named `bouncer_key_<name>` with a content of `<key>`. e.g. `bouncer_key_nginx` with a content of `mysecretkey12345`.
+
+A bouncer key can be any string but we recommend an alphanumeric value to keep consistent with crowdsec-generated keys and avoid problems with escaping special characters.
+
 ## Console
 We provide a web based interface to get more from Crowdsec: https://docs.crowdsec.net/docs/console
 
@@ -142,6 +152,7 @@ Using binds rather than named volumes ([more explanation here](https://docs.dock
 * `DISABLE_SCENARIOS`       - Scenarios to remove from the [hub](https://hub.crowdsec.net/browse/#configurations), separated by space : `-e DISABLE_SCENARIOS="crowdsecurity/http-bad-user-agent crowdsecurity/http-xss-probing"`
 * `DISABLE_POSTOVERFLOWS`   - Postoverflows to remove from the [hub](https://hub.crowdsec.net/browse/#configurations), separated by space : `-e DISABLE_POSTOVERFLOWS="crowdsecurity/cdn-whitelist crowdsecurity/seo-bots-whitelist"`
 * `PLUGIN_DIR`              - Directory for plugins (default: `/usr/local/lib/crowdsec/plugins/`) : `-e PLUGIN_DIR="<path>"`
+* `BOUNCER_KEY_<name>`      - Register a bouncer with the name `<name>` and a key equal to the value of the environment variable.
 
 ## Volumes
 

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -123,7 +123,9 @@ for BOUNCER in $(compgen -A variable | grep -i BOUNCER_KEY); do
     NAME=$(printf '%s' "$BOUNCER" | awk -F "_" '{printf $3}')
     if [[ -n $KEY ]] && [[ -n $NAME ]]; then
         if ! cscli -c "$CS_CONFIG_FILE" bouncers list -o json | jq -r .[].name | grep -q "${NAME}"; then
-            if ! cscli -c "$CS_CONFIG_FILE" bouncers add "${NAME}" -k "${KEY}" > /dev/null; then
+            if cscli -c "$CS_CONFIG_FILE" bouncers add "${NAME}" -k "${KEY}" > /dev/null; then
+                echo "Registered bouncer for ${NAME}"
+            else
                 echo "Failed to register bouncer for ${NAME}"
             fi
         fi
@@ -137,7 +139,9 @@ for BOUNCER in /run/secrets/@(bouncer_key|BOUNCER_KEY)* ; do
     NAME=$(echo "${BOUNCER}" | awk -F "/" '{printf $NF}' | awk -F "_" '{printf $3}')
     if [[ -n $KEY ]] && [[ -n $NAME ]]; then    
         if ! cscli -c "$CS_CONFIG_FILE" bouncers list -o json | jq -r .[].name | grep -q "${NAME}"; then
-            if ! cscli -c "$CS_CONFIG_FILE" bouncers add "${NAME}" -k "${KEY}" > /dev/null; then
+            if cscli -c "$CS_CONFIG_FILE" bouncers add "${NAME}" -k "${KEY}" > /dev/null; then
+                echo "Registered bouncer for ${NAME}"
+            else
                 echo "Failed to register bouncer for ${NAME}"
             fi
         fi

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -120,7 +120,7 @@ fi
 ## Register bouncers via env
 for BOUNCER in $(compgen -A variable | grep -i BOUNCER_KEY); do
     KEY=$(printf '%s' "${!BOUNCER}")
-    NAME=$(printf '%s' "$BOUNCER" | awk -F "_" '{printf $3}')
+    NAME=$(printf '%s' "$BOUNCER" | cut -d_  -f2-)
     if [[ -n $KEY ]] && [[ -n $NAME ]]; then
         if ! cscli -c "$CS_CONFIG_FILE" bouncers list -o json | jq -r .[].name | grep -q "${NAME}"; then
             if cscli -c "$CS_CONFIG_FILE" bouncers add "${NAME}" -k "${KEY}" > /dev/null; then
@@ -136,7 +136,7 @@ done
 shopt -s nullglob extglob
 for BOUNCER in /run/secrets/@(bouncer_key|BOUNCER_KEY)* ; do
     KEY=$(cat "${BOUNCER}")
-    NAME=$(echo "${BOUNCER}" | awk -F "/" '{printf $NF}' | awk -F "_" '{printf $3}')
+    NAME=$(echo "${BOUNCER}" | awk -F "/" '{printf $NF}' | cut -d_  -f2-)
     if [[ -n $KEY ]] && [[ -n $NAME ]]; then    
         if ! cscli -c "$CS_CONFIG_FILE" bouncers list -o json | jq -r .[].name | grep -q "${NAME}"; then
             if cscli -c "$CS_CONFIG_FILE" bouncers add "${NAME}" -k "${KEY}" > /dev/null; then

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -123,7 +123,9 @@ for BOUNCER in $(compgen -A variable | grep -i BOUNCER_KEY); do
     NAME=$(printf '%s' "$BOUNCER" | awk -F "_" '{printf $3}')
     if [[ -n $KEY ]] && [[ -n $NAME ]]; then
         if ! cscli -c "$CS_CONFIG_FILE" bouncers list -o json | jq -r .[].name | grep -q "${NAME}"; then
-            cscli -c "$CS_CONFIG_FILE" bouncers add "${NAME}" -k "${KEY}"
+            if ! cscli -c "$CS_CONFIG_FILE" bouncers add "${NAME}" -k "${KEY}" > /dev/null; then
+                echo "Failed to register bouncer for ${NAME}"
+            fi
         fi
     fi
 done
@@ -135,7 +137,9 @@ for BOUNCER in /run/secrets/@(bouncer_key|BOUNCER_KEY)* ; do
     NAME=$(echo "${BOUNCER}" | awk -F "/" '{printf $NF}' | awk -F "_" '{printf $3}')
     if [[ -n $KEY ]] && [[ -n $NAME ]]; then    
         if ! cscli -c "$CS_CONFIG_FILE" bouncers list -o json | jq -r .[].name | grep -q "${NAME}"; then
-            cscli -c "$CS_CONFIG_FILE" bouncers add "${NAME}" -k "${KEY}"
+            if ! cscli -c "$CS_CONFIG_FILE" bouncers add "${NAME}" -k "${KEY}" > /dev/null; then
+                echo "Failed to register bouncer for ${NAME}"
+            fi
         fi
     fi
 done

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -122,8 +122,8 @@ for BOUNCER in $(compgen -A variable | grep -i BOUNCER_KEY)
 do
     KEY=$(printf '%s' "${!BOUNCER}")
     NAME=$(printf '%s' "$BOUNCER" | awk -F "_" '{printf $3}')
-    if ! cscli -c "$CS_CONFIG_FILE" bouncers list -o json | jq -r .[].name | grep -q "${NAME}"; then
-        if [[ -n $KEY ]] && [[ -n $NAME ]]; then
+    if [[ -n $KEY ]] && [[ -n $NAME ]]; then
+        if ! cscli -c "$CS_CONFIG_FILE" bouncers list -o json | jq -r .[].name | grep -q "${NAME}"; then
             cscli -c "$CS_CONFIG_FILE" bouncers add "${NAME}" -k "${KEY}"
         fi
     fi
@@ -135,8 +135,8 @@ for BOUNCER in /run/secrets/@(bouncer_key|BOUNCER_KEY)*
 do
     KEY=$(cat "${BOUNCER}")
     NAME=$(echo "${BOUNCER}" | awk -F "/" '{printf $NF}' | awk -F "_" '{printf $3}')
-    if ! cscli -c "$CS_CONFIG_FILE" bouncers list -o json | jq -r .[].name | grep -q "${NAME}"; then
-        if [[ -n $KEY ]] && [[ -n $NAME ]]; then
+    if [[ -n $KEY ]] && [[ -n $NAME ]]; then    
+        if ! cscli -c "$CS_CONFIG_FILE" bouncers list -o json | jq -r .[].name | grep -q "${NAME}"; then
             cscli -c "$CS_CONFIG_FILE" bouncers add "${NAME}" -k "${KEY}"
         fi
     fi

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -117,6 +117,32 @@ if [ "$DISABLE_POSTOVERFLOWS" != "" ]; then
     cscli -c "$CS_CONFIG_FILE" postoverflows remove $DISABLE_POSTOVERFLOWS
 fi
 
+## Register bouncers via env
+for BOUNCER in $(compgen -A variable | grep -i BOUNCER_KEY)
+do
+    KEY=$(printf '%s' "${!BOUNCER}")
+    NAME=$(printf '%s' "$BOUNCER" | awk -F "_" '{printf $3}')
+    if ! cscli -c "$CS_CONFIG_FILE" bouncers list -o json | jq -r .[].name | grep -q "${NAME}"; then
+        if [[ -n $KEY ]] && [[ -n $NAME ]]; then
+            cscli -c "$CS_CONFIG_FILE" bouncers add "${NAME}" -k "${KEY}"
+        fi
+    fi
+done
+
+## Register bouncers via secrets
+shopt -s nullglob extglob
+for BOUNCER in /run/secrets/@(bouncer_key|BOUNCER_KEY)*
+do
+    KEY=$(cat "${BOUNCER}")
+    NAME=$(echo "${BOUNCER}" | awk -F "/" '{printf $NF}' | awk -F "_" '{printf $3}')
+    if ! cscli -c "$CS_CONFIG_FILE" bouncers list -o json | jq -r .[].name | grep -q "${NAME}"; then
+        if [[ -n $KEY ]] && [[ -n $NAME ]]; then
+            cscli -c "$CS_CONFIG_FILE" bouncers add "${NAME}" -k "${KEY}"
+        fi
+    fi
+done
+shopt -u nullglob extglob
+
 ARGS=""
 if [ "$CONFIG_FILE" != "" ]; then
     ARGS="-c $CONFIG_FILE"

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -76,13 +76,13 @@ if [ "$GID" != "" ]; then
 fi
 
 if [ "$USE_TLS" != "" ]; then
-   yq -i eval ".api.server.tls.cert_file = \"$CERT_FILE\"" "$CS_CONFIG_FILE"
-   yq -i eval ".api.server.tls.key_file = \"$KEY_FILE\"" "$CS_CONFIG_FILE"
-   yq -i eval '... comments=""' "$CS_CONFIG_FILE"
+    yq -i eval ".api.server.tls.cert_file = \"$CERT_FILE\"" "$CS_CONFIG_FILE"
+    yq -i eval ".api.server.tls.key_file = \"$KEY_FILE\"" "$CS_CONFIG_FILE"
+    yq -i eval '... comments=""' "$CS_CONFIG_FILE"
 fi
 
 if [ "$PLUGIN_DIR" != "/usr/local/lib/crowdsec/plugins/" ]; then
-   yq -i eval ".config_paths.plugin_dir = \"$PLUGIN_DIR\"" "$CS_CONFIG_FILE"
+    yq -i eval ".config_paths.plugin_dir = \"$PLUGIN_DIR\"" "$CS_CONFIG_FILE"
 fi
 
 ## Install collections, parsers, scenarios & postoverflows
@@ -118,8 +118,7 @@ if [ "$DISABLE_POSTOVERFLOWS" != "" ]; then
 fi
 
 ## Register bouncers via env
-for BOUNCER in $(compgen -A variable | grep -i BOUNCER_KEY)
-do
+for BOUNCER in $(compgen -A variable | grep -i BOUNCER_KEY); do
     KEY=$(printf '%s' "${!BOUNCER}")
     NAME=$(printf '%s' "$BOUNCER" | awk -F "_" '{printf $3}')
     if [[ -n $KEY ]] && [[ -n $NAME ]]; then
@@ -131,8 +130,7 @@ done
 
 ## Register bouncers via secrets
 shopt -s nullglob extglob
-for BOUNCER in /run/secrets/@(bouncer_key|BOUNCER_KEY)*
-do
+for BOUNCER in /run/secrets/@(bouncer_key|BOUNCER_KEY)* ; do
     KEY=$(cat "${BOUNCER}")
     NAME=$(echo "${BOUNCER}" | awk -F "/" '{printf $NF}' | awk -F "_" '{printf $3}')
     if [[ -n $KEY ]] && [[ -n $NAME ]]; then    


### PR DESCRIPTION
This PR allows users to add bouncers on container init, rather than having to exec into the container and run `cscli`, for automated deployment scenarios. `jq` is added to the Dockerfile to support parsing cscli output.

Supports both environment variables (in the format `BOUNCER_KEY_<NAME>=<API-KEY>`) and docker secrets (in the format `BOUNCER_KEY_<name>` with the contents `<API-KEY>`). Adding multiple bouncers and mixing environment and secrets are supported (though environment will take precedence in the event of conflicting names).

The init script checks that both a name and a key value have been provided, then it checks to see if there is already an existing bouncer with that name registered (in which case it skips it), and then registers the bouncer with the NAME and KEY provided.

This allows you to do something like:
```yml
services:
  crowdsec:
    image: docker.io/crowdsecurity/crowdsec:latest
    container_name: crowdsec
    environment:
      - BOUNCER_KEY_traefik=mysecretkey12345

  bouncer-traefik:
    image: docker.io/fbonalair/traefik-crowdsec-bouncer:latest
    container_name: crowdsec-bouncer-traefik
    environment:
      - CROWDSEC_BOUNCER_API_KEY=mysecretkey12345
    depends_on:
      - crowdsec
```
On first init of the crowdsec container the logs should output something along the lines of:
```
Api key for 'traefik':

   mysecretkey12345

Please keep this key since you will not be able to retrieve it!
```
And `cscli bouncers list` should show:
```
--------------------------------------------------------------
 NAME  IP ADDRESS  VALID  LAST API PULL         TYPE  VERSION 
--------------------------------------------------------------
 traefik             ✔️   2022-03-09T20:55:12Z                
--------------------------------------------------------------
```