### PR TITLE
Reduce the query unescape helper verbosity

### DIFF
--- a/pkg/exprhelpers/exprlib.go
+++ b/pkg/exprhelpers/exprlib.go
@@ -120,7 +120,7 @@ func PathEscape(s string) string {
 func PathUnescape(s string) string {
 	ret, err := url.PathUnescape(s)
 	if err != nil {
-		log.Errorf("unable to PathUnescape '%s': %+v", s, err)
+		log.Debugf("unable to PathUnescape '%s': %+v", s, err)
 		return s
 	}
 	return ret
@@ -129,7 +129,7 @@ func PathUnescape(s string) string {
 func QueryUnescape(s string) string {
 	ret, err := url.QueryUnescape(s)
 	if err != nil {
-		log.Errorf("unable to QueryUnescape '%s': %+v", s, err)
+		log.Debugf("unable to QueryUnescape '%s': %+v", s, err)
 		return s
 	}
 	return ret


### PR DESCRIPTION
- According to the net/url document, `QueryUnescape` returns an error if any % is not followed by two hexadecimal digits.