### PR TITLE
Display acquisition dir in cscli config show

### DIFF
--- a/cmd/crowdsec-cli/config.go
+++ b/cmd/crowdsec-cli/config.go
@@ -340,6 +340,9 @@ func NewConfigCmd() *cobra.Command {
 					fmt.Printf("Crowdsec:\n")
 					fmt.Printf("  - Acquisition File        : %s\n", csConfig.Crowdsec.AcquisitionFilePath)
 					fmt.Printf("  - Parsers routines        : %d\n", csConfig.Crowdsec.ParserRoutinesCount)
+					if csConfig.Crowdsec.AcquisitionDirPath != "" {
+						fmt.Printf("  - Acquisition Folder      : %s\n", csConfig.Crowdsec.AcquisitionDirPath)
+					}
 				}
 				if csConfig.Cscli != nil {
 					fmt.Printf("cscli:\n")


### PR DESCRIPTION
Fix #1347 

```bash
sudo cscli config show
Global:
   - Configuration Folder   : /etc/crowdsec
   - Data Folder            : /var/lib/crowdsec/data
   - Hub Folder             : /etc/crowdsec/hub
   - Simulation File        : /etc/crowdsec/simulation.yaml
   - Log Folder             : /var/log/
   - Log level              : info
   - Log Media              : file
Crowdsec:
  - Acquisition File        : /etc/crowdsec/acquis.yaml
  - Parsers routines        : 1
  - Acquisition Folder      : /etc/crowdsec/acquis.d/

```