### PR TITLE
remove trailing / from cp in make release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ package-common:
 	@cp $(SPLUNK_PLUGIN_FOLDER)/$(SPLUNK_PLUGIN_CONFIG) $(RELDIR)/$(subst ./,,$(SPLUNK_PLUGIN_FOLDER))
 	@cp $(EMAIL_PLUGIN_FOLDER)/$(EMAIL_PLUGIN_CONFIG) $(RELDIR)/$(subst ./,,$(EMAIL_PLUGIN_FOLDER))
 
-	@cp -R ./config/ $(RELDIR)
+	@cp -R ./config $(RELDIR)
 	@cp wizard.sh $(RELDIR)
 	@cp scripts/test_env.sh $(RELDIR)
 


### PR DESCRIPTION
When building on macos, if the first arg to `cp` ends with a `/`, the content of the directory is copied rather than the directory itself.

Removes the trailing / to be able to use `test_env.sh` properly on macos.