### PR TITLE
[wip] Support Client Auth via certificates

### DIFF
--- a/cmd/crowdsec-cli/bouncers.go
+++ b/cmd/crowdsec-cli/bouncers.go
@@ -9,6 +9,7 @@ import (
 
 	middlewares "github.com/crowdsecurity/crowdsec/pkg/apiserver/middlewares/v1"
 	"github.com/crowdsecurity/crowdsec/pkg/database"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/enescakir/emoji"
 	"github.com/olekukonko/tablewriter"
 	log "github.com/sirupsen/logrus"
@@ -64,7 +65,7 @@ Note: This command requires database direct access, so is intended to be run on 
 
 				table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 				table.SetAlignment(tablewriter.ALIGN_LEFT)
-				table.SetHeader([]string{"Name", "IP Address", "Valid", "Last API pull", "Type", "Version"})
+				table.SetHeader([]string{"Name", "IP Address", "Valid", "Last API pull", "Type", "Version", "Auth Type"})
 				for _, b := range blockers {
 					var revoked string
 					if !b.Revoked {
@@ -72,7 +73,7 @@ Note: This command requires database direct access, so is intended to be run on 
 					} else {
 						revoked = emoji.Prohibited.String()
 					}
-					table.Append([]string{b.Name, b.IPAddress, revoked, b.LastPull.Format(time.RFC3339), b.Type, b.Version})
+					table.Append([]string{b.Name, b.IPAddress, revoked, b.LastPull.Format(time.RFC3339), b.Type, b.Version, b.AuthType})
 				}
 				table.Render()
 			} else if csConfig.Cscli.Output == "json" {
@@ -83,7 +84,7 @@ Note: This command requires database direct access, so is intended to be run on 
 				fmt.Printf("%s", string(x))
 			} else if csConfig.Cscli.Output == "raw" {
 				csvwriter := csv.NewWriter(os.Stdout)
-				err := csvwriter.Write([]string{"name", "ip", "revoked", "last_pull", "type", "version"})
+				err := csvwriter.Write([]string{"name", "ip", "revoked", "last_pull", "type", "version", "auth_type"})
 				if err != nil {
 					log.Fatalf("failed to write raw header: %s", err)
 				}
@@ -94,7 +95,7 @@ Note: This command requires database direct access, so is intended to be run on 
 					} else {
 						revoked = "pending"
 					}
-					err := csvwriter.Write([]string{b.Name, b.IPAddress, revoked, b.LastPull.Format(time.RFC3339), b.Type, b.Version})
+					err := csvwriter.Write([]string{b.Name, b.IPAddress, revoked, b.LastPull.Format(time.RFC3339), b.Type, b.Version, b.AuthType})
 					if err != nil {
 						log.Fatalf("failed to write raw: %s", err)
 					}
@@ -128,7 +129,7 @@ cscli bouncers add MyBouncerName -k %s`, generatePassword(32)),
 			if err != nil {
 				log.Fatalf("unable to generate api key: %s", err)
 			}
-			err = dbClient.CreateBouncer(keyName, keyIP, middlewares.HashSHA512(apiKey))
+			err = dbClient.CreateBouncer(keyName, keyIP, middlewares.HashSHA512(apiKey), types.ApiKeyAuthType)
 			if err != nil {
 				log.Fatalf("unable to create bouncer: %s", err)
 			}

--- a/go.sum
+++ b/go.sum
@@ -1349,6 +1349,7 @@ golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.9-0.20211216111533-8d383106f7e7 h1:M1gcVrIb2lSn2FIL19DG0+/b8nNVKJ7W7b4WcAGZAYM=
 golang.org/x/tools v0.1.9-0.20211216111533-8d383106f7e7/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/apiclient/client.go
+++ b/pkg/apiclient/client.go
@@ -3,6 +3,7 @@ package apiclient
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -15,6 +16,8 @@ import (
 
 var (
 	InsecureSkipVerify = false
+	Cert               *tls.Certificate
+	CaCertPool         *x509.CertPool
 )
 
 type ApiClient struct {
@@ -48,7 +51,12 @@ func NewClient(config *Config) (*ApiClient, error) {
 		VersionPrefix:  config.VersionPrefix,
 		UpdateScenario: config.UpdateScenario,
 	}
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: InsecureSkipVerify}
+	tlsconfig := tls.Config{InsecureSkipVerify: InsecureSkipVerify}
+	if Cert != nil {
+		tlsconfig.RootCAs = CaCertPool
+		tlsconfig.Certificates = []tls.Certificate{*Cert}
+	}
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tlsconfig
 	c := &ApiClient{client: t.Client(), BaseURL: config.URL, UserAgent: config.UserAgent, URLPrefix: config.VersionPrefix}
 	c.common.client = c
 	c.Decisions = (*DecisionsService)(&c.common)
@@ -64,7 +72,12 @@ func NewDefaultClient(URL *url.URL, prefix string, userAgent string, client *htt
 	if client == nil {
 		client = &http.Client{}
 		if ht, ok := http.DefaultTransport.(*http.Transport); ok {
-			ht.TLSClientConfig = &tls.Config{InsecureSkipVerify: InsecureSkipVerify}
+			tlsconfig := tls.Config{InsecureSkipVerify: InsecureSkipVerify}
+			if Cert != nil {
+				tlsconfig.RootCAs = CaCertPool
+				tlsconfig.Certificates = []tls.Certificate{*Cert}
+			}
+			ht.TLSClientConfig = &tlsconfig
 			client.Transport = ht
 		}
 	}
@@ -82,7 +95,12 @@ func RegisterClient(config *Config, client *http.Client) (*ApiClient, error) {
 	if client == nil {
 		client = &http.Client{}
 	}
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: InsecureSkipVerify}
+	tlsconfig := tls.Config{InsecureSkipVerify: InsecureSkipVerify}
+	if Cert != nil {
+		tlsconfig.RootCAs = CaCertPool
+		tlsconfig.Certificates = []tls.Certificate{*Cert}
+	}
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tlsconfig
 	c := &ApiClient{client: client, BaseURL: config.URL, UserAgent: config.UserAgent, URLPrefix: config.VersionPrefix}
 	c.common.client = c
 	c.Decisions = (*DecisionsService)(&c.common)

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -366,17 +366,19 @@ func (s *APIServer) AttachPluginBroker(broker *csplugin.PluginBroker) {
 }
 
 func (s *APIServer) InitController() error {
+	s.controller.AgentsAllowedOu = s.TLS.AllowedAgentsOU
+	s.controller.BouncersAllowedOu = s.TLS.AllowedBouncersOU
 	err := s.controller.Init()
 	if err != nil {
 		return errors.Wrap(err, "controller init")
 	}
-	err = s.controller.HandlerV1.Middlewares.JWT.SetAllowedOUs(s.TLS.AllowedAgentsOU)
-	if err != nil {
-		return errors.Wrap(err, "configuring jwt allowed ous")
-	}
-	err = s.controller.HandlerV1.Middlewares.APIKey.SetAllowedOUs(s.TLS.AllowedBouncersOU)
-	if err != nil {
-		return errors.Wrap(err, "configuring api allowed ous")
-	}
+	// err = s.controller.HandlerV1.Middlewares.JWT.SetAllowedOUs(s.TLS.AllowedAgentsOU)
+	// if err != nil {
+	// 	return errors.Wrap(err, "configuring jwt allowed ous")
+	// }
+	// err = s.controller.HandlerV1.Middlewares.APIKey.SetAllowedOUs(s.TLS.AllowedBouncersOU)
+	// if err != nil {
+	// 	return errors.Wrap(err, "configuring api allowed ous")
+	// }
 	return err
 }

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -367,5 +367,16 @@ func (s *APIServer) AttachPluginBroker(broker *csplugin.PluginBroker) {
 
 func (s *APIServer) InitController() error {
 	err := s.controller.Init()
+	if err != nil {
+		return errors.Wrap(err, "controller init")
+	}
+	err = s.controller.HandlerV1.Middlewares.JWT.SetAllowedOUs(s.TLS.AllowedAgentsOU)
+	if err != nil {
+		return errors.Wrap(err, "configuring jwt allowed ous")
+	}
+	err = s.controller.HandlerV1.Middlewares.APIKey.SetAllowedOUs(s.TLS.AllowedBouncersOU)
+	if err != nil {
+		return errors.Wrap(err, "configuring api allowed ous")
+	}
 	return err
 }

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -250,6 +250,10 @@ func (s *APIServer) GetTLSConfig() (*tls.Config, error) {
 	var caCertPool *x509.CertPool
 	var clientAuthType = tls.VerifyClientCertIfGiven //tls.ClientAuthType(s.TLS.ClientVerification)
 
+	if s.TLS == nil {
+		return &tls.Config{}, nil
+	}
+
 	if clientAuthType > tls.RequestClientCert {
 		caCert, err = ioutil.ReadFile(s.TLS.CACertPath)
 		if err != nil {

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -260,7 +260,7 @@ func (s *APIServer) GetTLSConfig() (*tls.Config, error) {
 	}
 
 	return &tls.Config{
-		ServerName: s.TLS.ServerName,
+		ServerName: s.TLS.ServerName, //should it be removed ?
 		// ClientAuth: tls.NoClientCert,				// Client certificate will not be requested and it is not required
 		// ClientAuth: tls.RequestClientCert,			// Client certificate will be requested, but it is not required
 		// ClientAuth: tls.RequireAnyClientCert,		// Client certificate is required, but any client certificate is acceptable

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -276,7 +276,7 @@ func CreateTestBouncer() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to generate api key: %s", err)
 	}
-	err = dbClient.CreateBouncer("test", "127.0.0.1", middlewares.HashSHA512(apiKey))
+	err = dbClient.CreateBouncer("test", "127.0.0.1", middlewares.HashSHA512(apiKey), types.ApiKeyAuthType)
 	if err != nil {
 		return "", fmt.Errorf("unable to create blocker: %s", err)
 	}

--- a/pkg/apiserver/controllers/controller.go
+++ b/pkg/apiserver/controllers/controller.go
@@ -25,6 +25,7 @@ type Controller struct {
 	Log           *log.Logger
 	ConsoleConfig *csconfig.ConsoleConfig
 	TrustedIPs    []net.IPNet
+	HandlerV1     *v1.Controller
 }
 
 func (c *Controller) Init() error {
@@ -55,8 +56,12 @@ func serveHealth() http.HandlerFunc {
 }
 
 func (c *Controller) NewV1() error {
+	var err error
 
-	handlerV1, err := v1.New(c.DBClient, c.Ectx, c.Profiles, c.CAPIChan, c.PluginChannel, *c.ConsoleConfig, c.TrustedIPs)
+	c.HandlerV1, err = v1.New(c.DBClient,
+		c.Ectx, c.Profiles,
+		c.CAPIChan, c.PluginChannel,
+		*c.ConsoleConfig, c.TrustedIPs)
 	if err != nil {
 		return err
 	}
@@ -72,30 +77,30 @@ func (c *Controller) NewV1() error {
 	})
 
 	groupV1 := c.Router.Group("/v1")
-	groupV1.POST("/watchers", handlerV1.CreateMachine)
-	groupV1.POST("/watchers/login", handlerV1.Middlewares.JWT.Middleware.LoginHandler)
+	groupV1.POST("/watchers", c.HandlerV1.CreateMachine)
+	groupV1.POST("/watchers/login", c.HandlerV1.Middlewares.JWT.Middleware.LoginHandler)
 
 	jwtAuth := groupV1.Group("")
-	jwtAuth.GET("/refresh_token", handlerV1.Middlewares.JWT.Middleware.RefreshHandler)
-	jwtAuth.Use(handlerV1.Middlewares.JWT.Middleware.MiddlewareFunc(), v1.PrometheusMachinesMiddleware())
+	jwtAuth.GET("/refresh_token", c.HandlerV1.Middlewares.JWT.Middleware.RefreshHandler)
+	jwtAuth.Use(c.HandlerV1.Middlewares.JWT.Middleware.MiddlewareFunc(), v1.PrometheusMachinesMiddleware())
 	{
-		jwtAuth.POST("/alerts", handlerV1.CreateAlert)
-		jwtAuth.GET("/alerts", handlerV1.FindAlerts)
-		jwtAuth.HEAD("/alerts", handlerV1.FindAlerts)
-		jwtAuth.GET("/alerts/:alert_id", handlerV1.FindAlertByID)
-		jwtAuth.HEAD("/alerts/:alert_id", handlerV1.FindAlertByID)
-		jwtAuth.DELETE("/alerts", handlerV1.DeleteAlerts)
-		jwtAuth.DELETE("/decisions", handlerV1.DeleteDecisions)
-		jwtAuth.DELETE("/decisions/:decision_id", handlerV1.DeleteDecisionById)
+		jwtAuth.POST("/alerts", c.HandlerV1.CreateAlert)
+		jwtAuth.GET("/alerts", c.HandlerV1.FindAlerts)
+		jwtAuth.HEAD("/alerts", c.HandlerV1.FindAlerts)
+		jwtAuth.GET("/alerts/:alert_id", c.HandlerV1.FindAlertByID)
+		jwtAuth.HEAD("/alerts/:alert_id", c.HandlerV1.FindAlertByID)
+		jwtAuth.DELETE("/alerts", c.HandlerV1.DeleteAlerts)
+		jwtAuth.DELETE("/decisions", c.HandlerV1.DeleteDecisions)
+		jwtAuth.DELETE("/decisions/:decision_id", c.HandlerV1.DeleteDecisionById)
 	}
 
 	apiKeyAuth := groupV1.Group("")
-	apiKeyAuth.Use(handlerV1.Middlewares.APIKey.MiddlewareFunc(), v1.PrometheusBouncersMiddleware())
+	apiKeyAuth.Use(c.HandlerV1.Middlewares.APIKey.MiddlewareFunc(), v1.PrometheusBouncersMiddleware())
 	{
-		apiKeyAuth.GET("/decisions", handlerV1.GetDecision)
-		apiKeyAuth.HEAD("/decisions", handlerV1.GetDecision)
-		apiKeyAuth.GET("/decisions/stream", handlerV1.StreamDecision)
-		apiKeyAuth.HEAD("/decisions/stream", handlerV1.StreamDecision)
+		apiKeyAuth.GET("/decisions", c.HandlerV1.GetDecision)
+		apiKeyAuth.HEAD("/decisions", c.HandlerV1.GetDecision)
+		apiKeyAuth.GET("/decisions/stream", c.HandlerV1.StreamDecision)
+		apiKeyAuth.HEAD("/decisions/stream", c.HandlerV1.StreamDecision)
 	}
 
 	return nil

--- a/pkg/apiserver/controllers/controller.go
+++ b/pkg/apiserver/controllers/controller.go
@@ -16,16 +16,18 @@ import (
 )
 
 type Controller struct {
-	Ectx          context.Context
-	DBClient      *database.Client
-	Router        *gin.Engine
-	Profiles      []*csconfig.ProfileCfg
-	CAPIChan      chan []*models.Alert
-	PluginChannel chan csplugin.ProfileAlert
-	Log           *log.Logger
-	ConsoleConfig *csconfig.ConsoleConfig
-	TrustedIPs    []net.IPNet
-	HandlerV1     *v1.Controller
+	Ectx              context.Context
+	DBClient          *database.Client
+	Router            *gin.Engine
+	Profiles          []*csconfig.ProfileCfg
+	CAPIChan          chan []*models.Alert
+	PluginChannel     chan csplugin.ProfileAlert
+	Log               *log.Logger
+	ConsoleConfig     *csconfig.ConsoleConfig
+	TrustedIPs        []net.IPNet
+	HandlerV1         *v1.Controller
+	AgentsAllowedOu   []string
+	BouncersAllowedOu []string
 }
 
 func (c *Controller) Init() error {
@@ -58,14 +60,32 @@ func serveHealth() http.HandlerFunc {
 func (c *Controller) NewV1() error {
 	var err error
 
-	c.HandlerV1, err = v1.New(c.DBClient,
-		c.Ectx, c.Profiles,
-		c.CAPIChan, c.PluginChannel,
-		*c.ConsoleConfig, c.TrustedIPs)
+	v1Config := v1.ControllerV1Config{
+		DbClient:          c.DBClient,
+		Ctx:               c.Ectx,
+		Profiles:          c.Profiles,
+		CapiChan:          c.CAPIChan,
+		PluginChannel:     c.PluginChannel,
+		ConsoleConfig:     *c.ConsoleConfig,
+		TrustedIPs:        c.TrustedIPs,
+		AllowedAgentsOU:   c.AgentsAllowedOu,
+		AllowedBouncersOU: c.BouncersAllowedOu,
+	}
+
+	c.HandlerV1, err = v1.New(&v1Config)
 	if err != nil {
 		return err
 	}
-
+	/*
+		err = c.HandlerV1.Middlewares.JWT.SetAllowedOUs(c.AgentsAllowedOu)
+		if err != nil {
+			return errors.Wrap(err, "setting allowed agents ou")
+		}
+		c.HandlerV1.Middlewares.APIKey.SetAllowedOUs(c.BouncersAllowedOu)
+		if err != nil {
+			return errors.Wrap(err, "setting allowed bouncers ou")
+		}
+	*/
 	c.Router.GET("/health", gin.WrapF(serveHealth()))
 	c.Router.Use(v1.PrometheusMiddleware())
 	c.Router.HandleMethodNotAllowed = true

--- a/pkg/apiserver/controllers/v1/machines.go
+++ b/pkg/apiserver/controllers/v1/machines.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/crowdsecurity/crowdsec/pkg/models"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/gin-gonic/gin"
 	"github.com/go-openapi/strfmt"
 )
@@ -20,12 +21,11 @@ func (c *Controller) CreateMachine(gctx *gin.Context) {
 		return
 	}
 
-	_, err = c.DBClient.CreateMachine(input.MachineID, input.Password, gctx.ClientIP(), false, false)
+	_, err = c.DBClient.CreateMachine(input.MachineID, input.Password, gctx.ClientIP(), false, false, types.ApiKeyAuthType)
 	if err != nil {
 		c.HandleDBErrors(gctx, err)
 		return
 	}
 
 	gctx.Status(http.StatusCreated)
-	return
 }

--- a/pkg/apiserver/middlewares/v1/api_key.go
+++ b/pkg/apiserver/middlewares/v1/api_key.go
@@ -34,11 +34,11 @@ func GenerateAPIKey(n int) (string, error) {
 	return hex.EncodeToString(bytes), nil
 }
 
-func NewAPIKey(dbClient *database.Client) *APIKey {
+func NewAPIKey(dbClient *database.Client, AllowedOu []string) *APIKey {
 	return &APIKey{
 		HeaderName: APIKeyHeader,
 		DbClient:   dbClient,
-		//TLSAuth:    &TLSAuth{AllowedOU: "bouncer"},
+		AllowedOu:  AllowedOu,
 	}
 }
 
@@ -60,6 +60,7 @@ func (a *APIKey) SetAllowedOUs(allowedOu []string) error {
 		}
 		a.AllowedOu = append(a.AllowedOu, ou)
 	}
+	log.Infof("%p Allowed Bouncers OU : %v", a, a.AllowedOu)
 	return nil
 }
 

--- a/pkg/apiserver/middlewares/v1/api_key.go
+++ b/pkg/apiserver/middlewares/v1/api_key.go
@@ -61,6 +61,7 @@ func (a *APIKey) MiddlewareFunc() gin.HandlerFunc {
 				c.Abort()
 				return
 			}
+			log.Infof("Trying to find bouncer %s for cert", bouncerName)
 			bouncer, err = a.DbClient.SelectBouncerByName(bouncerName)
 			if err != nil {
 				if !strings.Contains(err.Error(), "bouncer not found") {
@@ -81,6 +82,7 @@ func (a *APIKey) MiddlewareFunc() gin.HandlerFunc {
 					c.Abort()
 					return
 				}
+				log.Infof("Creating bouncer %s", bouncerName)
 				err = a.DbClient.CreateBouncer(bouncerName, c.ClientIP(), HashSHA512(apiKey))
 				if err != nil {
 					log.Errorf("auth api key error: %s", err)
@@ -88,6 +90,7 @@ func (a *APIKey) MiddlewareFunc() gin.HandlerFunc {
 					c.Abort()
 					return
 				}
+				log.Info("Getting bouncer %s from db after creation", bouncerName)
 				bouncer, err = a.DbClient.SelectBouncerByName(bouncerName)
 				if err != nil {
 					log.Errorf("auth api key error: %s", err)
@@ -95,6 +98,8 @@ func (a *APIKey) MiddlewareFunc() gin.HandlerFunc {
 					c.Abort()
 					return
 				}
+				log.Infof("Got bouncer %s", bouncer.Name)
+				log.Infof("Bouncer details: %+v", bouncer)
 			}
 		} else {
 			val, ok := c.Request.Header[APIKeyHeader]

--- a/pkg/apiserver/middlewares/v1/api_key.go
+++ b/pkg/apiserver/middlewares/v1/api_key.go
@@ -54,7 +54,7 @@ func (a *APIKey) MiddlewareFunc() gin.HandlerFunc {
 		var bouncer *ent.Bouncer
 		var err error
 
-		if c.Request.TLS != nil {
+		if c.Request.TLS != nil && len(c.Request.TLS.PeerCertificates) > 0 {
 			validCert, bouncerName := a.TLSAuth.ValidateCert(c)
 			if !validCert {
 				c.JSON(http.StatusForbidden, gin.H{"message": "access forbidden"})

--- a/pkg/apiserver/middlewares/v1/api_key.go
+++ b/pkg/apiserver/middlewares/v1/api_key.go
@@ -71,6 +71,7 @@ func (a *APIKey) MiddlewareFunc() gin.HandlerFunc {
 					return
 				}
 			}
+			log.Infof("Bouncer debug: %+v", bouncer)
 
 			if bouncer == nil {
 				//Because we have a valid cert, automatically create the bouncer in the database if it does not exist

--- a/pkg/apiserver/middlewares/v1/api_key.go
+++ b/pkg/apiserver/middlewares/v1/api_key.go
@@ -63,10 +63,12 @@ func (a *APIKey) MiddlewareFunc() gin.HandlerFunc {
 			}
 			bouncer, err = a.DbClient.SelectBouncerByName(bouncerName)
 			if err != nil {
-				log.Errorf("auth api key error: %s", err)
-				c.JSON(http.StatusForbidden, gin.H{"message": "access forbidden"})
-				c.Abort()
-				return
+				if !strings.Contains(err.Error(), "bouncer not found") {
+					log.Errorf("auth api key error: %s", err)
+					c.JSON(http.StatusForbidden, gin.H{"message": "access forbidden"})
+					c.Abort()
+					return
+				}
 			}
 
 			if bouncer == nil {

--- a/pkg/apiserver/middlewares/v1/api_key.go
+++ b/pkg/apiserver/middlewares/v1/api_key.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/crowdsecurity/crowdsec/pkg/database"
 	"github.com/crowdsecurity/crowdsec/pkg/database/ent"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 )
@@ -95,7 +96,7 @@ func (a *APIKey) MiddlewareFunc() gin.HandlerFunc {
 					return
 				}
 				log.Infof("Creating bouncer %s", bouncerName)
-				err = a.DbClient.CreateBouncer(bouncerName, c.ClientIP(), HashSHA512(apiKey))
+				err = a.DbClient.CreateBouncer(bouncerName, c.ClientIP(), HashSHA512(apiKey), types.TlsAuthType)
 				if err != nil {
 					log.Errorf("auth api key error: %s", err)
 					c.JSON(http.StatusForbidden, gin.H{"message": "access forbidden"})

--- a/pkg/apiserver/middlewares/v1/api_key.go
+++ b/pkg/apiserver/middlewares/v1/api_key.go
@@ -69,6 +69,8 @@ func (a *APIKey) MiddlewareFunc() gin.HandlerFunc {
 					c.JSON(http.StatusForbidden, gin.H{"message": "access forbidden"})
 					c.Abort()
 					return
+				} else {
+					bouncer = nil
 				}
 			}
 			log.Infof("Bouncer debug: %+v", bouncer)

--- a/pkg/apiserver/middlewares/v1/jwt.go
+++ b/pkg/apiserver/middlewares/v1/jwt.go
@@ -15,6 +15,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/database/ent"
 	"github.com/crowdsecurity/crowdsec/pkg/database/ent/machine"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/gin-gonic/gin"
 	"github.com/go-openapi/strfmt"
 	log "github.com/sirupsen/logrus"
@@ -109,7 +110,7 @@ func (j *JWT) Authenticator(c *gin.Context) (interface{}, error) {
 			//Machine was not found, let's create it
 			log.Printf("machine %s not found, create it", machineID)
 			password := strfmt.Password("")
-			_, err = j.DbClient.CreateMachine(&machineID, &password, "", true, true)
+			_, err = j.DbClient.CreateMachine(&machineID, &password, "", true, true, types.TlsAuthType)
 			if err != nil {
 				return "", errors.Wrapf(err, "while creating machine entry for %s", machineID)
 			}

--- a/pkg/apiserver/middlewares/v1/middlewares.go
+++ b/pkg/apiserver/middlewares/v1/middlewares.go
@@ -7,16 +7,16 @@ type Middlewares struct {
 	JWT    *JWT
 }
 
-func NewMiddlewares(dbClient *database.Client) (*Middlewares, error) {
+func NewMiddlewares(dbClient *database.Client, AllowedAgentsOU []string, AllowedBouncersOU []string) (*Middlewares, error) {
 	var err error
 
 	ret := &Middlewares{}
 
-	ret.JWT, err = NewJWT(dbClient)
+	ret.JWT, err = NewJWT(dbClient, AllowedAgentsOU)
 	if err != nil {
 		return &Middlewares{}, err
 	}
 
-	ret.APIKey = NewAPIKey(dbClient)
+	ret.APIKey = NewAPIKey(dbClient, AllowedBouncersOU)
 	return ret, nil
 }

--- a/pkg/apiserver/middlewares/v1/middlewares.go
+++ b/pkg/apiserver/middlewares/v1/middlewares.go
@@ -18,6 +18,5 @@ func NewMiddlewares(dbClient *database.Client) (*Middlewares, error) {
 	}
 
 	ret.APIKey = NewAPIKey(dbClient)
-
 	return ret, nil
 }

--- a/pkg/apiserver/middlewares/v1/tls_auth.go
+++ b/pkg/apiserver/middlewares/v1/tls_auth.go
@@ -1,123 +1,16 @@
 package v1
 
 import (
-	"bytes"
-	"crypto"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/url"
-	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ocsp"
 )
 
-func ocspQuery(server string, cert *x509.Certificate, issuer *x509.Certificate) (*ocsp.Response, error) {
-	req, err := ocsp.CreateRequest(cert, issuer, &ocsp.RequestOptions{Hash: crypto.SHA256})
-	if err != nil {
-		log.Errorf("TLSAuth: error creating OCSP request: %s", err)
-		return nil, err
-	}
-	httpRequest, err := http.NewRequest(http.MethodPost, server, bytes.NewBuffer(req))
-	if err != nil {
-		log.Error("TLSAuth: cannot create HTTP request for OCSP")
-		return nil, err
-	}
-	ocspURL, err := url.Parse(server)
-	if err != nil {
-		log.Error("TLSAuth: cannot parse OCSP URL")
-		return nil, err
-	}
-	httpRequest.Header.Add("Content-Type", "application/ocsp-request")
-	httpRequest.Header.Add("Accept", "application/ocsp-response")
-	httpRequest.Header.Add("host", ocspURL.Host)
-	httpClient := &http.Client{}
-	httpResponse, err := httpClient.Do(httpRequest)
-	if err != nil {
-		log.Error("TLSAuth: cannot send HTTP request to OCSP")
-		return nil, err
-	}
-	defer httpResponse.Body.Close()
-	output, err := ioutil.ReadAll(httpResponse.Body)
-	if err != nil {
-		log.Error("TLSAuth: cannot read HTTP response from OCSP")
-		return nil, err
-	}
-	ocspResponse, err := ocsp.ParseResponseForCert(output, cert, issuer)
-	return ocspResponse, err
-}
-
-func isExpired(cert *x509.Certificate) bool {
-	now := time.Now().UTC()
-
-	if cert.NotAfter.UTC().Before(now) {
-		log.Errorf("TLSAuth: client certificate is expired (NotAfter: %s)", cert.NotAfter.UTC())
-		return true
-	}
-	if cert.NotBefore.UTC().After(now) {
-		log.Errorf("TLSAuth: client certificate is not yet valid (NotBefore: %s)", cert.NotBefore.UTC())
-		return true
-	}
-	return false
-}
-
-func isOCSPRevoked(cert *x509.Certificate, issuer *x509.Certificate) (bool, error) {
-	if cert.OCSPServer == nil || (cert.OCSPServer != nil && len(cert.OCSPServer) == 0) {
-		log.Infof("TLSAuth: no OCSP Server present in client certificate, skipping OCSP verification")
-		return false, nil
-	}
-	for _, server := range cert.OCSPServer {
-		ocspResponse, err := ocspQuery(server, cert, issuer)
-		if err != nil {
-			log.Errorf("TLSAuth: error querying OCSP server %s: %s", server, err)
-			continue
-		}
-		switch ocspResponse.Status {
-		case ocsp.Good:
-			return false, nil
-		case ocsp.Revoked:
-			return true, fmt.Errorf("client certificate is revoked by server %s", server)
-		case ocsp.Unknown:
-			log.Debugf("unknow OCSP status for server %s", server)
-			continue
-		}
-	}
-	log.Infof("Could not get any valid OCSP response, assuming the cert is revoked")
-	return true, nil
-}
-
-func isRevoked(cert *x509.Certificate, issuer *x509.Certificate) (bool, error) {
-	revoked, err := isOCSPRevoked(cert, issuer)
-	if err != nil {
-		return true, err
-	}
-	if revoked {
-		return revoked, nil
-	}
-	return false, nil
-}
-
-func isInvalid(cert *x509.Certificate, issuer *x509.Certificate) (bool, error) {
-	if isExpired(cert) {
-		return true, nil
-	}
-	revoked, err := isRevoked(cert, issuer)
-	if err != nil {
-		//Fail securely, if we can't check the revokation status, let's consider the cert invalid
-		//We may change this in the future based on users feedback, but this seems the most sensible thing to do
-		return true, errors.Wrap(err, "could not check for client certification revokation status")
-	}
-
-	return revoked, nil
-}
-
-func ValidateCert(c *gin.Context, AllowedOu []string) (bool, string, error) {
+func ValidateCert(c *gin.Context, AllowedOus []string) (bool, string, error) {
 	//Checks cert validity, Returns true + CN if client cert matches requested OU
-
+	var clientCert *x509.Certificate
 	if c.Request.TLS == nil || len(c.Request.TLS.PeerCertificates) == 0 {
 		//do not error if it's not TLS or there are no peer certs
 		return false, "", nil
@@ -125,13 +18,9 @@ func ValidateCert(c *gin.Context, AllowedOu []string) (bool, string, error) {
 
 	if len(c.Request.TLS.VerifiedChains) > 0 {
 		validOU := false
-		clientCert := c.Request.TLS.VerifiedChains[0][0]
-		if len(c.Request.TLS.VerifiedChains[0]) == 1 {
-			log.Errorf("TLSAuth: no issuer cert in chain")
-			return false, "", errors.New("no issuer cert in chain")
-		}
+		clientCert = c.Request.TLS.VerifiedChains[0][0]
 		for _, ou := range clientCert.Subject.OrganizationalUnit {
-			for _, allowedOu := range AllowedOu {
+			for _, allowedOu := range AllowedOus {
 				if allowedOu == ou {
 					validOU = true
 					break
@@ -139,17 +28,11 @@ func ValidateCert(c *gin.Context, AllowedOu []string) (bool, string, error) {
 			}
 		}
 		if !validOU {
-			log.Errorf("TLSAuth: client certificate is not from a bouncer")
-			return false, "", fmt.Errorf("client certificate OU (%+v) doesn't match expected OU", clientCert.Subject.OrganizationalUnit)
+			//log.Errorf("Cert Authentication: client certificate OU isn't valid")
+			return false, "", fmt.Errorf("client certificate OU (%v) doesn't match expected OU (%v)",
+				clientCert.Subject.OrganizationalUnit, AllowedOus)
 		}
-		revoked, err := isInvalid(clientCert, c.Request.TLS.VerifiedChains[0][1])
-		if err != nil {
-			log.Errorf("TLSAuth: error checking if client certificate is revoked: %s", err)
-			return false, "", errors.Wrap(err, "could not check for client certification revokation status")
-		}
-		if revoked {
-			return false, "", fmt.Errorf("client certificate is revoked")
-		}
+		log.Infof("client OU %v is allowed vs required OU %v", clientCert.Subject.OrganizationalUnit, AllowedOus)
 		return true, clientCert.Subject.CommonName, nil
 	}
 	return false, "", fmt.Errorf("no verified cert in request")

--- a/pkg/apiserver/middlewares/v1/tls_auth.go
+++ b/pkg/apiserver/middlewares/v1/tls_auth.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+)
+
+type TLSAuth struct {
+}
+
+func (t *TLSAuth) ValidateCert(c *gin.Context, prefix string) bool {
+	if c.Request.TLS != nil {
+		if len(c.Request.TLS.VerifiedChains) > 0 {
+			clientCert := c.Request.TLS.VerifiedChains[0][0]
+			if !strings.HasPrefix(clientCert.Subject.CommonName, prefix) {
+				log.Errorf("APIKey: client certificate is not from a bouncer : %s", clientCert.Subject.CommonName)
+				return false
+			} else {
+				return true
+			}
+		} else {
+			log.Error("Found no verified certs in request")
+			return false
+		}
+	}
+	return false
+}

--- a/pkg/apiserver/middlewares/v1/tls_auth.go
+++ b/pkg/apiserver/middlewares/v1/tls_auth.go
@@ -16,7 +16,7 @@ func (t *TLSAuth) ValidateCert(c *gin.Context) (bool, string) {
 		if len(c.Request.TLS.VerifiedChains) > 0 {
 			validOU := false
 			clientCert := c.Request.TLS.VerifiedChains[0][0]
-			for _, ou := range clientCert.Subject.Organization {
+			for _, ou := range clientCert.Subject.OrganizationalUnit {
 				if t.AllowedOU == ou {
 					validOU = true
 				}

--- a/pkg/apiserver/middlewares/v1/tls_auth.go
+++ b/pkg/apiserver/middlewares/v1/tls_auth.go
@@ -1,11 +1,119 @@
 package v1
 
 import (
+	"bytes"
+	"crypto"
+	"crypto/x509"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ocsp"
 )
+
+func ocspQuery(server string, cert *x509.Certificate, issuer *x509.Certificate) (*ocsp.Response, error) {
+	req, err := ocsp.CreateRequest(cert, issuer, &ocsp.RequestOptions{Hash: crypto.SHA256})
+	if err != nil {
+		log.Errorf("TLSAuth: error creating OCSP request: %s", err)
+		return nil, err
+	}
+	httpRequest, err := http.NewRequest(http.MethodPost, server, bytes.NewBuffer(req))
+	if err != nil {
+		log.Error("TLSAuth: cannot create HTTP request for OCSP")
+		return nil, err
+	}
+	ocspURL, err := url.Parse(server)
+	if err != nil {
+		log.Error("TLSAuth: cannot parse OCSP URL")
+		return nil, err
+	}
+	httpRequest.Header.Add("Content-Type", "application/ocsp-request")
+	httpRequest.Header.Add("Accept", "application/ocsp-response")
+	httpRequest.Header.Add("host", ocspURL.Host)
+	httpClient := &http.Client{}
+	httpResponse, err := httpClient.Do(httpRequest)
+	if err != nil {
+		log.Error("TLSAuth: cannot send HTTP request to OCSP")
+		return nil, err
+	}
+	defer httpResponse.Body.Close()
+	output, err := ioutil.ReadAll(httpResponse.Body)
+	if err != nil {
+		log.Error("TLSAuth: cannot read HTTP response from OCSP")
+		return nil, err
+	}
+	ocspResponse, err := ocsp.ParseResponseForCert(output, cert, issuer)
+	return ocspResponse, err
+}
+
+func isExpired(cert *x509.Certificate) bool {
+	now := time.Now().UTC()
+
+	if cert.NotAfter.UTC().Before(now) {
+		log.Errorf("TLSAuth: client certificate is expired (NotAfter: %s)", cert.NotAfter.UTC())
+		return true
+	}
+	if cert.NotBefore.UTC().After(now) {
+		log.Errorf("TLSAuth: client certificate is not yet valid (NotBefore: %s)", cert.NotBefore.UTC())
+		return true
+	}
+	return false
+}
+
+func isOCSPRevoked(cert *x509.Certificate, issuer *x509.Certificate) (bool, error) {
+	if cert.OCSPServer == nil || (cert.OCSPServer != nil && len(cert.OCSPServer) == 0) {
+		log.Infof("TLSAuth: no OCSP Server present in client certificate, skipping OCSP verification")
+		return false, nil
+	}
+	for _, server := range cert.OCSPServer {
+		ocspResponse, err := ocspQuery(server, cert, issuer)
+		if err != nil {
+			log.Errorf("TLSAuth: error querying OCSP server %s: %s", server, err)
+			continue
+		}
+		switch ocspResponse.Status {
+		case ocsp.Good:
+			return false, nil
+		case ocsp.Revoked:
+			return true, fmt.Errorf("client certificate is revoked by server %s", server)
+		case ocsp.Unknown:
+			log.Debugf("unknow OCSP status for server %s", server)
+			continue
+		}
+	}
+	log.Infof("Could not get any valid OCSP response, assuming the cert is revoked")
+	return true, nil
+}
+
+func isRevoked(cert *x509.Certificate, issuer *x509.Certificate) (bool, error) {
+	revoked, err := isOCSPRevoked(cert, issuer)
+	if err != nil {
+		return true, err
+	}
+	if revoked {
+		return revoked, nil
+	}
+	return false, nil
+}
+
+func isInvalid(cert *x509.Certificate, issuer *x509.Certificate) (bool, error) {
+	if isExpired(cert) {
+		return true, nil
+	}
+	revoked, err := isRevoked(cert, issuer)
+	if err != nil {
+		//Fail securely, if we can't check the revokation status, let's consider the cert invalid
+		//We may change this in the future based on users feedback, but this seems the most sensible thing to do
+		return true, errors.Wrap(err, "could not check for client certification revokation status")
+	}
+
+	return revoked, nil
+}
 
 func ValidateCert(c *gin.Context, AllowedOu []string) (bool, string, error) {
 	//Checks cert validity, Returns true + CN if client cert matches requested OU
@@ -18,6 +126,10 @@ func ValidateCert(c *gin.Context, AllowedOu []string) (bool, string, error) {
 	if len(c.Request.TLS.VerifiedChains) > 0 {
 		validOU := false
 		clientCert := c.Request.TLS.VerifiedChains[0][0]
+		if len(c.Request.TLS.VerifiedChains[0]) == 1 {
+			log.Errorf("TLSAuth: no issuer cert in chain")
+			return false, "", errors.New("no issuer cert in chain")
+		}
 		for _, ou := range clientCert.Subject.OrganizationalUnit {
 			for _, allowedOu := range AllowedOu {
 				if allowedOu == ou {
@@ -27,8 +139,16 @@ func ValidateCert(c *gin.Context, AllowedOu []string) (bool, string, error) {
 			}
 		}
 		if !validOU {
-			log.Errorf("APIKey: client certificate is not from a bouncer")
+			log.Errorf("TLSAuth: client certificate is not from a bouncer")
 			return false, "", fmt.Errorf("client certificate OU (%+v) doesn't match expected OU", clientCert.Subject.OrganizationalUnit)
+		}
+		revoked, err := isInvalid(clientCert, c.Request.TLS.VerifiedChains[0][1])
+		if err != nil {
+			log.Errorf("TLSAuth: error checking if client certificate is revoked: %s", err)
+			return false, "", errors.Wrap(err, "could not check for client certification revokation status")
+		}
+		if revoked {
+			return false, "", fmt.Errorf("client certificate is revoked")
 		}
 		return true, clientCert.Subject.CommonName, nil
 	}

--- a/pkg/apiserver/middlewares/v1/tls_auth.go
+++ b/pkg/apiserver/middlewares/v1/tls_auth.go
@@ -7,29 +7,30 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type TLSAuth struct {
-	AllowedOU string
-}
+func ValidateCert(c *gin.Context, AllowedOu []string) (bool, string, error) {
+	//Checks cert validity, Returns true + CN if client cert matches requested OU
 
-func (t *TLSAuth) ValidateCert(c *gin.Context) (bool, string) {
-	if c.Request.TLS != nil {
-		if len(c.Request.TLS.VerifiedChains) > 0 {
-			validOU := false
-			clientCert := c.Request.TLS.VerifiedChains[0][0]
-			for _, ou := range clientCert.Subject.OrganizationalUnit {
-				if t.AllowedOU == ou {
+	if c.Request.TLS == nil || len(c.Request.TLS.PeerCertificates) == 0 {
+		//do not error if it's not TLS or there are no peer certs
+		return false, "", nil
+	}
+
+	if len(c.Request.TLS.VerifiedChains) > 0 {
+		validOU := false
+		clientCert := c.Request.TLS.VerifiedChains[0][0]
+		for _, ou := range clientCert.Subject.OrganizationalUnit {
+			for _, allowedOu := range AllowedOu {
+				if allowedOu == ou {
 					validOU = true
+					break
 				}
 			}
-			if !validOU {
-				log.Errorf("APIKey: client certificate is not from a bouncer")
-				return false, ""
-			}
-			return true, fmt.Sprintf("%s-%s", clientCert.Subject.CommonName, c.ClientIP())
-		} else {
-			log.Error("Found no verified certs in request")
-			return false, ""
 		}
+		if !validOU {
+			log.Errorf("APIKey: client certificate is not from a bouncer")
+			return false, "", fmt.Errorf("client certificate OU (%+v) doesn't match expected OU", clientCert.Subject.OrganizationalUnit)
+		}
+		return true, clientCert.Subject.CommonName, nil
 	}
-	return false, ""
+	return false, "", fmt.Errorf("no verified cert in request")
 }

--- a/pkg/csconfig/api.go
+++ b/pkg/csconfig/api.go
@@ -128,7 +128,6 @@ type TLSCfg struct {
 	KeyFilePath        string `yaml:"key_file"`
 	ClientVerification int    `yaml:"client_verification"`
 	ServerName         string `yaml:"server_name"`
-	CACertName         string `yaml:"ca_cert"`
 	CACertPath         string `yaml:"ca_cert_path"`
 }
 

--- a/pkg/csconfig/api.go
+++ b/pkg/csconfig/api.go
@@ -152,11 +152,13 @@ type LocalApiServerCfg struct {
 }
 
 type TLSCfg struct {
-	CertFilePath       string `yaml:"cert_file"`
-	KeyFilePath        string `yaml:"key_file"`
-	ClientVerification int    `yaml:"client_verification"`
-	ServerName         string `yaml:"server_name"`
-	CACertPath         string `yaml:"ca_cert_path"`
+	CertFilePath       string   `yaml:"cert_file"`
+	KeyFilePath        string   `yaml:"key_file"`
+	ClientVerification int      `yaml:"client_verification"`
+	ServerName         string   `yaml:"server_name"`
+	CACertPath         string   `yaml:"ca_cert_path"`
+	AllowedAgentsOU    []string `yaml:"agents_allowed_ou"`
+	AllowedBouncersOU  []string `yaml:"bouncers_allowed_ou"`
 }
 
 func (c *Config) LoadAPIServer() error {

--- a/pkg/csconfig/api.go
+++ b/pkg/csconfig/api.go
@@ -124,8 +124,12 @@ type LocalApiServerCfg struct {
 }
 
 type TLSCfg struct {
-	CertFilePath string `yaml:"cert_file"`
-	KeyFilePath  string `yaml:"key_file"`
+	CertFilePath       string `yaml:"cert_file"`
+	KeyFilePath        string `yaml:"key_file"`
+	ClientVerification int    `yaml:"client_verification"`
+	ServerName         string `yaml:"server_name"`
+	CACertName         string `yaml:"ca_cert"`
+	CACertPath         string `yaml:"ca_cert_path"`
 }
 
 func (c *Config) LoadAPIServer() error {

--- a/pkg/csconfig/database.go
+++ b/pkg/csconfig/database.go
@@ -2,6 +2,7 @@ package csconfig
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 	log "github.com/sirupsen/logrus"
@@ -23,9 +24,20 @@ type DatabaseCfg struct {
 	MaxOpenConns *int        `yaml:"max_open_conns,omitempty"`
 }
 
+type AuthGCCfg struct {
+	Cert                  *string `yaml:"cert,omitempty"`
+	CertDuration          *time.Duration
+	Api                   *string `yaml:"api_key,omitempty"`
+	ApiDuration           *time.Duration
+	LoginPassword         *string `yaml:"login_password,omitempty"`
+	LoginPasswordDuration *time.Duration
+}
+
 type FlushDBCfg struct {
-	MaxItems *int    `yaml:"max_items"`
-	MaxAge   *string `yaml:"max_age"`
+	MaxItems   *int       `yaml:"max_items,omitempty"`
+	MaxAge     *string    `yaml:"max_age,omitempty"`
+	BouncersGC *AuthGCCfg `yaml:"bouncers_autodelete,omitempty"`
+	AgentsGC   *AuthGCCfg `yaml:"agents_autodelete,omitempty"`
 }
 
 func (c *Config) LoadDBConfig() error {

--- a/pkg/database/bouncers.go
+++ b/pkg/database/bouncers.go
@@ -18,6 +18,15 @@ func (c *Client) SelectBouncer(apiKeyHash string) (*ent.Bouncer, error) {
 	return result, nil
 }
 
+func (c *Client) SelectBouncerByName(bouncerName string) (*ent.Bouncer, error) {
+	result, err := c.Ent.Bouncer.Query().Where(bouncer.NameEQ(bouncerName)).First(c.CTX)
+	if err != nil {
+		return &ent.Bouncer{}, errors.Wrapf(QueryFail, "select bouncer: %s", err)
+	}
+
+	return result, nil
+}
+
 func (c *Client) ListBouncers() ([]*ent.Bouncer, error) {
 	result, err := c.Ent.Bouncer.Query().All(c.CTX)
 	if err != nil {

--- a/pkg/database/bouncers.go
+++ b/pkg/database/bouncers.go
@@ -35,12 +35,13 @@ func (c *Client) ListBouncers() ([]*ent.Bouncer, error) {
 	return result, nil
 }
 
-func (c *Client) CreateBouncer(name string, ipAddr string, apiKey string) error {
+func (c *Client) CreateBouncer(name string, ipAddr string, apiKey string, authType string) error {
 	_, err := c.Ent.Bouncer.
 		Create().
 		SetName(name).
 		SetAPIKey(apiKey).
 		SetRevoked(false).
+		SetAuthType(authType).
 		Save(c.CTX)
 	if err != nil {
 		if ent.IsConstraintError(err) {

--- a/pkg/database/ent/bouncer.go
+++ b/pkg/database/ent/bouncer.go
@@ -36,6 +36,8 @@ type Bouncer struct {
 	Until time.Time `json:"until"`
 	// LastPull holds the value of the "last_pull" field.
 	LastPull time.Time `json:"last_pull"`
+	// AuthType holds the value of the "auth_type" field.
+	AuthType string `json:"auth_type"`
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -47,7 +49,7 @@ func (*Bouncer) scanValues(columns []string) ([]interface{}, error) {
 			values[i] = new(sql.NullBool)
 		case bouncer.FieldID:
 			values[i] = new(sql.NullInt64)
-		case bouncer.FieldName, bouncer.FieldAPIKey, bouncer.FieldIPAddress, bouncer.FieldType, bouncer.FieldVersion:
+		case bouncer.FieldName, bouncer.FieldAPIKey, bouncer.FieldIPAddress, bouncer.FieldType, bouncer.FieldVersion, bouncer.FieldAuthType:
 			values[i] = new(sql.NullString)
 		case bouncer.FieldCreatedAt, bouncer.FieldUpdatedAt, bouncer.FieldUntil, bouncer.FieldLastPull:
 			values[i] = new(sql.NullTime)
@@ -134,6 +136,12 @@ func (b *Bouncer) assignValues(columns []string, values []interface{}) error {
 			} else if value.Valid {
 				b.LastPull = value.Time
 			}
+		case bouncer.FieldAuthType:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field auth_type", values[i])
+			} else if value.Valid {
+				b.AuthType = value.String
+			}
 		}
 	}
 	return nil
@@ -186,6 +194,8 @@ func (b *Bouncer) String() string {
 	builder.WriteString(b.Until.Format(time.ANSIC))
 	builder.WriteString(", last_pull=")
 	builder.WriteString(b.LastPull.Format(time.ANSIC))
+	builder.WriteString(", auth_type=")
+	builder.WriteString(b.AuthType)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/database/ent/bouncer/bouncer.go
+++ b/pkg/database/ent/bouncer/bouncer.go
@@ -31,6 +31,8 @@ const (
 	FieldUntil = "until"
 	// FieldLastPull holds the string denoting the last_pull field in the database.
 	FieldLastPull = "last_pull"
+	// FieldAuthType holds the string denoting the auth_type field in the database.
+	FieldAuthType = "auth_type"
 	// Table holds the table name of the bouncer in the database.
 	Table = "bouncers"
 )
@@ -48,6 +50,7 @@ var Columns = []string{
 	FieldVersion,
 	FieldUntil,
 	FieldLastPull,
+	FieldAuthType,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -75,4 +78,6 @@ var (
 	DefaultUntil func() time.Time
 	// DefaultLastPull holds the default value on creation for the "last_pull" field.
 	DefaultLastPull func() time.Time
+	// DefaultAuthType holds the default value on creation for the "auth_type" field.
+	DefaultAuthType string
 )

--- a/pkg/database/ent/bouncer/where.go
+++ b/pkg/database/ent/bouncer/where.go
@@ -162,6 +162,13 @@ func LastPull(v time.Time) predicate.Bouncer {
 	})
 }
 
+// AuthType applies equality check predicate on the "auth_type" field. It's identical to AuthTypeEQ.
+func AuthType(v string) predicate.Bouncer {
+	return predicate.Bouncer(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldAuthType), v))
+	})
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Bouncer {
 	return predicate.Bouncer(func(s *sql.Selector) {
@@ -1116,6 +1123,117 @@ func LastPullLT(v time.Time) predicate.Bouncer {
 func LastPullLTE(v time.Time) predicate.Bouncer {
 	return predicate.Bouncer(func(s *sql.Selector) {
 		s.Where(sql.LTE(s.C(FieldLastPull), v))
+	})
+}
+
+// AuthTypeEQ applies the EQ predicate on the "auth_type" field.
+func AuthTypeEQ(v string) predicate.Bouncer {
+	return predicate.Bouncer(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeNEQ applies the NEQ predicate on the "auth_type" field.
+func AuthTypeNEQ(v string) predicate.Bouncer {
+	return predicate.Bouncer(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeIn applies the In predicate on the "auth_type" field.
+func AuthTypeIn(vs ...string) predicate.Bouncer {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Bouncer(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.In(s.C(FieldAuthType), v...))
+	})
+}
+
+// AuthTypeNotIn applies the NotIn predicate on the "auth_type" field.
+func AuthTypeNotIn(vs ...string) predicate.Bouncer {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Bouncer(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.NotIn(s.C(FieldAuthType), v...))
+	})
+}
+
+// AuthTypeGT applies the GT predicate on the "auth_type" field.
+func AuthTypeGT(v string) predicate.Bouncer {
+	return predicate.Bouncer(func(s *sql.Selector) {
+		s.Where(sql.GT(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeGTE applies the GTE predicate on the "auth_type" field.
+func AuthTypeGTE(v string) predicate.Bouncer {
+	return predicate.Bouncer(func(s *sql.Selector) {
+		s.Where(sql.GTE(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeLT applies the LT predicate on the "auth_type" field.
+func AuthTypeLT(v string) predicate.Bouncer {
+	return predicate.Bouncer(func(s *sql.Selector) {
+		s.Where(sql.LT(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeLTE applies the LTE predicate on the "auth_type" field.
+func AuthTypeLTE(v string) predicate.Bouncer {
+	return predicate.Bouncer(func(s *sql.Selector) {
+		s.Where(sql.LTE(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeContains applies the Contains predicate on the "auth_type" field.
+func AuthTypeContains(v string) predicate.Bouncer {
+	return predicate.Bouncer(func(s *sql.Selector) {
+		s.Where(sql.Contains(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeHasPrefix applies the HasPrefix predicate on the "auth_type" field.
+func AuthTypeHasPrefix(v string) predicate.Bouncer {
+	return predicate.Bouncer(func(s *sql.Selector) {
+		s.Where(sql.HasPrefix(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeHasSuffix applies the HasSuffix predicate on the "auth_type" field.
+func AuthTypeHasSuffix(v string) predicate.Bouncer {
+	return predicate.Bouncer(func(s *sql.Selector) {
+		s.Where(sql.HasSuffix(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeEqualFold applies the EqualFold predicate on the "auth_type" field.
+func AuthTypeEqualFold(v string) predicate.Bouncer {
+	return predicate.Bouncer(func(s *sql.Selector) {
+		s.Where(sql.EqualFold(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeContainsFold applies the ContainsFold predicate on the "auth_type" field.
+func AuthTypeContainsFold(v string) predicate.Bouncer {
+	return predicate.Bouncer(func(s *sql.Selector) {
+		s.Where(sql.ContainsFold(s.C(FieldAuthType), v))
 	})
 }
 

--- a/pkg/database/ent/bouncer_create.go
+++ b/pkg/database/ent/bouncer_create.go
@@ -136,6 +136,20 @@ func (bc *BouncerCreate) SetNillableLastPull(t *time.Time) *BouncerCreate {
 	return bc
 }
 
+// SetAuthType sets the "auth_type" field.
+func (bc *BouncerCreate) SetAuthType(s string) *BouncerCreate {
+	bc.mutation.SetAuthType(s)
+	return bc
+}
+
+// SetNillableAuthType sets the "auth_type" field if the given value is not nil.
+func (bc *BouncerCreate) SetNillableAuthType(s *string) *BouncerCreate {
+	if s != nil {
+		bc.SetAuthType(*s)
+	}
+	return bc
+}
+
 // Mutation returns the BouncerMutation object of the builder.
 func (bc *BouncerCreate) Mutation() *BouncerMutation {
 	return bc.mutation
@@ -227,6 +241,10 @@ func (bc *BouncerCreate) defaults() {
 		v := bouncer.DefaultLastPull()
 		bc.mutation.SetLastPull(v)
 	}
+	if _, ok := bc.mutation.AuthType(); !ok {
+		v := bouncer.DefaultAuthType
+		bc.mutation.SetAuthType(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -242,6 +260,9 @@ func (bc *BouncerCreate) check() error {
 	}
 	if _, ok := bc.mutation.LastPull(); !ok {
 		return &ValidationError{Name: "last_pull", err: errors.New(`ent: missing required field "Bouncer.last_pull"`)}
+	}
+	if _, ok := bc.mutation.AuthType(); !ok {
+		return &ValidationError{Name: "auth_type", err: errors.New(`ent: missing required field "Bouncer.auth_type"`)}
 	}
 	return nil
 }
@@ -349,6 +370,14 @@ func (bc *BouncerCreate) createSpec() (*Bouncer, *sqlgraph.CreateSpec) {
 			Column: bouncer.FieldLastPull,
 		})
 		_node.LastPull = value
+	}
+	if value, ok := bc.mutation.AuthType(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: bouncer.FieldAuthType,
+		})
+		_node.AuthType = value
 	}
 	return _node, _spec
 }

--- a/pkg/database/ent/bouncer_update.go
+++ b/pkg/database/ent/bouncer_update.go
@@ -164,6 +164,20 @@ func (bu *BouncerUpdate) SetNillableLastPull(t *time.Time) *BouncerUpdate {
 	return bu
 }
 
+// SetAuthType sets the "auth_type" field.
+func (bu *BouncerUpdate) SetAuthType(s string) *BouncerUpdate {
+	bu.mutation.SetAuthType(s)
+	return bu
+}
+
+// SetNillableAuthType sets the "auth_type" field if the given value is not nil.
+func (bu *BouncerUpdate) SetNillableAuthType(s *string) *BouncerUpdate {
+	if s != nil {
+		bu.SetAuthType(*s)
+	}
+	return bu
+}
+
 // Mutation returns the BouncerMutation object of the builder.
 func (bu *BouncerUpdate) Mutation() *BouncerMutation {
 	return bu.mutation
@@ -360,6 +374,13 @@ func (bu *BouncerUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: bouncer.FieldLastPull,
 		})
 	}
+	if value, ok := bu.mutation.AuthType(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: bouncer.FieldAuthType,
+		})
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, bu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{bouncer.Label}
@@ -511,6 +532,20 @@ func (buo *BouncerUpdateOne) SetLastPull(t time.Time) *BouncerUpdateOne {
 func (buo *BouncerUpdateOne) SetNillableLastPull(t *time.Time) *BouncerUpdateOne {
 	if t != nil {
 		buo.SetLastPull(*t)
+	}
+	return buo
+}
+
+// SetAuthType sets the "auth_type" field.
+func (buo *BouncerUpdateOne) SetAuthType(s string) *BouncerUpdateOne {
+	buo.mutation.SetAuthType(s)
+	return buo
+}
+
+// SetNillableAuthType sets the "auth_type" field if the given value is not nil.
+func (buo *BouncerUpdateOne) SetNillableAuthType(s *string) *BouncerUpdateOne {
+	if s != nil {
+		buo.SetAuthType(*s)
 	}
 	return buo
 }
@@ -733,6 +768,13 @@ func (buo *BouncerUpdateOne) sqlSave(ctx context.Context) (_node *Bouncer, err e
 			Type:   field.TypeTime,
 			Value:  value,
 			Column: bouncer.FieldLastPull,
+		})
+	}
+	if value, ok := buo.mutation.AuthType(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: bouncer.FieldAuthType,
 		})
 	}
 	_node = &Bouncer{config: buo.config}

--- a/pkg/database/ent/machine.go
+++ b/pkg/database/ent/machine.go
@@ -36,6 +36,8 @@ type Machine struct {
 	IsValidated bool `json:"isValidated,omitempty"`
 	// Status holds the value of the "status" field.
 	Status string `json:"status,omitempty"`
+	// AuthType holds the value of the "auth_type" field.
+	AuthType string `json:"auth_type"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the MachineQuery when eager-loading is set.
 	Edges MachineEdges `json:"edges"`
@@ -68,7 +70,7 @@ func (*Machine) scanValues(columns []string) ([]interface{}, error) {
 			values[i] = new(sql.NullBool)
 		case machine.FieldID:
 			values[i] = new(sql.NullInt64)
-		case machine.FieldMachineId, machine.FieldPassword, machine.FieldIpAddress, machine.FieldScenarios, machine.FieldVersion, machine.FieldStatus:
+		case machine.FieldMachineId, machine.FieldPassword, machine.FieldIpAddress, machine.FieldScenarios, machine.FieldVersion, machine.FieldStatus, machine.FieldAuthType:
 			values[i] = new(sql.NullString)
 		case machine.FieldCreatedAt, machine.FieldUpdatedAt, machine.FieldLastPush:
 			values[i] = new(sql.NullTime)
@@ -156,6 +158,12 @@ func (m *Machine) assignValues(columns []string, values []interface{}) error {
 			} else if value.Valid {
 				m.Status = value.String
 			}
+		case machine.FieldAuthType:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field auth_type", values[i])
+			} else if value.Valid {
+				m.AuthType = value.String
+			}
 		}
 	}
 	return nil
@@ -214,6 +222,8 @@ func (m *Machine) String() string {
 	builder.WriteString(fmt.Sprintf("%v", m.IsValidated))
 	builder.WriteString(", status=")
 	builder.WriteString(m.Status)
+	builder.WriteString(", auth_type=")
+	builder.WriteString(m.AuthType)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/database/ent/machine/machine.go
+++ b/pkg/database/ent/machine/machine.go
@@ -31,6 +31,8 @@ const (
 	FieldIsValidated = "is_validated"
 	// FieldStatus holds the string denoting the status field in the database.
 	FieldStatus = "status"
+	// FieldAuthType holds the string denoting the auth_type field in the database.
+	FieldAuthType = "auth_type"
 	// EdgeAlerts holds the string denoting the alerts edge name in mutations.
 	EdgeAlerts = "alerts"
 	// Table holds the table name of the machine in the database.
@@ -57,6 +59,7 @@ var Columns = []string{
 	FieldVersion,
 	FieldIsValidated,
 	FieldStatus,
+	FieldAuthType,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -86,4 +89,6 @@ var (
 	ScenariosValidator func(string) error
 	// DefaultIsValidated holds the default value on creation for the "isValidated" field.
 	DefaultIsValidated bool
+	// DefaultAuthType holds the default value on creation for the "auth_type" field.
+	DefaultAuthType string
 )

--- a/pkg/database/ent/machine/where.go
+++ b/pkg/database/ent/machine/where.go
@@ -163,6 +163,13 @@ func Status(v string) predicate.Machine {
 	})
 }
 
+// AuthType applies equality check predicate on the "auth_type" field. It's identical to AuthTypeEQ.
+func AuthType(v string) predicate.Machine {
+	return predicate.Machine(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldAuthType), v))
+	})
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Machine {
 	return predicate.Machine(func(s *sql.Selector) {
@@ -1152,6 +1159,117 @@ func StatusEqualFold(v string) predicate.Machine {
 func StatusContainsFold(v string) predicate.Machine {
 	return predicate.Machine(func(s *sql.Selector) {
 		s.Where(sql.ContainsFold(s.C(FieldStatus), v))
+	})
+}
+
+// AuthTypeEQ applies the EQ predicate on the "auth_type" field.
+func AuthTypeEQ(v string) predicate.Machine {
+	return predicate.Machine(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeNEQ applies the NEQ predicate on the "auth_type" field.
+func AuthTypeNEQ(v string) predicate.Machine {
+	return predicate.Machine(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeIn applies the In predicate on the "auth_type" field.
+func AuthTypeIn(vs ...string) predicate.Machine {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Machine(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.In(s.C(FieldAuthType), v...))
+	})
+}
+
+// AuthTypeNotIn applies the NotIn predicate on the "auth_type" field.
+func AuthTypeNotIn(vs ...string) predicate.Machine {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Machine(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.NotIn(s.C(FieldAuthType), v...))
+	})
+}
+
+// AuthTypeGT applies the GT predicate on the "auth_type" field.
+func AuthTypeGT(v string) predicate.Machine {
+	return predicate.Machine(func(s *sql.Selector) {
+		s.Where(sql.GT(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeGTE applies the GTE predicate on the "auth_type" field.
+func AuthTypeGTE(v string) predicate.Machine {
+	return predicate.Machine(func(s *sql.Selector) {
+		s.Where(sql.GTE(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeLT applies the LT predicate on the "auth_type" field.
+func AuthTypeLT(v string) predicate.Machine {
+	return predicate.Machine(func(s *sql.Selector) {
+		s.Where(sql.LT(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeLTE applies the LTE predicate on the "auth_type" field.
+func AuthTypeLTE(v string) predicate.Machine {
+	return predicate.Machine(func(s *sql.Selector) {
+		s.Where(sql.LTE(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeContains applies the Contains predicate on the "auth_type" field.
+func AuthTypeContains(v string) predicate.Machine {
+	return predicate.Machine(func(s *sql.Selector) {
+		s.Where(sql.Contains(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeHasPrefix applies the HasPrefix predicate on the "auth_type" field.
+func AuthTypeHasPrefix(v string) predicate.Machine {
+	return predicate.Machine(func(s *sql.Selector) {
+		s.Where(sql.HasPrefix(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeHasSuffix applies the HasSuffix predicate on the "auth_type" field.
+func AuthTypeHasSuffix(v string) predicate.Machine {
+	return predicate.Machine(func(s *sql.Selector) {
+		s.Where(sql.HasSuffix(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeEqualFold applies the EqualFold predicate on the "auth_type" field.
+func AuthTypeEqualFold(v string) predicate.Machine {
+	return predicate.Machine(func(s *sql.Selector) {
+		s.Where(sql.EqualFold(s.C(FieldAuthType), v))
+	})
+}
+
+// AuthTypeContainsFold applies the ContainsFold predicate on the "auth_type" field.
+func AuthTypeContainsFold(v string) predicate.Machine {
+	return predicate.Machine(func(s *sql.Selector) {
+		s.Where(sql.ContainsFold(s.C(FieldAuthType), v))
 	})
 }
 

--- a/pkg/database/ent/machine_create.go
+++ b/pkg/database/ent/machine_create.go
@@ -137,6 +137,20 @@ func (mc *MachineCreate) SetNillableStatus(s *string) *MachineCreate {
 	return mc
 }
 
+// SetAuthType sets the "auth_type" field.
+func (mc *MachineCreate) SetAuthType(s string) *MachineCreate {
+	mc.mutation.SetAuthType(s)
+	return mc
+}
+
+// SetNillableAuthType sets the "auth_type" field if the given value is not nil.
+func (mc *MachineCreate) SetNillableAuthType(s *string) *MachineCreate {
+	if s != nil {
+		mc.SetAuthType(*s)
+	}
+	return mc
+}
+
 // AddAlertIDs adds the "alerts" edge to the Alert entity by IDs.
 func (mc *MachineCreate) AddAlertIDs(ids ...int) *MachineCreate {
 	mc.mutation.AddAlertIDs(ids...)
@@ -239,6 +253,10 @@ func (mc *MachineCreate) defaults() {
 		v := machine.DefaultIsValidated
 		mc.mutation.SetIsValidated(v)
 	}
+	if _, ok := mc.mutation.AuthType(); !ok {
+		v := machine.DefaultAuthType
+		mc.mutation.SetAuthType(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -259,6 +277,9 @@ func (mc *MachineCreate) check() error {
 	}
 	if _, ok := mc.mutation.IsValidated(); !ok {
 		return &ValidationError{Name: "isValidated", err: errors.New(`ent: missing required field "Machine.isValidated"`)}
+	}
+	if _, ok := mc.mutation.AuthType(); !ok {
+		return &ValidationError{Name: "auth_type", err: errors.New(`ent: missing required field "Machine.auth_type"`)}
 	}
 	return nil
 }
@@ -366,6 +387,14 @@ func (mc *MachineCreate) createSpec() (*Machine, *sqlgraph.CreateSpec) {
 			Column: machine.FieldStatus,
 		})
 		_node.Status = value
+	}
+	if value, ok := mc.mutation.AuthType(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: machine.FieldAuthType,
+		})
+		_node.AuthType = value
 	}
 	if nodes := mc.mutation.AlertsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/database/ent/machine_update.go
+++ b/pkg/database/ent/machine_update.go
@@ -157,6 +157,20 @@ func (mu *MachineUpdate) ClearStatus() *MachineUpdate {
 	return mu
 }
 
+// SetAuthType sets the "auth_type" field.
+func (mu *MachineUpdate) SetAuthType(s string) *MachineUpdate {
+	mu.mutation.SetAuthType(s)
+	return mu
+}
+
+// SetNillableAuthType sets the "auth_type" field if the given value is not nil.
+func (mu *MachineUpdate) SetNillableAuthType(s *string) *MachineUpdate {
+	if s != nil {
+		mu.SetAuthType(*s)
+	}
+	return mu
+}
+
 // AddAlertIDs adds the "alerts" edge to the Alert entity by IDs.
 func (mu *MachineUpdate) AddAlertIDs(ids ...int) *MachineUpdate {
 	mu.mutation.AddAlertIDs(ids...)
@@ -409,6 +423,13 @@ func (mu *MachineUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: machine.FieldStatus,
 		})
 	}
+	if value, ok := mu.mutation.AuthType(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: machine.FieldAuthType,
+		})
+	}
 	if mu.mutation.AlertsCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2M,
@@ -607,6 +628,20 @@ func (muo *MachineUpdateOne) SetNillableStatus(s *string) *MachineUpdateOne {
 // ClearStatus clears the value of the "status" field.
 func (muo *MachineUpdateOne) ClearStatus() *MachineUpdateOne {
 	muo.mutation.ClearStatus()
+	return muo
+}
+
+// SetAuthType sets the "auth_type" field.
+func (muo *MachineUpdateOne) SetAuthType(s string) *MachineUpdateOne {
+	muo.mutation.SetAuthType(s)
+	return muo
+}
+
+// SetNillableAuthType sets the "auth_type" field if the given value is not nil.
+func (muo *MachineUpdateOne) SetNillableAuthType(s *string) *MachineUpdateOne {
+	if s != nil {
+		muo.SetAuthType(*s)
+	}
 	return muo
 }
 
@@ -884,6 +919,13 @@ func (muo *MachineUpdateOne) sqlSave(ctx context.Context) (_node *Machine, err e
 		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: machine.FieldStatus,
+		})
+	}
+	if value, ok := muo.mutation.AuthType(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: machine.FieldAuthType,
 		})
 	}
 	if muo.mutation.AlertsCleared() {

--- a/pkg/database/ent/migrate/schema.go
+++ b/pkg/database/ent/migrate/schema.go
@@ -69,6 +69,7 @@ var (
 		{Name: "version", Type: field.TypeString, Nullable: true},
 		{Name: "until", Type: field.TypeTime, Nullable: true},
 		{Name: "last_pull", Type: field.TypeTime},
+		{Name: "auth_type", Type: field.TypeString, Default: "api-key"},
 	}
 	// BouncersTable holds the schema information for the "bouncers" table.
 	BouncersTable = &schema.Table{
@@ -152,6 +153,7 @@ var (
 		{Name: "version", Type: field.TypeString, Nullable: true},
 		{Name: "is_validated", Type: field.TypeBool, Default: false},
 		{Name: "status", Type: field.TypeString, Nullable: true},
+		{Name: "auth_type", Type: field.TypeString, Default: "api-key"},
 	}
 	// MachinesTable holds the schema information for the "machines" table.
 	MachinesTable = &schema.Table{

--- a/pkg/database/ent/mutation.go
+++ b/pkg/database/ent/mutation.go
@@ -2338,6 +2338,7 @@ type BouncerMutation struct {
 	version       *string
 	until         *time.Time
 	last_pull     *time.Time
+	auth_type     *string
 	clearedFields map[string]struct{}
 	done          bool
 	oldValue      func(context.Context) (*Bouncer, error)
@@ -2880,6 +2881,42 @@ func (m *BouncerMutation) ResetLastPull() {
 	m.last_pull = nil
 }
 
+// SetAuthType sets the "auth_type" field.
+func (m *BouncerMutation) SetAuthType(s string) {
+	m.auth_type = &s
+}
+
+// AuthType returns the value of the "auth_type" field in the mutation.
+func (m *BouncerMutation) AuthType() (r string, exists bool) {
+	v := m.auth_type
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAuthType returns the old "auth_type" field's value of the Bouncer entity.
+// If the Bouncer object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BouncerMutation) OldAuthType(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAuthType is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAuthType requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAuthType: %w", err)
+	}
+	return oldValue.AuthType, nil
+}
+
+// ResetAuthType resets all changes to the "auth_type" field.
+func (m *BouncerMutation) ResetAuthType() {
+	m.auth_type = nil
+}
+
 // Where appends a list predicates to the BouncerMutation builder.
 func (m *BouncerMutation) Where(ps ...predicate.Bouncer) {
 	m.predicates = append(m.predicates, ps...)
@@ -2899,7 +2936,7 @@ func (m *BouncerMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *BouncerMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m.created_at != nil {
 		fields = append(fields, bouncer.FieldCreatedAt)
 	}
@@ -2930,6 +2967,9 @@ func (m *BouncerMutation) Fields() []string {
 	if m.last_pull != nil {
 		fields = append(fields, bouncer.FieldLastPull)
 	}
+	if m.auth_type != nil {
+		fields = append(fields, bouncer.FieldAuthType)
+	}
 	return fields
 }
 
@@ -2958,6 +2998,8 @@ func (m *BouncerMutation) Field(name string) (ent.Value, bool) {
 		return m.Until()
 	case bouncer.FieldLastPull:
 		return m.LastPull()
+	case bouncer.FieldAuthType:
+		return m.AuthType()
 	}
 	return nil, false
 }
@@ -2987,6 +3029,8 @@ func (m *BouncerMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldUntil(ctx)
 	case bouncer.FieldLastPull:
 		return m.OldLastPull(ctx)
+	case bouncer.FieldAuthType:
+		return m.OldAuthType(ctx)
 	}
 	return nil, fmt.Errorf("unknown Bouncer field %s", name)
 }
@@ -3065,6 +3109,13 @@ func (m *BouncerMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetLastPull(v)
+		return nil
+	case bouncer.FieldAuthType:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAuthType(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Bouncer field %s", name)
@@ -3183,6 +3234,9 @@ func (m *BouncerMutation) ResetField(name string) error {
 		return nil
 	case bouncer.FieldLastPull:
 		m.ResetLastPull()
+		return nil
+	case bouncer.FieldAuthType:
+		m.ResetAuthType()
 		return nil
 	}
 	return fmt.Errorf("unknown Bouncer field %s", name)
@@ -5226,6 +5280,7 @@ type MachineMutation struct {
 	version       *string
 	isValidated   *bool
 	status        *string
+	auth_type     *string
 	clearedFields map[string]struct{}
 	alerts        map[int]struct{}
 	removedalerts map[int]struct{}
@@ -5771,6 +5826,42 @@ func (m *MachineMutation) ResetStatus() {
 	delete(m.clearedFields, machine.FieldStatus)
 }
 
+// SetAuthType sets the "auth_type" field.
+func (m *MachineMutation) SetAuthType(s string) {
+	m.auth_type = &s
+}
+
+// AuthType returns the value of the "auth_type" field in the mutation.
+func (m *MachineMutation) AuthType() (r string, exists bool) {
+	v := m.auth_type
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAuthType returns the old "auth_type" field's value of the Machine entity.
+// If the Machine object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *MachineMutation) OldAuthType(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAuthType is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAuthType requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAuthType: %w", err)
+	}
+	return oldValue.AuthType, nil
+}
+
+// ResetAuthType resets all changes to the "auth_type" field.
+func (m *MachineMutation) ResetAuthType() {
+	m.auth_type = nil
+}
+
 // AddAlertIDs adds the "alerts" edge to the Alert entity by ids.
 func (m *MachineMutation) AddAlertIDs(ids ...int) {
 	if m.alerts == nil {
@@ -5844,7 +5935,7 @@ func (m *MachineMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *MachineMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m.created_at != nil {
 		fields = append(fields, machine.FieldCreatedAt)
 	}
@@ -5875,6 +5966,9 @@ func (m *MachineMutation) Fields() []string {
 	if m.status != nil {
 		fields = append(fields, machine.FieldStatus)
 	}
+	if m.auth_type != nil {
+		fields = append(fields, machine.FieldAuthType)
+	}
 	return fields
 }
 
@@ -5903,6 +5997,8 @@ func (m *MachineMutation) Field(name string) (ent.Value, bool) {
 		return m.IsValidated()
 	case machine.FieldStatus:
 		return m.Status()
+	case machine.FieldAuthType:
+		return m.AuthType()
 	}
 	return nil, false
 }
@@ -5932,6 +6028,8 @@ func (m *MachineMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldIsValidated(ctx)
 	case machine.FieldStatus:
 		return m.OldStatus(ctx)
+	case machine.FieldAuthType:
+		return m.OldAuthType(ctx)
 	}
 	return nil, fmt.Errorf("unknown Machine field %s", name)
 }
@@ -6010,6 +6108,13 @@ func (m *MachineMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetStatus(v)
+		return nil
+	case machine.FieldAuthType:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAuthType(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Machine field %s", name)
@@ -6128,6 +6233,9 @@ func (m *MachineMutation) ResetField(name string) error {
 		return nil
 	case machine.FieldStatus:
 		m.ResetStatus()
+		return nil
+	case machine.FieldAuthType:
+		m.ResetAuthType()
 		return nil
 	}
 	return fmt.Errorf("unknown Machine field %s", name)

--- a/pkg/database/ent/runtime.go
+++ b/pkg/database/ent/runtime.go
@@ -82,6 +82,10 @@ func init() {
 	bouncerDescLastPull := bouncerFields[9].Descriptor()
 	// bouncer.DefaultLastPull holds the default value on creation for the last_pull field.
 	bouncer.DefaultLastPull = bouncerDescLastPull.Default.(func() time.Time)
+	// bouncerDescAuthType is the schema descriptor for auth_type field.
+	bouncerDescAuthType := bouncerFields[10].Descriptor()
+	// bouncer.DefaultAuthType holds the default value on creation for the auth_type field.
+	bouncer.DefaultAuthType = bouncerDescAuthType.Default.(string)
 	decisionFields := schema.Decision{}.Fields()
 	_ = decisionFields
 	// decisionDescCreatedAt is the schema descriptor for created_at field.
@@ -146,6 +150,10 @@ func init() {
 	machineDescIsValidated := machineFields[8].Descriptor()
 	// machine.DefaultIsValidated holds the default value on creation for the isValidated field.
 	machine.DefaultIsValidated = machineDescIsValidated.Default.(bool)
+	// machineDescAuthType is the schema descriptor for auth_type field.
+	machineDescAuthType := machineFields[10].Descriptor()
+	// machine.DefaultAuthType holds the default value on creation for the auth_type field.
+	machine.DefaultAuthType = machineDescAuthType.Default.(string)
 	metaFields := schema.Meta{}.Fields()
 	_ = metaFields
 	// metaDescCreatedAt is the schema descriptor for created_at field.

--- a/pkg/database/ent/schema/bouncer.go
+++ b/pkg/database/ent/schema/bouncer.go
@@ -29,6 +29,7 @@ func (Bouncer) Fields() []ent.Field {
 		field.Time("until").Default(types.UtcNow).Optional().StructTag(`json:"until"`),
 		field.Time("last_pull").
 			Default(types.UtcNow).StructTag(`json:"last_pull"`),
+		field.String("auth_type").StructTag(`json:"auth_type"`).Default(types.ApiKeyAuthType),
 	}
 }
 

--- a/pkg/database/ent/schema/machine.go
+++ b/pkg/database/ent/schema/machine.go
@@ -32,7 +32,7 @@ func (Machine) Fields() []ent.Field {
 		field.Bool("isValidated").
 			Default(false),
 		field.String("status").Optional(),
-		field.String("auth_type").Default(types.ApiKeyAuthType).StructTag(`json:"auth_type"`),
+		field.String("auth_type").Default(types.PasswordAuthType).StructTag(`json:"auth_type"`),
 	}
 }
 

--- a/pkg/database/ent/schema/machine.go
+++ b/pkg/database/ent/schema/machine.go
@@ -32,6 +32,7 @@ func (Machine) Fields() []ent.Field {
 		field.Bool("isValidated").
 			Default(false),
 		field.String("status").Optional(),
+		field.String("auth_type").Default(types.ApiKeyAuthType).StructTag(`json:"auth_type"`),
 	}
 }
 

--- a/pkg/database/machines.go
+++ b/pkg/database/machines.go
@@ -14,7 +14,7 @@ import (
 
 const CapiMachineID = "CAPI"
 
-func (c *Client) CreateMachine(machineID *string, password *strfmt.Password, ipAddress string, isValidated bool, force bool) (int, error) {
+func (c *Client) CreateMachine(machineID *string, password *strfmt.Password, ipAddress string, isValidated bool, force bool, authType string) (int, error) {
 	hashPassword, err := bcrypt.GenerateFromPassword([]byte(*password), bcrypt.DefaultCost)
 	if err != nil {
 		c.Log.Warningf("CreateMachine : %s", err)
@@ -46,6 +46,7 @@ func (c *Client) CreateMachine(machineID *string, password *strfmt.Password, ipA
 		SetPassword(string(hashPassword)).
 		SetIpAddress(ipAddress).
 		SetIsValidated(isValidated).
+		SetAuthType(authType).
 		Save(c.CTX)
 
 	if err != nil {

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -1,0 +1,4 @@
+package types
+
+const ApiKeyAuthType = "api-key"
+const TlsAuthType = "tls"

--- a/pkg/types/constants.go
+++ b/pkg/types/constants.go
@@ -2,3 +2,4 @@ package types
 
 const ApiKeyAuthType = "api-key"
 const TlsAuthType = "tls"
+const PasswordAuthType = "password"


### PR DESCRIPTION
This PR is a work in progress to allow both bouncers and agents to allow to the local api via client certificates rather than api-key or login/password. This feature should make crowdsec industrialization easier (ie. k8s / openstack etc.).

 - [x] Support for client cert authentication for bouncers and agents :
   - in LAPI, user can specify a list of valid OUs for bouncer and agent auth.
   - JWT/ApiKey middlewares are checking client certificate validity and OU
   - Agent/Bouncer name is derived from the provided CN (w/ addition of source IP)
   - Agent/Bouncer db entries are created at runtime when the client auths for the first time
 - [x] Support for CRL and OSCP
 - [x] The PR as well includes the addition of a garbage collector for bouncers/agents :
   - specify a max age for tls and/or api types : bouncer reaching this age since last pull will be deleted from db
   - specify a max age for tls and/or pasword types : agents with no existing alerts reaching this age since last push will be deleted from db
 - [ ] Reflect changes in go-cs-bouncer
 - [ ] Doc
 - [ ] Tests