### PR TITLE
Fix plugin default config to support group threshold

### DIFF
--- a/pkg/csplugin/broker.go
+++ b/pkg/csplugin/broker.go
@@ -356,8 +356,8 @@ func setRequiredFields(pluginCfg *PluginConfig) {
 		pluginCfg.TimeOut = time.Second * 5
 	}
 
-	if pluginCfg.GroupWait == time.Second*0 {
-		pluginCfg.GroupWait = time.Second * 1
+	if pluginCfg.GroupWait == time.Second*0 && pluginCfg.GroupThreshold == 0 {
+		pluginCfg.GroupThreshold = 1
 	}
 }
 

--- a/pkg/csplugin/tests/notifications/dummy.yaml
+++ b/pkg/csplugin/tests/notifications/dummy.yaml
@@ -4,7 +4,7 @@ name: dummy_default # Must match the registered plugin in the profile
 # One of "trace", "debug", "info", "warn", "error", "off"
 log_level: info
 
-# group_wait:         # Time to wait collecting alerts before relaying a message to this plugin, eg "30s"
+group_wait: 1s       # Time to wait collecting alerts before relaying a message to this plugin, eg "30s"
 # group_threshold:    # Amount of alerts that triggers a message before <group_wait> has expired, eg "10"
 # max_retry:          # Number of attempts to relay messages to plugins in case of error
 # timeout:            # Time to wait for response from the plugin before considering the attempt a failure, eg "10s"


### PR DESCRIPTION
Fixes https://discourse.crowdsec.net/t/http-plugin-configuration-group-wait-and-group-threshold-problem/649/3

This error was caused due to somewhat wrong default config.
Old logic was:

If group_wait  is absent then set group_wait = 1s . This is fine in majority of cases. However when group_wait is absent and group_threshold is present, then also the code was setting group_wait = 1s . Thus rectifying group_threshold semantic.

New logic is:

Set group_threshold=1 only if group_threshold and group_wait is absent. Otherwise use provided config.

