### PR TITLE
allow capi register in functional tests

### DIFF
--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -101,7 +101,8 @@ func NewCapiCmd() *cobra.Command {
 		},
 	}
 	cmdCapiRegister.Flags().StringVarP(&outputFile, "file", "f", "", "output file destination")
-	cmdCapiRegister.Flags().StringVar(&capiUserPrefix, "override-capi-user-prefix", "", "prepend text to the CAPI user to register (use for tests only)")
+	cmdCapiRegister.Flags().StringVar(&capiUserPrefix, "schmilblick", "", "set a schmilblick (use in tests only)")
+	cmdCapiRegister.Flags().MarkHidden("schmilblick")
 	cmdCapi.AddCommand(cmdCapiRegister)
 
 	var cmdCapiStatus = &cobra.Command{

--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -20,6 +20,7 @@ import (
 
 var CAPIURLPrefix string = "v2"
 var CAPIBaseURL string = "https://api.crowdsec.net/"
+var capiUserPrefix string
 
 func NewCapiCmd() *cobra.Command {
 	var cmdCapi = &cobra.Command{
@@ -46,8 +47,7 @@ func NewCapiCmd() *cobra.Command {
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
-
-			id, err := generateID()
+			capiUser, err := generateID(capiUserPrefix)
 			if err != nil {
 				log.Fatalf("unable to generate machine id: %s", err)
 			}
@@ -57,7 +57,7 @@ func NewCapiCmd() *cobra.Command {
 				log.Fatalf("unable to parse api url %s : %s", CAPIBaseURL, err)
 			}
 			_, err = apiclient.RegisterClient(&apiclient.Config{
-				MachineID:     id,
+				MachineID:     capiUser,
 				Password:      password,
 				UserAgent:     fmt.Sprintf("crowdsec/%s", cwversion.VersionStr()),
 				URL:           apiurl,
@@ -79,7 +79,7 @@ func NewCapiCmd() *cobra.Command {
 				dumpFile = ""
 			}
 			apiCfg := csconfig.ApiCredentialsCfg{
-				Login:    id,
+				Login:    capiUser,
 				Password: password.String(),
 				URL:      CAPIBaseURL,
 			}
@@ -101,6 +101,7 @@ func NewCapiCmd() *cobra.Command {
 		},
 	}
 	cmdCapiRegister.Flags().StringVarP(&outputFile, "file", "f", "", "output file destination")
+	cmdCapiRegister.Flags().StringVar(&capiUserPrefix, "override-capi-user-prefix", "", "prepend text to the CAPI user to register (use for tests only)")
 	cmdCapi.AddCommand(cmdCapiRegister)
 
 	var cmdCapiStatus = &cobra.Command{

--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -51,7 +51,7 @@ Keep in mind the machine needs to be validated by an administrator on LAPI side 
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 			if lapiUser == "" {
-				lapiUser, err = generateID()
+				lapiUser, err = generateID("")
 				if err != nil {
 					log.Fatalf("unable to generate machine id: %s", err)
 				}

--- a/tests/instance-data
+++ b/tests/instance-data
@@ -90,7 +90,7 @@ make_init_data() {
     ./instance-db setup
 
     "${CSCLI}" machines add githubciXXXXXXXXXXXXXXXXXXXXXXXX --auto
-    "${CSCLI}" capi register
+    "${CSCLI}" capi register --override-capi-user-prefix githubciXXXXXXXXXXXXXXXXXXXXXXXX
     "${CSCLI}" hub update
     "${CSCLI}" collections install crowdsecurity/linux
 

--- a/tests/instance-data
+++ b/tests/instance-data
@@ -90,7 +90,7 @@ make_init_data() {
     ./instance-db setup
 
     "${CSCLI}" machines add githubciXXXXXXXXXXXXXXXXXXXXXXXX --auto
-    "${CSCLI}" capi register --override-capi-user-prefix githubciXXXXXXXXXXXXXXXXXXXXXXXX
+    "${CSCLI}" capi register --schmilblick githubciXXXXXXXXXXXXXXXXXXXXXXXX
     "${CSCLI}" hub update
     "${CSCLI}" collections install crowdsecurity/linux
 


### PR DESCRIPTION
This allows to set a recognizable value for tests, in all possible contexts including where machine-id cannot be changed (non-root) or could break systems (dev machines). When all code that creates test instances is converted we can set new users with machineid.protectedID() which sends a hash instead for increased privacy.