### PR TITLE
Improve plugins grouping (alternative to #1424)

### DIFF
--- a/.github/workflows/bats-sqlite-coverage.yml
+++ b/.github/workflows/bats-sqlite-coverage.yml
@@ -38,7 +38,8 @@ jobs:
       run: TEST_COVERAGE=true make bats-clean bats-build bats-fixture
 
     - name: "Run tests (with coverage)"
-      run: TEST_COVERAGE=true make bats-test
+      #run: TEST_COVERAGE=true make bats-test
+      run: ./tests/run-tests tests/bats/70_http_plugin.bats
 
     - name: Upload coverage report
       uses: actions/upload-artifact@v2

--- a/.github/workflows/bats-sqlite-coverage.yml
+++ b/.github/workflows/bats-sqlite-coverage.yml
@@ -38,8 +38,7 @@ jobs:
       run: TEST_COVERAGE=true make bats-clean bats-build bats-fixture
 
     - name: "Run tests (with coverage)"
-      #run: TEST_COVERAGE=true make bats-test
-      run: ./tests/run-tests tests/bats/70_http_plugin.bats
+      run: TEST_COVERAGE=true make bats-test
 
     - name: Upload coverage report
       uses: actions/upload-artifact@v2

--- a/pkg/csplugin/broker.go
+++ b/pkg/csplugin/broker.go
@@ -367,9 +367,9 @@ func setRequiredFields(pluginCfg *PluginConfig) {
 	// 	pluginCfg.GroupWait = time.Second * 1
 	// }
 
-	if pluginCfg.GroupWait == time.Second*0 && pluginCfg.GroupThreshold == 0 {
-		pluginCfg.GroupThreshold = 1
-	}
+	// if pluginCfg.GroupWait == time.Second*0 && pluginCfg.GroupThreshold == 0 {
+	// 	pluginCfg.GroupThreshold = 1
+	// }
 }
 
 func pluginIsValid(path string) error {

--- a/pkg/csplugin/broker.go
+++ b/pkg/csplugin/broker.go
@@ -58,12 +58,12 @@ type PluginBroker struct {
 type PluginConfig struct {
 	Type           string        `yaml:"type"`
 	Name           string        `yaml:"name"`
-	GroupWait      time.Duration `yaml:"group_wait"`
-	GroupThreshold int           `yaml:"group_threshold"`
-	MaxRetry       int           `yaml:"max_retry"`
-	TimeOut        time.Duration `yaml:"timeout"`
+	GroupWait      time.Duration `yaml:"group_wait,omitempty"`
+	GroupThreshold int           `yaml:"group_threshold,omitempty"`
+	MaxRetry       int           `yaml:"max_retry,omitempty"`
+	TimeOut        time.Duration `yaml:"timeout,omitempty"`
 
-	Format string `yaml:"format"` // specific to notification plugins
+	Format string `yaml:"format,omitempty"` // specific to notification plugins
 
 	Config map[string]interface{} `yaml:",inline"` //to keep the plugin-specific config
 
@@ -368,7 +368,6 @@ func setRequiredFields(pluginCfg *PluginConfig) {
 	// }
 
 	if pluginCfg.GroupWait == time.Second*0 && pluginCfg.GroupThreshold == 0 {
-		log.Printf("GroupThreshold is set to 1 by default")
 		pluginCfg.GroupThreshold = 1
 	}
 }

--- a/pkg/csplugin/broker.go
+++ b/pkg/csplugin/broker.go
@@ -363,13 +363,6 @@ func setRequiredFields(pluginCfg *PluginConfig) {
 		pluginCfg.TimeOut = time.Second * 5
 	}
 
-	// if pluginCfg.GroupWait == time.Second*0 {
-	// 	pluginCfg.GroupWait = time.Second * 1
-	// }
-
-	// if pluginCfg.GroupWait == time.Second*0 && pluginCfg.GroupThreshold == 0 {
-	// 	pluginCfg.GroupThreshold = 1
-	// }
 }
 
 func pluginIsValid(path string) error {

--- a/pkg/csplugin/broker_test.go
+++ b/pkg/csplugin/broker_test.go
@@ -519,7 +519,7 @@ func TestBrokerRunTimeThreshold(t *testing.T) {
 	}
 }
 
-func TestBrokerRun(t *testing.T) {
+func TestBrokerRunSimple(t *testing.T) {
 	DefaultEmptyTicker = 50 * time.Millisecond
 	buildDummyPlugin()
 	setPluginPermTo744()

--- a/pkg/csplugin/broker_test.go
+++ b/pkg/csplugin/broker_test.go
@@ -285,14 +285,14 @@ func TestBrokerNoThreshold(t *testing.T) {
 	setPluginPermTo744()
 	defer tearDown()
 	//init
-	procCfg := csconfig.PluginCfg{}
+	pluginCfg := csconfig.PluginCfg{}
 	pb := PluginBroker{}
 	profiles := csconfig.NewDefaultConfig().API.Server.Profiles
 	profiles = append(profiles, &csconfig.ProfileCfg{
 		Notifications: []string{"dummy_default"},
 	})
 	//default config
-	err := pb.Init(&procCfg, profiles, &csconfig.ConfigurationPaths{
+	err := pb.Init(&pluginCfg, profiles, &csconfig.ConfigurationPaths{
 		PluginDir:       testPath,
 		NotificationDir: "./tests/notifications",
 	})
@@ -336,7 +336,7 @@ func TestBrokerRunGroupAndTimeThreshold_TimeFirst(t *testing.T) {
 	defer tearDown()
 
 	//init
-	procCfg := csconfig.PluginCfg{}
+	pluginCfg := csconfig.PluginCfg{}
 	pb := PluginBroker{}
 	profiles := csconfig.NewDefaultConfig().API.Server.Profiles
 	profiles = append(profiles, &csconfig.ProfileCfg{
@@ -347,7 +347,7 @@ func TestBrokerRunGroupAndTimeThreshold_TimeFirst(t *testing.T) {
 	cfg.GroupThreshold = 4
 	cfg.GroupWait = 1 * time.Second
 	writeconfig(t, cfg, "tests/notifications/dummy.yaml")
-	err := pb.Init(&procCfg, profiles, &csconfig.ConfigurationPaths{
+	err := pb.Init(&pluginCfg, profiles, &csconfig.ConfigurationPaths{
 		PluginDir:       testPath,
 		NotificationDir: "./tests/notifications",
 	})
@@ -382,7 +382,7 @@ func TestBrokerRunGroupAndTimeThreshold_CountFirst(t *testing.T) {
 	setPluginPermTo744()
 	defer tearDown()
 	//init
-	procCfg := csconfig.PluginCfg{}
+	pluginCfg := csconfig.PluginCfg{}
 	pb := PluginBroker{}
 	profiles := csconfig.NewDefaultConfig().API.Server.Profiles
 	profiles = append(profiles, &csconfig.ProfileCfg{
@@ -393,7 +393,7 @@ func TestBrokerRunGroupAndTimeThreshold_CountFirst(t *testing.T) {
 	cfg.GroupThreshold = 4
 	cfg.GroupWait = 4 * time.Second
 	writeconfig(t, cfg, "tests/notifications/dummy.yaml")
-	err := pb.Init(&procCfg, profiles, &csconfig.ConfigurationPaths{
+	err := pb.Init(&pluginCfg, profiles, &csconfig.ConfigurationPaths{
 		PluginDir:       testPath,
 		NotificationDir: "./tests/notifications",
 	})
@@ -432,7 +432,7 @@ func TestBrokerRunGroupThreshold(t *testing.T) {
 	setPluginPermTo744()
 	defer tearDown()
 	//init
-	procCfg := csconfig.PluginCfg{}
+	pluginCfg := csconfig.PluginCfg{}
 	pb := PluginBroker{}
 	profiles := csconfig.NewDefaultConfig().API.Server.Profiles
 	profiles = append(profiles, &csconfig.ProfileCfg{
@@ -442,7 +442,7 @@ func TestBrokerRunGroupThreshold(t *testing.T) {
 	raw, cfg := readconfig(t, "tests/notifications/dummy.yaml")
 	cfg.GroupThreshold = 4
 	writeconfig(t, cfg, "tests/notifications/dummy.yaml")
-	err := pb.Init(&procCfg, profiles, &csconfig.ConfigurationPaths{
+	err := pb.Init(&pluginCfg, profiles, &csconfig.ConfigurationPaths{
 		PluginDir:       testPath,
 		NotificationDir: "./tests/notifications",
 	})
@@ -480,7 +480,7 @@ func TestBrokerRunTimeThreshold(t *testing.T) {
 	setPluginPermTo744()
 	defer tearDown()
 	//init
-	procCfg := csconfig.PluginCfg{}
+	pluginCfg := csconfig.PluginCfg{}
 	pb := PluginBroker{}
 	profiles := csconfig.NewDefaultConfig().API.Server.Profiles
 	profiles = append(profiles, &csconfig.ProfileCfg{
@@ -490,7 +490,7 @@ func TestBrokerRunTimeThreshold(t *testing.T) {
 	raw, cfg := readconfig(t, "tests/notifications/dummy.yaml")
 	cfg.GroupWait = time.Duration(1 * time.Second)
 	writeconfig(t, cfg, "tests/notifications/dummy.yaml")
-	err := pb.Init(&procCfg, profiles, &csconfig.ConfigurationPaths{
+	err := pb.Init(&pluginCfg, profiles, &csconfig.ConfigurationPaths{
 		PluginDir:       testPath,
 		NotificationDir: "./tests/notifications",
 	})
@@ -524,13 +524,13 @@ func TestBrokerRunSimple(t *testing.T) {
 	buildDummyPlugin()
 	setPluginPermTo744()
 	defer tearDown()
-	procCfg := csconfig.PluginCfg{}
+	pluginCfg := csconfig.PluginCfg{}
 	pb := PluginBroker{}
 	profiles := csconfig.NewDefaultConfig().API.Server.Profiles
 	profiles = append(profiles, &csconfig.ProfileCfg{
 		Notifications: []string{"dummy_default"},
 	})
-	err := pb.Init(&procCfg, profiles, &csconfig.ConfigurationPaths{
+	err := pb.Init(&pluginCfg, profiles, &csconfig.ConfigurationPaths{
 		PluginDir:       testPath,
 		NotificationDir: "./tests/notifications",
 	})

--- a/pkg/csplugin/watcher.go
+++ b/pkg/csplugin/watcher.go
@@ -1,7 +1,6 @@
 package csplugin
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -116,7 +115,7 @@ func (pw *PluginWatcher) watchPluginTicker(pluginName string) {
 			send := false
 			//if count threshold was set, honor no matter what
 			if pc, _ := pw.AlertCountByPluginName.Get(pluginName); watchCount > 0 && pc >= watchCount {
-				fmt.Printf("[%s] %d alerts received, sending\n", pluginName, pc)
+				log.Tracef("[%s] %d alerts received, sending\n", pluginName, pc)
 				send = true
 				pw.AlertCountByPluginName.Set(pluginName, 0)
 			}

--- a/pkg/csplugin/watcher.go
+++ b/pkg/csplugin/watcher.go
@@ -90,19 +90,21 @@ func (pw *PluginWatcher) watchPluginTicker(pluginName string) {
 			}
 			//if time threshold only was set
 			if watchTime > 0 && watchTime == interval {
+				fmt.Printf("watchTime triggered, sending\n")
 				send = true
 			}
 
 			//if we hit timer because it was set low to honor count, check if we should trigger
-			if watchTime == time.Second && watchTime != interval {
-				fmt.Printf("last send %s, %s elapsed send %s\n", lastSend, time.Now().Sub(lastSend), pluginName)
-				if lastSend.Add(interval).After(time.Now()) {
+			if watchTime == time.Second && watchTime != interval && interval != 0 {
+				fmt.Printf("last send [%s] %s elapsed, required [%s], send %s\n", lastSend, time.Now().Sub(lastSend), interval, pluginName)
+				if lastSend.Add(interval).Before(time.Now()) {
+					fmt.Printf("SENDING %s, %s elapsed send %s\n", lastSend, time.Now().Sub(lastSend), pluginName)
 					send = true
 					lastSend = time.Now()
 				}
 			}
 			if send {
-				fmt.Printf("trigger %s\n", pluginName)
+				fmt.Printf("SENDING TO %s\n", pluginName)
 				pw.PluginEvents <- pluginName
 			} else {
 				fmt.Printf("skip %s\n", pluginName)

--- a/pkg/csplugin/watcher.go
+++ b/pkg/csplugin/watcher.go
@@ -119,8 +119,6 @@ func (pw *PluginWatcher) watchPluginTicker(pluginName string) {
 				fmt.Printf("[%s] %d alerts received, sending\n", pluginName, pc)
 				send = true
 				pw.AlertCountByPluginName.Set(pluginName, 0)
-			} else {
-				fmt.Printf("[%s] %d alerts received, NOT sending\n", pluginName, pc)
 			}
 			//if time threshold only was set
 			if watchTime > 0 && watchTime == interval {

--- a/pkg/csplugin/watcher.go
+++ b/pkg/csplugin/watcher.go
@@ -152,7 +152,7 @@ func (pw *PluginWatcher) watchPluginAlertCounts() {
 		select {
 		case pluginName := <-pw.Inserts:
 			//we only "count" pending alerts, and watchPluginTicker is actually going to send it
-			if threshold := pw.PluginConfigByName[pluginName].GroupThreshold; threshold > 0 {
+			if _, ok := pw.PluginConfigByName[pluginName]; ok {
 				curr, _ := pw.AlertCountByPluginName.Get(pluginName)
 				pw.AlertCountByPluginName.Set(pluginName, curr+1)
 			}

--- a/pkg/csplugin/watcher.go
+++ b/pkg/csplugin/watcher.go
@@ -1,10 +1,10 @@
 package csplugin
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/models"
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/tomb.v2"
 )
 
@@ -20,6 +20,8 @@ type PluginWatcher struct {
 	Inserts                chan string
 	tomb                   *tomb.Tomb
 }
+
+var DefaultEmptyTicker = time.Second * 1
 
 func (pw *PluginWatcher) Init(configs map[string]PluginConfig, alertsByPluginName map[string][]*models.Alert) {
 	pw.PluginConfigByName = configs
@@ -60,17 +62,17 @@ func (pw *PluginWatcher) watchPluginTicker(pluginName string) {
 	//only size is set
 	if threshold > 0 && interval == 0 {
 		watchCount = threshold
-		watchTime = time.Second
+		watchTime = DefaultEmptyTicker
 	} else if interval != 0 && threshold == 0 {
 		//only time is set
 		watchTime = interval
 	} else if interval != 0 && threshold != 0 {
 		//both are set
-		watchTime = time.Second
+		watchTime = DefaultEmptyTicker
 		watchCount = threshold
 	} else {
 		//none are set, we sent every event we receive
-		watchTime = time.Second
+		watchTime = DefaultEmptyTicker
 		watchCount = 1
 	}
 
@@ -82,32 +84,27 @@ func (pw *PluginWatcher) watchPluginTicker(pluginName string) {
 			send := false
 			//if count threshold was set, honor no matter what
 			if watchCount > 0 && pw.AlertCountByPluginName[pluginName] >= watchCount {
-				fmt.Printf("[%s] %d alerts received, sending\n", pluginName, pw.AlertCountByPluginName[pluginName])
+				log.Tracef("sending alerts to %s, threshold %d reached", pluginName, pw.AlertCountByPluginName[pluginName])
 				send = true
 				pw.AlertCountByPluginName[pluginName] = 0
-			} else {
-				fmt.Printf("[%s] %d alerts received, NOT sending\n", pluginName, pw.AlertCountByPluginName[pluginName])
 			}
 			//if time threshold only was set
 			if watchTime > 0 && watchTime == interval {
-				fmt.Printf("watchTime triggered, sending\n")
+				log.Tracef("sending alerts to %s, duration %s elapsed", pluginName, interval)
 				send = true
 			}
 
 			//if we hit timer because it was set low to honor count, check if we should trigger
-			if watchTime == time.Second && watchTime != interval && interval != 0 {
-				fmt.Printf("last send [%s] %s elapsed, required [%s], send %s\n", lastSend, time.Now().Sub(lastSend), interval, pluginName)
+			if watchTime == DefaultEmptyTicker && watchTime != interval && interval != 0 {
 				if lastSend.Add(interval).Before(time.Now()) {
-					fmt.Printf("SENDING %s, %s elapsed send %s\n", lastSend, time.Now().Sub(lastSend), pluginName)
+					log.Tracef("sending alerts to %s, duration %s elapsed", pluginName, interval)
 					send = true
 					lastSend = time.Now()
 				}
 			}
 			if send {
-				fmt.Printf("SENDING TO %s\n", pluginName)
+				log.Tracef("sending alerts to %s", pluginName)
 				pw.PluginEvents <- pluginName
-			} else {
-				fmt.Printf("skip %s\n", pluginName)
 			}
 		case <-pw.tomb.Dying():
 			ticker.Stop()

--- a/pkg/csplugin/watcher_test.go
+++ b/pkg/csplugin/watcher_test.go
@@ -34,7 +34,8 @@ func insertNAlertsToPlugin(pw *PluginWatcher, n int, pluginName string) {
 
 func listenChannelWithTimeout(ctx context.Context, channel chan string) error {
 	select {
-	case <-channel:
+	case x := <-channel:
+		log.Printf("received -> %v", x)
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/pkg/csplugin/watcher_test.go
+++ b/pkg/csplugin/watcher_test.go
@@ -21,9 +21,11 @@ func resetTestTomb(testTomb *tomb.Tomb) {
 }
 
 func resetWatcherAlertCounter(pw *PluginWatcher) {
-	for k := range pw.AlertCountByPluginName {
-		pw.AlertCountByPluginName[k] = 0
+	pw.AlertCountByPluginName.Lock()
+	for k := range pw.AlertCountByPluginName.data {
+		pw.AlertCountByPluginName.data[k] = 0
 	}
+	pw.AlertCountByPluginName.Unlock()
 }
 
 func insertNAlertsToPlugin(pw *PluginWatcher, n int, pluginName string) {

--- a/pkg/types/utils.go
+++ b/pkg/types/utils.go
@@ -248,7 +248,7 @@ func UtcNow() time.Time {
 func GetLineCountForFile(filepath string) int {
 	f, err := os.Open(filepath)
 	if err != nil {
-		log.Fatalf("unable to open log file %s", filepath)
+		log.Fatalf("unable to open log file %s : %s", filepath, err)
 	}
 	defer f.Close()
 	lc := 0

--- a/tests/bats/70_http_plugin.bats
+++ b/tests/bats/70_http_plugin.bats
@@ -59,8 +59,10 @@ setup() {
 
 @test "$FILE expected 1 log line from http server" {
     run -0 wc -l <"${MOCK_OUT}"
+    echo $MOCK_OUT >&3
     # wc can pad with spaces on some platforms
     run -0 tr -d ' ' < <(output)
+    echo $output >&3
     assert_output 1
 }
 

--- a/tests/bats/70_http_plugin.bats
+++ b/tests/bats/70_http_plugin.bats
@@ -54,17 +54,13 @@ setup() {
 
     run -0 cscli decisions add --ip 1.2.3.5 --duration 30s
     assert_output --partial 'Decision successfully added'
-    sleep 2
+    sleep 5
 }
 
 @test "$FILE expected 1 log line from http server" {
     run -0 wc -l <"${MOCK_OUT}"
-    echo "YEAH YEAH YEAH" >&3
-    echo ${MOCK_OUT} >&3
-    cat ${MOCK_OUT} >&3
     # wc can pad with spaces on some platforms
     run -0 tr -d ' ' < <(output)
-    echo $output >&3
     assert_output 1
 }
 

--- a/tests/bats/70_http_plugin.bats
+++ b/tests/bats/70_http_plugin.bats
@@ -59,7 +59,7 @@ setup() {
 
 @test "$FILE expected 1 log line from http server" {
     run -0 wc -l <"${MOCK_OUT}"
-    echo $MOCK_OUT >&3
+    cat ${MOCK_OUT} >&3
     # wc can pad with spaces on some platforms
     run -0 tr -d ' ' < <(output)
     echo $output >&3

--- a/tests/bats/70_http_plugin.bats
+++ b/tests/bats/70_http_plugin.bats
@@ -59,6 +59,7 @@ setup() {
 
 @test "$FILE expected 1 log line from http server" {
     run -0 wc -l <"${MOCK_OUT}"
+    echo ${MOCK_OUT} >&3
     cat ${MOCK_OUT} >&3
     # wc can pad with spaces on some platforms
     run -0 tr -d ' ' < <(output)

--- a/tests/bats/70_http_plugin.bats
+++ b/tests/bats/70_http_plugin.bats
@@ -59,6 +59,7 @@ setup() {
 
 @test "$FILE expected 1 log line from http server" {
     run -0 wc -l <"${MOCK_OUT}"
+    echo "YEAH YEAH YEAH" >&3
     echo ${MOCK_OUT} >&3
     cat ${MOCK_OUT} >&3
     # wc can pad with spaces on some platforms

--- a/tests/mock-http.py
+++ b/tests/mock-http.py
@@ -21,6 +21,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         self.send_header('Content-type','application/json')
         self.end_headers()
         self.wfile.write(json.dumps({}).encode())
+        self.wfile.flush()
         return
 
     def log_message(self, format, *args):


### PR DESCRIPTION
Fixes https://discourse.crowdsec.net/t/http-plugin-configuration-group-wait-and-group-threshold-problem/649/3

This error was caused due to somewhat wrong default config.

New logic is:
 - Simplify the watcher : only the ticker-based watcher can trigger events processing
 - Ensure w/ extra tests that treshold can be set by "time", "count", "time+count" or none
