### PR TITLE
docker: add enroll on startup

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -153,6 +153,9 @@ Using binds rather than named volumes ([more explanation here](https://docs.dock
 * `DISABLE_POSTOVERFLOWS`   - Postoverflows to remove from the [hub](https://hub.crowdsec.net/browse/#configurations), separated by space : `-e DISABLE_POSTOVERFLOWS="crowdsecurity/cdn-whitelist crowdsecurity/seo-bots-whitelist"`
 * `PLUGIN_DIR`              - Directory for plugins (default: `/usr/local/lib/crowdsec/plugins/`) : `-e PLUGIN_DIR="<path>"`
 * `BOUNCER_KEY_<name>`      - Register a bouncer with the name `<name>` and a key equal to the value of the environment variable.
+* `ENROLL_KEY`              - Enroll key retrieved from [the console](https://app.crowdsec.net/) to enroll the instance.
+* `ENROLL_INSTANCE_NAME`    - To set an instance name and see it on [the console](https://app.crowdsec.net/).
+* `ENROLL_TAGS`             - To set tags when enrolling an instance and use them for search and filtering on [the console](https://app.crowdsec.net/)
 
 ## Volumes
 

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -65,6 +65,21 @@ if [ "$DISABLE_ONLINE_API" == "" ] && [ "$CONFIG_FILE" == "" ] ; then
     fi
 fi
 
+## Enroll instance if enroll key is provided
+if [ "$DISABLE_ONLINE_API" == "" ] && [ "$ENROLL_KEY" != "" ] ; then
+    enroll_args=""
+    if [ "$ENROLL_INSTANCE_NAME"  != "" ] ; then
+        enroll_args="--name $ENROLL_INSTANCE_NAME"
+    fi
+    if [ "$ENROLL_TAGS"  != "" ] ; then
+        for tag in ${ENROLL_TAGS}
+        do
+            enroll_args="$enroll_args --tags $tag"
+        done
+    fi
+    cscli console enroll $enroll_args $ENROLL_KEY
+fi
+
 # crowdsec sqlite database permissions
 if [ "$GID" != "" ]; then
     IS_SQLITE=$(yq eval '.db_config.type == "sqlite"' "$CS_CONFIG_FILE")


### PR DESCRIPTION
To fix this https://github.com/crowdsecurity/crowdsec/issues/1286

* Support enroll on container start with instance name and tags.

tested locally:
```
$ docker run --rm --name crowdsec -e ENROLL_KEY="<my_enroll_key>" -e ENROLL_INSTANCE_NAME="docker-test" -e ENROLL_TAGS="test docker linux" crowdsec-local
```

![image](https://user-images.githubusercontent.com/19668340/164219643-5b09317b-f030-460c-8791-19871220210a.png)
