### PR TITLE
cscli: add autocompletions for hubitems

### DIFF
--- a/cmd/crowdsec-cli/alerts.go
+++ b/cmd/crowdsec-cli/alerts.go
@@ -350,6 +350,7 @@ cscli alerts list --type ban`,
 cscli alerts delete --range 1.2.3.0/24
 cscli alerts delete -s crowdsecurity/ssh-bf"`,
 		DisableAutoGenTag: true,
+		Aliases:           []string{"remove"},
 		Args:              cobra.ExactArgs(0),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			if AlertDeleteAll {

--- a/cmd/crowdsec-cli/bouncers.go
+++ b/cmd/crowdsec-cli/bouncers.go
@@ -157,6 +157,7 @@ cscli bouncers add MyBouncerName -k %s`, generatePassword(32)),
 		Use:               "delete MyBouncerName",
 		Short:             "delete bouncer",
 		Args:              cobra.MinimumNArgs(1),
+		Aliases:           []string{"remove"},
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, bouncerID := range args {

--- a/cmd/crowdsec-cli/bouncers.go
+++ b/cmd/crowdsec-cli/bouncers.go
@@ -28,6 +28,7 @@ func NewBouncersCmd() *cobra.Command {
 Note: This command requires database direct access, so is intended to be run on Local API/master.
 `,
 		Args:              cobra.MinimumNArgs(1),
+		Aliases:           []string{"bouncer"},
 		DisableAutoGenTag: true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			var err error

--- a/cmd/crowdsec-cli/collections.go
+++ b/cmd/crowdsec-cli/collections.go
@@ -54,16 +54,7 @@ func NewCollectionsCmd() *cobra.Command {
 		Example: `cscli collections install crowdsec/xxx crowdsec/xyz`,
 		Args:    cobra.MinimumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			upstreamCollections := make([]string, 0)
-			hubItems := cwhub.GetHubStatusForItemType(cwhub.COLLECTIONS, "", true)
-			for _, item := range hubItems {
-				upstreamCollections = append(upstreamCollections, item.Name)
-			}
-			cobra.CompDebugln(fmt.Sprintf("collections: %+v", upstreamCollections), true)
-			return upstreamCollections, cobra.ShellCompDirectiveNoFileComp
+			return compAllItems(cwhub.COLLECTIONS, args, toComplete)
 		},
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -91,16 +82,7 @@ func NewCollectionsCmd() *cobra.Command {
 		Aliases:           []string{"delete"},
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			installedCollections, err := cwhub.GetInstalledCollectionsAsString()
-			if err != nil {
-				cobra.CompDebugln(fmt.Sprintf("list installed collections err: %s", err), true)
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			cobra.CompDebugln(fmt.Sprintf("collections: %+v", installedCollections), true)
-			return installedCollections, cobra.ShellCompDirectiveNoFileComp
+			return compInstalledItems(cwhub.COLLECTIONS, args, toComplete)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if all {
@@ -140,16 +122,7 @@ func NewCollectionsCmd() *cobra.Command {
 		Example:           `cscli collections upgrade crowdsec/xxx crowdsec/xyz`,
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			installedCollections, err := cwhub.GetInstalledCollectionsAsString()
-			if err != nil {
-				cobra.CompDebugln(fmt.Sprintf("list installed collections err: %s", err), true)
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			cobra.CompDebugln(fmt.Sprintf("collections: %+v", installedCollections), true)
-			return installedCollections, cobra.ShellCompDirectiveNoFileComp
+			return compInstalledItems(cwhub.COLLECTIONS, args, toComplete)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if all {
@@ -176,16 +149,7 @@ func NewCollectionsCmd() *cobra.Command {
 		Args:              cobra.MinimumNArgs(1),
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			installedCollections, err := cwhub.GetInstalledCollectionsAsString()
-			if err != nil {
-				cobra.CompDebugln(fmt.Sprintf("list installed collections err: %s", err), true)
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			cobra.CompDebugln(fmt.Sprintf("collections: %+v", installedCollections), true)
-			return installedCollections, cobra.ShellCompDirectiveNoFileComp
+			return compInstalledItems(cwhub.COLLECTIONS, args, toComplete)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, name := range args {

--- a/cmd/crowdsec-cli/collections.go
+++ b/cmd/crowdsec-cli/collections.go
@@ -88,6 +88,7 @@ func NewCollectionsCmd() *cobra.Command {
 		Short:             "Remove given collection(s)",
 		Long:              `Remove given collection(s) from hub`,
 		Example:           `cscli collections remove crowdsec/xxx crowdsec/xyz`,
+		Aliases:           []string{"delete"},
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if err := LoadHub(); err != nil {

--- a/cmd/crowdsec-cli/decisions.go
+++ b/cmd/crowdsec-cli/decisions.go
@@ -143,6 +143,7 @@ func NewDecisionsCmd() *cobra.Command {
 		Short:   "Manage decisions",
 		Long:    `Add/List/Delete/Import decisions from LAPI`,
 		Example: `cscli decisions [action] [filter]`,
+		Aliases: []string{"decision"},
 		/*TBD example*/
 		Args:              cobra.MinimumNArgs(1),
 		DisableAutoGenTag: true,

--- a/cmd/crowdsec-cli/decisions.go
+++ b/cmd/crowdsec-cli/decisions.go
@@ -420,6 +420,7 @@ cscli decisions add --scope username --value foobar
 		Use:               "delete [options]",
 		Short:             "Delete decisions",
 		DisableAutoGenTag: true,
+		Aliases:           []string{"remove"},
 		Example: `cscli decisions delete -r 1.2.3.0/24
 cscli decisions delete -i 1.2.3.4
 cscli decisions delete -s crowdsecurity/ssh-bf

--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -291,6 +291,7 @@ cscli machines add MyTestMachine --password MyPassword
 		Short:             "delete machines",
 		Example:           `cscli machines delete "machine_name"`,
 		Args:              cobra.MinimumNArgs(1),
+		Aliases:           []string{"remove"},
 		DisableAutoGenTag: true,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			var err error

--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -102,6 +102,7 @@ Note: This command requires database direct access, so is intended to be run on 
 `,
 		Example:           `cscli machines [action]`,
 		DisableAutoGenTag: true,
+		Aliases:           []string{"machine"},
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if err := csConfig.LoadAPIServer(); err != nil || csConfig.DisableAPI {
 				if err != nil {

--- a/cmd/crowdsec-cli/metrics.go
+++ b/cmd/crowdsec-cli/metrics.go
@@ -394,6 +394,7 @@ func NewMetricsCmd() *cobra.Command {
 		Short:             "Display crowdsec prometheus metrics.",
 		Long:              `Fetch metrics from the prometheus server and display them in a human-friendly way`,
 		Args:              cobra.ExactArgs(0),
+		Aliases:           []string{"metric"},
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := csConfig.LoadPrometheus(); err != nil {

--- a/cmd/crowdsec-cli/metrics.go
+++ b/cmd/crowdsec-cli/metrics.go
@@ -394,7 +394,6 @@ func NewMetricsCmd() *cobra.Command {
 		Short:             "Display crowdsec prometheus metrics.",
 		Long:              `Fetch metrics from the prometheus server and display them in a human-friendly way`,
 		Args:              cobra.ExactArgs(0),
-		Aliases:           []string{"metric"},
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := csConfig.LoadPrometheus(); err != nil {

--- a/cmd/crowdsec-cli/parsers.go
+++ b/cmd/crowdsec-cli/parsers.go
@@ -58,16 +58,7 @@ cscli parsers remove crowdsecurity/sshd-logs
 		Args:              cobra.MinimumNArgs(1),
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			upstreamParsers := make([]string, 0)
-			hubItems := cwhub.GetHubStatusForItemType(cwhub.PARSERS, "", true)
-			for _, item := range hubItems {
-				upstreamParsers = append(upstreamParsers, item.Name)
-			}
-			cobra.CompDebugln(fmt.Sprintf("parsers: %+v", upstreamParsers), true)
-			return upstreamParsers, cobra.ShellCompDirectiveNoFileComp
+			return compAllItems(cwhub.PARSERS, args, toComplete)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, name := range args {
@@ -94,16 +85,7 @@ cscli parsers remove crowdsecurity/sshd-logs
 		Example:           `cscli parsers remove crowdsec/xxx crowdsec/xyz`,
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			installedParsers, err := cwhub.GetInstalledParsersAsString()
-			if err != nil {
-				cobra.CompDebugln(fmt.Sprintf("list installed parsers err: %s", err), true)
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			cobra.CompDebugln(fmt.Sprintf("parsers: %+v", installedParsers), true)
-			return installedParsers, cobra.ShellCompDirectiveNoFileComp
+			return compInstalledItems(cwhub.PARSERS, args, toComplete)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if all {
@@ -132,16 +114,7 @@ cscli parsers remove crowdsecurity/sshd-logs
 		Example:           `cscli parsers upgrade crowdsec/xxx crowdsec/xyz`,
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			installedParsers, err := cwhub.GetInstalledParsersAsString()
-			if err != nil {
-				cobra.CompDebugln(fmt.Sprintf("list installed parsers err: %s", err), true)
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			cobra.CompDebugln(fmt.Sprintf("parsers: %+v", installedParsers), true)
-			return installedParsers, cobra.ShellCompDirectiveNoFileComp
+			return compInstalledItems(cwhub.PARSERS, args, toComplete)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if all {
@@ -168,16 +141,7 @@ cscli parsers remove crowdsecurity/sshd-logs
 		DisableAutoGenTag: true,
 		Args:              cobra.MinimumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			installedParsers, err := cwhub.GetInstalledParsersAsString()
-			if err != nil {
-				cobra.CompDebugln(fmt.Sprintf("list installed parsers err: %s", err), true)
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			cobra.CompDebugln(fmt.Sprintf("parsers: %+v", installedParsers), true)
-			return installedParsers, cobra.ShellCompDirectiveNoFileComp
+			return compInstalledItems(cwhub.PARSERS, args, toComplete)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			InspectItem(args[0], cwhub.PARSERS)

--- a/cmd/crowdsec-cli/parsers.go
+++ b/cmd/crowdsec-cli/parsers.go
@@ -90,6 +90,7 @@ cscli parsers remove crowdsecurity/sshd-logs
 		Use:               "remove [config]",
 		Short:             "Remove given parser(s)",
 		Long:              `Remove given parse(s) from hub`,
+		Aliases:           []string{"delete"},
 		Example:           `cscli parsers remove crowdsec/xxx crowdsec/xyz`,
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/crowdsec-cli/parsers.go
+++ b/cmd/crowdsec-cli/parsers.go
@@ -21,6 +21,7 @@ cscli parsers list
 cscli parsers remove crowdsecurity/sshd-logs
 `,
 		Args:              cobra.MinimumNArgs(1),
+		Aliases:           []string{"parser"},
 		DisableAutoGenTag: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := csConfig.LoadHub(); err != nil {
@@ -56,6 +57,18 @@ cscli parsers remove crowdsecurity/sshd-logs
 		Example:           `cscli parsers install crowdsec/xxx crowdsec/xyz`,
 		Args:              cobra.MinimumNArgs(1),
 		DisableAutoGenTag: true,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if err := LoadHub(); err != nil {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			upstreamParsers := make([]string, 0)
+			hubItems := cwhub.GetHubStatusForItemType(cwhub.PARSERS, "", true)
+			for _, item := range hubItems {
+				upstreamParsers = append(upstreamParsers, item.Name)
+			}
+			cobra.CompDebugln(fmt.Sprintf("parsers: %+v", upstreamParsers), true)
+			return upstreamParsers, cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, name := range args {
 				if err := cwhub.InstallItem(csConfig, name, cwhub.PARSERS, forceAction, downloadOnly); err != nil {
@@ -79,6 +92,18 @@ cscli parsers remove crowdsecurity/sshd-logs
 		Long:              `Remove given parse(s) from hub`,
 		Example:           `cscli parsers remove crowdsec/xxx crowdsec/xyz`,
 		DisableAutoGenTag: true,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if err := LoadHub(); err != nil {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			installedParsers, err := cwhub.GetInstalledParsersAsString()
+			if err != nil {
+				cobra.CompDebugln(fmt.Sprintf("list installed parsers err: %s", err), true)
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			cobra.CompDebugln(fmt.Sprintf("parsers: %+v", installedParsers), true)
+			return installedParsers, cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if all {
 				cwhub.RemoveMany(csConfig, cwhub.PARSERS, "", all, purge, forceAction)
@@ -105,6 +130,18 @@ cscli parsers remove crowdsecurity/sshd-logs
 		Long:              `Fetch and upgrade given parser(s) from hub`,
 		Example:           `cscli parsers upgrade crowdsec/xxx crowdsec/xyz`,
 		DisableAutoGenTag: true,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if err := LoadHub(); err != nil {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			installedParsers, err := cwhub.GetInstalledParsersAsString()
+			if err != nil {
+				cobra.CompDebugln(fmt.Sprintf("list installed parsers err: %s", err), true)
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			cobra.CompDebugln(fmt.Sprintf("parsers: %+v", installedParsers), true)
+			return installedParsers, cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if all {
 				cwhub.UpgradeConfig(csConfig, cwhub.PARSERS, "", forceAction)
@@ -129,6 +166,18 @@ cscli parsers remove crowdsecurity/sshd-logs
 		Example:           `cscli parsers inspect crowdsec/xxx`,
 		DisableAutoGenTag: true,
 		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if err := LoadHub(); err != nil {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			installedParsers, err := cwhub.GetInstalledParsersAsString()
+			if err != nil {
+				cobra.CompDebugln(fmt.Sprintf("list installed parsers err: %s", err), true)
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			cobra.CompDebugln(fmt.Sprintf("parsers: %+v", installedParsers), true)
+			return installedParsers, cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			InspectItem(args[0], cwhub.PARSERS)
 		},

--- a/cmd/crowdsec-cli/postoverflows.go
+++ b/cmd/crowdsec-cli/postoverflows.go
@@ -91,6 +91,7 @@ func NewPostOverflowsCmd() *cobra.Command {
 		Long:              `remove given postoverflow(s)`,
 		Example:           `cscli postoverflows remove crowdsec/xxx crowdsec/xyz`,
 		DisableAutoGenTag: true,
+		Aliases:           []string{"delete"},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if err := LoadHub(); err != nil {
 				return nil, cobra.ShellCompDirectiveDefault

--- a/cmd/crowdsec-cli/postoverflows.go
+++ b/cmd/crowdsec-cli/postoverflows.go
@@ -57,16 +57,7 @@ func NewPostOverflowsCmd() *cobra.Command {
 		Args:              cobra.MinimumNArgs(1),
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			upstreamPostOverflow := make([]string, 0)
-			hubItems := cwhub.GetHubStatusForItemType(cwhub.PARSERS_OVFLW, "", true)
-			for _, item := range hubItems {
-				upstreamPostOverflow = append(upstreamPostOverflow, item.Name)
-			}
-			cobra.CompDebugln(fmt.Sprintf("postoverflows: %+v", upstreamPostOverflow), true)
-			return upstreamPostOverflow, cobra.ShellCompDirectiveNoFileComp
+			return compAllItems(cwhub.PARSERS_OVFLW, args, toComplete)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, name := range args {
@@ -93,16 +84,7 @@ func NewPostOverflowsCmd() *cobra.Command {
 		DisableAutoGenTag: true,
 		Aliases:           []string{"delete"},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			installedPostoverflow, err := cwhub.GetInstalledPostOverflowsAsString()
-			if err != nil {
-				cobra.CompDebugln(fmt.Sprintf("list installed postoverflow err: %s", err), true)
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			cobra.CompDebugln(fmt.Sprintf("postoverflow: %+v", installedPostoverflow), true)
-			return installedPostoverflow, cobra.ShellCompDirectiveNoFileComp
+			return compInstalledItems(cwhub.PARSERS_OVFLW, args, toComplete)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if all {
@@ -131,16 +113,7 @@ func NewPostOverflowsCmd() *cobra.Command {
 		Example:           `cscli postoverflows upgrade crowdsec/xxx crowdsec/xyz`,
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			installedPostoverflow, err := cwhub.GetInstalledPostOverflowsAsString()
-			if err != nil {
-				cobra.CompDebugln(fmt.Sprintf("list installed postoverflow err: %s", err), true)
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			cobra.CompDebugln(fmt.Sprintf("postoverflow: %+v", installedPostoverflow), true)
-			return installedPostoverflow, cobra.ShellCompDirectiveNoFileComp
+			return compInstalledItems(cwhub.PARSERS_OVFLW, args, toComplete)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if all {
@@ -166,16 +139,7 @@ func NewPostOverflowsCmd() *cobra.Command {
 		Example:           `cscli postoverflows inspect crowdsec/xxx crowdsec/xyz`,
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			installedPostoverflow, err := cwhub.GetInstalledPostOverflowsAsString()
-			if err != nil {
-				cobra.CompDebugln(fmt.Sprintf("list installed postoverflow err: %s", err), true)
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			cobra.CompDebugln(fmt.Sprintf("postoverflow: %+v", installedPostoverflow), true)
-			return installedPostoverflow, cobra.ShellCompDirectiveNoFileComp
+			return compInstalledItems(cwhub.PARSERS_OVFLW, args, toComplete)
 		},
 		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/crowdsec-cli/postoverflows.go
+++ b/cmd/crowdsec-cli/postoverflows.go
@@ -20,6 +20,7 @@ func NewPostOverflowsCmd() *cobra.Command {
 		cscli postoverflows list
 		cscli postoverflows remove crowdsecurity/cdn-whitelist`,
 		Args:              cobra.MinimumNArgs(1),
+		Aliases:           []string{"postoverflow"},
 		DisableAutoGenTag: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := csConfig.LoadHub(); err != nil {
@@ -55,6 +56,18 @@ func NewPostOverflowsCmd() *cobra.Command {
 		Example:           `cscli postoverflows install crowdsec/xxx crowdsec/xyz`,
 		Args:              cobra.MinimumNArgs(1),
 		DisableAutoGenTag: true,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if err := LoadHub(); err != nil {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			upstreamPostOverflow := make([]string, 0)
+			hubItems := cwhub.GetHubStatusForItemType(cwhub.PARSERS_OVFLW, "", true)
+			for _, item := range hubItems {
+				upstreamPostOverflow = append(upstreamPostOverflow, item.Name)
+			}
+			cobra.CompDebugln(fmt.Sprintf("postoverflows: %+v", upstreamPostOverflow), true)
+			return upstreamPostOverflow, cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, name := range args {
 				if err := cwhub.InstallItem(csConfig, name, cwhub.PARSERS_OVFLW, forceAction, downloadOnly); err != nil {
@@ -78,6 +91,18 @@ func NewPostOverflowsCmd() *cobra.Command {
 		Long:              `remove given postoverflow(s)`,
 		Example:           `cscli postoverflows remove crowdsec/xxx crowdsec/xyz`,
 		DisableAutoGenTag: true,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if err := LoadHub(); err != nil {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			installedPostoverflow, err := cwhub.GetInstalledPostOverflowsAsString()
+			if err != nil {
+				cobra.CompDebugln(fmt.Sprintf("list installed postoverflow err: %s", err), true)
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			cobra.CompDebugln(fmt.Sprintf("postoverflow: %+v", installedPostoverflow), true)
+			return installedPostoverflow, cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if all {
 				cwhub.RemoveMany(csConfig, cwhub.PARSERS_OVFLW, "", all, purge, forceAction)
@@ -104,6 +129,18 @@ func NewPostOverflowsCmd() *cobra.Command {
 		Long:              `Fetch and Upgrade given postoverflow(s) from hub`,
 		Example:           `cscli postoverflows upgrade crowdsec/xxx crowdsec/xyz`,
 		DisableAutoGenTag: true,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if err := LoadHub(); err != nil {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			installedPostoverflow, err := cwhub.GetInstalledPostOverflowsAsString()
+			if err != nil {
+				cobra.CompDebugln(fmt.Sprintf("list installed postoverflow err: %s", err), true)
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			cobra.CompDebugln(fmt.Sprintf("postoverflow: %+v", installedPostoverflow), true)
+			return installedPostoverflow, cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if all {
 				cwhub.UpgradeConfig(csConfig, cwhub.PARSERS_OVFLW, "", forceAction)
@@ -127,7 +164,19 @@ func NewPostOverflowsCmd() *cobra.Command {
 		Long:              `Inspect given postoverflow`,
 		Example:           `cscli postoverflows inspect crowdsec/xxx crowdsec/xyz`,
 		DisableAutoGenTag: true,
-		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if err := LoadHub(); err != nil {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			installedPostoverflow, err := cwhub.GetInstalledPostOverflowsAsString()
+			if err != nil {
+				cobra.CompDebugln(fmt.Sprintf("list installed postoverflow err: %s", err), true)
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			cobra.CompDebugln(fmt.Sprintf("postoverflow: %+v", installedPostoverflow), true)
+			return installedPostoverflow, cobra.ShellCompDirectiveNoFileComp
+		},
+		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			InspectItem(args[0], cwhub.PARSERS_OVFLW)
 		},

--- a/cmd/crowdsec-cli/scenarios.go
+++ b/cmd/crowdsec-cli/scenarios.go
@@ -93,6 +93,7 @@ cscli scenarios remove crowdsecurity/ssh-bf
 		Short:   "Remove given scenario(s)",
 		Long:    `remove given scenario(s)`,
 		Example: `cscli scenarios remove crowdsec/xxx crowdsec/xyz`,
+		Aliases: []string{"delete"},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if err := LoadHub(); err != nil {
 				return nil, cobra.ShellCompDirectiveDefault

--- a/cmd/crowdsec-cli/scenarios.go
+++ b/cmd/crowdsec-cli/scenarios.go
@@ -59,16 +59,7 @@ cscli scenarios remove crowdsecurity/ssh-bf
 		Example: `cscli scenarios install crowdsec/xxx crowdsec/xyz`,
 		Args:    cobra.MinimumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			upstreamScenario := make([]string, 0)
-			hubItems := cwhub.GetHubStatusForItemType(cwhub.SCENARIOS, "", true)
-			for _, item := range hubItems {
-				upstreamScenario = append(upstreamScenario, item.Name)
-			}
-			cobra.CompDebugln(fmt.Sprintf("scenarios: %+v", upstreamScenario), true)
-			return upstreamScenario, cobra.ShellCompDirectiveNoFileComp
+			return compAllItems(cwhub.SCENARIOS, args, toComplete)
 		},
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -95,16 +86,7 @@ cscli scenarios remove crowdsecurity/ssh-bf
 		Example: `cscli scenarios remove crowdsec/xxx crowdsec/xyz`,
 		Aliases: []string{"delete"},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			installedScenario, err := cwhub.GetInstalledScenariosAsString()
-			if err != nil {
-				cobra.CompDebugln(fmt.Sprintf("list installed scenarios err: %s", err), true)
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			cobra.CompDebugln(fmt.Sprintf("scenarios: %+v", installedScenario), true)
-			return installedScenario, cobra.ShellCompDirectiveNoFileComp
+			return compInstalledItems(cwhub.SCENARIOS, args, toComplete)
 		},
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -133,16 +115,7 @@ cscli scenarios remove crowdsecurity/ssh-bf
 		Long:    `Fetch and Upgrade given scenario(s) from hub`,
 		Example: `cscli scenarios upgrade crowdsec/xxx crowdsec/xyz`,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			installedScenario, err := cwhub.GetInstalledScenariosAsString()
-			if err != nil {
-				cobra.CompDebugln(fmt.Sprintf("list installed scenarios err: %s", err), true)
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			cobra.CompDebugln(fmt.Sprintf("scenarios: %+v", installedScenario), true)
-			return installedScenario, cobra.ShellCompDirectiveNoFileComp
+			return compInstalledItems(cwhub.SCENARIOS, args, toComplete)
 		},
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -169,16 +142,7 @@ cscli scenarios remove crowdsecurity/ssh-bf
 		Example: `cscli scenarios inspect crowdsec/xxx`,
 		Args:    cobra.MinimumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if err := LoadHub(); err != nil {
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			installedScenario, err := cwhub.GetInstalledScenariosAsString()
-			if err != nil {
-				cobra.CompDebugln(fmt.Sprintf("list installed scenarios err: %s", err), true)
-				return nil, cobra.ShellCompDirectiveDefault
-			}
-			cobra.CompDebugln(fmt.Sprintf("scenarios: %+v", installedScenario), true)
-			return installedScenario, cobra.ShellCompDirectiveNoFileComp
+			return compInstalledItems(cwhub.SCENARIOS, args, toComplete)
 		},
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -74,10 +74,19 @@ func compAllItems(itemType string, args []string, toComplete string) ([]string, 
 	if err := LoadHub(); err != nil {
 		return nil, cobra.ShellCompDirectiveDefault
 	}
+
+	cobra.CompDebugln(fmt.Sprintf("args: %+v | toComplete: %s", args, toComplete), true)
+
 	comp := make([]string, 0)
 	hubItems := cwhub.GetHubStatusForItemType(itemType, "", true)
 	for _, item := range hubItems {
-		comp = append(comp, item.Name)
+		if toComplete == "" {
+			comp = append(comp, item.Name)
+		} else {
+			if strings.Contains(item.Name, toComplete) {
+				comp = append(comp, item.Name)
+			}
+		}
 	}
 	cobra.CompDebugln(fmt.Sprintf("%s: %+v", itemType, comp), true)
 	return comp, cobra.ShellCompDirectiveNoFileComp
@@ -88,17 +97,17 @@ func compInstalledItems(itemType string, args []string, toComplete string) ([]st
 		return nil, cobra.ShellCompDirectiveDefault
 	}
 
-	var comp []string
+	var items []string
 	var err error
 	switch itemType {
 	case cwhub.PARSERS:
-		comp, err = cwhub.GetInstalledParsersAsString()
+		items, err = cwhub.GetInstalledParsersAsString()
 	case cwhub.SCENARIOS:
-		comp, err = cwhub.GetInstalledScenariosAsString()
+		items, err = cwhub.GetInstalledScenariosAsString()
 	case cwhub.PARSERS_OVFLW:
-		comp, err = cwhub.GetInstalledPostOverflowsAsString()
+		items, err = cwhub.GetInstalledPostOverflowsAsString()
 	case cwhub.COLLECTIONS:
-		comp, err = cwhub.GetInstalledCollectionsAsString()
+		items, err = cwhub.GetInstalledCollectionsAsString()
 	default:
 		return nil, cobra.ShellCompDirectiveDefault
 	}
@@ -106,6 +115,17 @@ func compInstalledItems(itemType string, args []string, toComplete string) ([]st
 	if err != nil {
 		cobra.CompDebugln(fmt.Sprintf("list installed %s err: %s", itemType, err), true)
 		return nil, cobra.ShellCompDirectiveDefault
+	}
+	comp := make([]string, 0)
+
+	if toComplete != "" {
+		for _, item := range items {
+			if strings.Contains(item, toComplete) {
+				comp = append(comp, item)
+			}
+		}
+	} else {
+		comp = items
 	}
 
 	cobra.CompDebugln(fmt.Sprintf("%s: %+v", itemType, comp), true)

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -51,6 +51,25 @@ func indexOf(s string, slice []string) int {
 	return -1
 }
 
+func LoadHub() error {
+	if err := csConfig.LoadHub(); err != nil {
+		log.Fatalf(err.Error())
+	}
+	if csConfig.Hub == nil {
+		return fmt.Errorf("unable to load hub")
+	}
+
+	if err := setHubBranch(); err != nil {
+		log.Warningf("unable to set hub branch (%s), default to master")
+	}
+
+	if err := cwhub.GetHubIdx(csConfig.Hub); err != nil {
+		return fmt.Errorf("Failed to get Hub index : '%v'. Run 'sudo cscli hub update' to get the hub index", err)
+	}
+
+	return nil
+}
+
 func ListItems(itemTypes []string, args []string, showType bool, showHeader bool, all bool) {
 
 	var hubStatusByItemType = make(map[string][]cwhub.ItemHubStatus)

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -75,8 +75,6 @@ func compAllItems(itemType string, args []string, toComplete string) ([]string, 
 		return nil, cobra.ShellCompDirectiveDefault
 	}
 
-	cobra.CompDebugln(fmt.Sprintf("args: %+v | toComplete: %s", args, toComplete), true)
-
 	comp := make([]string, 0)
 	hubItems := cwhub.GetHubStatusForItemType(itemType, "", true)
 	for _, item := range hubItems {

--- a/pkg/cwhub/cwhub.go
+++ b/pkg/cwhub/cwhub.go
@@ -263,6 +263,87 @@ func GetInstalledScenarios() ([]Item, error) {
 	return retItems, nil
 }
 
+func GetInstalledParsers() ([]Item, error) {
+	var retItems []Item
+
+	if _, ok := hubIdx[PARSERS]; !ok {
+		return nil, fmt.Errorf("no parsers in hubIdx")
+	}
+	for _, item := range hubIdx[PARSERS] {
+		if item.Installed {
+			retItems = append(retItems, item)
+		}
+	}
+	return retItems, nil
+}
+
+func GetInstalledParsersAsString() ([]string, error) {
+	var retStr []string
+
+	items, err := GetInstalledParsers()
+	if err != nil {
+		return nil, errors.Wrap(err, "while fetching parsers")
+	}
+	for _, it := range items {
+		retStr = append(retStr, it.Name)
+	}
+	return retStr, nil
+}
+
+func GetInstalledPostOverflows() ([]Item, error) {
+	var retItems []Item
+
+	if _, ok := hubIdx[PARSERS_OVFLW]; !ok {
+		return nil, fmt.Errorf("no post overflows in hubIdx")
+	}
+	for _, item := range hubIdx[PARSERS_OVFLW] {
+		if item.Installed {
+			retItems = append(retItems, item)
+		}
+	}
+	return retItems, nil
+}
+
+func GetInstalledPostOverflowsAsString() ([]string, error) {
+	var retStr []string
+
+	items, err := GetInstalledPostOverflows()
+	if err != nil {
+		return nil, errors.Wrap(err, "while fetching post overflows")
+	}
+	for _, it := range items {
+		retStr = append(retStr, it.Name)
+	}
+	return retStr, nil
+}
+
+func GetInstalledCollectionsAsString() ([]string, error) {
+	var retStr []string
+
+	items, err := GetInstalledCollections()
+	if err != nil {
+		return nil, errors.Wrap(err, "while fetching collections")
+	}
+	for _, it := range items {
+		retStr = append(retStr, it.Name)
+	}
+	return retStr, nil
+}
+
+func GetInstalledCollections() ([]Item, error) {
+	var retItems []Item
+
+	if _, ok := hubIdx[COLLECTIONS]; !ok {
+		return nil, fmt.Errorf("no collection in hubIdx")
+	}
+	for _, item := range hubIdx[COLLECTIONS] {
+		if item.Installed {
+			retItems = append(retItems, item)
+		}
+	}
+	return retItems, nil
+}
+
 //Returns a list of entries for packages : name, status, local_path, local_version, utf8_status (fancy)
 func GetHubStatusForItemType(itemType string, name string, all bool) []ItemHubStatus {
 	if _, ok := hubIdx[itemType]; !ok {


### PR DESCRIPTION
- Add autocompletien for hub items:
Example:
```
sudo cscli collections install nex [tab][tab]
``` 
will automatically complete as follow: `sudo cscli collections install crowdsecurity/nextcloud`

- Add aliases for all plurial commands (ie. machines/machine, scenarios/scenario etc ..)
- Add aliases for `delete`/`remove` commands (ie. `cscli machines delete` / `cscli machines remove` now works)