### PR TITLE
[wip] Disable a scenario/parser without tainting a collection

### DIFF
--- a/pkg/cwhub/cwhub.go
+++ b/pkg/cwhub/cwhub.go
@@ -217,6 +217,10 @@ func ItemStatus(v Item) (string, bool, bool, bool) {
 		strret = "enabled"
 	}
 
+	if v.Downloaded && !v.Installed {
+		strret += ",downloaded"
+	}
+
 	Managed := true
 	if v.Local {
 		Managed = false
@@ -278,7 +282,7 @@ func GetHubStatusForItemType(itemType string, name string, all bool) []ItemHubSt
 			continue
 		}
 		//Only enabled items ?
-		if !all && !item.Installed {
+		if !all && !item.Downloaded {
 			continue
 		}
 		//Check the item status

--- a/pkg/cwhub/loader.go
+++ b/pkg/cwhub/loader.go
@@ -248,7 +248,6 @@ func CollecDepsCheck(v *Item) error {
 		log.Debugf("%s dependencies not checked : not up-to-date", v.Name)
 		return nil
 	}
-
 	/*if it's a collection, ensure all the items are installed, or tag it as tainted*/
 	if v.Type == COLLECTIONS {
 		log.Tracef("checking submembers of %s installed:%t", v.Name, v.Installed)
@@ -277,11 +276,8 @@ func CollecDepsCheck(v *Item) error {
 					v.Tainted = true
 					return fmt.Errorf("tainted %s %s, tainted.", ptrtype, p)
 				}
-				if !val.Installed && v.Installed {
-					v.Tainted = true
-					return fmt.Errorf("missing %s %s, tainted.", ptrtype, p)
-				}
-				if !val.UpToDate {
+
+				if !val.UpToDate && val.Installed {
 					v.UpToDate = false
 					return fmt.Errorf("outdated %s %s", ptrtype, p)
 				}

--- a/tests/bats/20_collections.bats
+++ b/tests/bats/20_collections.bats
@@ -53,3 +53,18 @@ teardown() {
     assert_output --partial "unable to disable crowdsecurity/mysql"
     assert_output --partial "doesn't exist"
 }
+
+@test "$FILE disable scenario wihtout tainting a collection" {
+    run -0 cscli scenarios remove crowdsecurity/ssh-slow-bf
+    run -0 cscli collections list -o json
+    run -0 jq '.collections[] | select(.name=="crowdsecurity/sshd") | .status=="enabled"' <(output)
+    assert_output 'true'
+}
+
+@test "$FILE disable parser wihtout tainting a collection" {
+    run -0 cscli collections install crowdsecurity/mysql
+    run -0 cscli parsers remove crowdsecurity/mysql-logs
+    run -0 cscli collections list -o json
+    run -0 jq '.collections[] | select(.name=="crowdsecurity/mysql") | .status=="enabled"' <(output)
+    assert_output 'true'
+}


### PR DESCRIPTION
Fix https://github.com/crowdsecurity/crowdsec/issues/1348

Note: Currently, `cscli <item_type> remove` doesn't really remove an item but disable it (we need to provide `--purge` to remove the item).

- Don't consider a collection as tainted if we have remove it without `--purge`

TODO: check behavior on item or collection upgrade