### PR TITLE
Improve distinct/uniq behaviour

### DIFF
--- a/pkg/leakybucket/tests/simple-leaky-uniq-cachesize/bucket.yaml
+++ b/pkg/leakybucket/tests/simple-leaky-uniq-cachesize/bucket.yaml
@@ -1,0 +1,14 @@
+# ssh bruteforce
+type: leaky
+debug: true
+name: test/simple-leaky
+description: "Simple leaky"
+filter: "evt.Line.Labels.type =='testlog'"
+leakspeed: "10s"
+capacity: 5
+cache_size: 2
+distinct: evt.Meta.uniq_key
+groupby: evt.Meta.source_ip
+labels:
+ type: overflow_1
+

--- a/pkg/leakybucket/tests/simple-leaky-uniq-cachesize/bucket.yaml
+++ b/pkg/leakybucket/tests/simple-leaky-uniq-cachesize/bucket.yaml
@@ -4,9 +4,9 @@ debug: true
 name: test/simple-leaky
 description: "Simple leaky"
 filter: "evt.Line.Labels.type =='testlog'"
-leakspeed: "10s"
-capacity: 5
-cache_size: 2
+leakspeed: "20s"
+capacity: 3
+cache_size: 1
 distinct: evt.Meta.uniq_key
 groupby: evt.Meta.source_ip
 labels:

--- a/pkg/leakybucket/tests/simple-leaky-uniq-cachesize/scenarios.yaml
+++ b/pkg/leakybucket/tests/simple-leaky-uniq-cachesize/scenarios.yaml
@@ -1,0 +1,2 @@
+ - filename: {{.TestDirectory}}/bucket.yaml
+

--- a/pkg/leakybucket/tests/simple-leaky-uniq-cachesize/test.json
+++ b/pkg/leakybucket/tests/simple-leaky-uniq-cachesize/test.json
@@ -1,0 +1,128 @@
+{
+  "lines": [
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE1 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:00+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.4",
+        "uniq_key": "aaa"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:01+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.4",
+        "uniq_key": "aaa"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:02+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.4",
+        "uniq_key": "aab"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:02+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.4",
+        "uniq_key": "aab"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:02+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.4",
+        "uniq_key": "aac"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:02+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.4",
+        "uniq_key": "aad"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:02+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.4",
+        "uniq_key": "aae"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:02+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.4",
+        "uniq_key": "aaf"
+      }
+    }
+  ],
+  "results": [
+    {
+      "Alert": {
+        "sources": {
+          "1.2.3.4": {
+              "scope": "Ip",
+              "value": "1.2.3.4",
+            
+            "ip": "1.2.3.4"
+          }
+        },
+        "Alert" : {
+        "scenario": "test/simple-leaky",
+        "events_count": 6
+        }
+       
+      }
+    }
+  ]
+}
+

--- a/pkg/leakybucket/tests/simple-leaky-uniq-cachesize/test.json
+++ b/pkg/leakybucket/tests/simple-leaky-uniq-cachesize/test.json
@@ -23,19 +23,6 @@
       "MarshaledTime": "2020-01-01T10:00:01+00:00",
       "Meta": {
         "source_ip": "1.2.3.4",
-        "uniq_key": "aaa"
-      }
-    },
-    {
-      "Line": {
-        "Labels": {
-          "type": "testlog"
-        },
-        "Raw": "xxheader VALUE2 trailing stuff"
-      },
-      "MarshaledTime": "2020-01-01T10:00:02+00:00",
-      "Meta": {
-        "source_ip": "1.2.3.4",
         "uniq_key": "aab"
       }
     },
@@ -46,20 +33,7 @@
         },
         "Raw": "xxheader VALUE2 trailing stuff"
       },
-      "MarshaledTime": "2020-01-01T10:00:02+00:00",
-      "Meta": {
-        "source_ip": "1.2.3.4",
-        "uniq_key": "aab"
-      }
-    },
-    {
-      "Line": {
-        "Labels": {
-          "type": "testlog"
-        },
-        "Raw": "xxheader VALUE2 trailing stuff"
-      },
-      "MarshaledTime": "2020-01-01T10:00:02+00:00",
+      "MarshaledTime": "2020-01-01T10:00:01+00:00",
       "Meta": {
         "source_ip": "1.2.3.4",
         "uniq_key": "aac"
@@ -75,33 +49,125 @@
       "MarshaledTime": "2020-01-01T10:00:02+00:00",
       "Meta": {
         "source_ip": "1.2.3.4",
+        "uniq_key": "aaa"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:02+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.4",
+        "uniq_key": "aaa"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:03+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.4",
+        "uniq_key": "aab"
+      }
+    },
+
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:03+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.5",
+        "uniq_key": "aaa"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:04+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.5",
+        "uniq_key": "aab"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:04+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.5",
+        "uniq_key": "aac"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:05+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.5",
+        "uniq_key": "aaa"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:05+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.5",
+        "uniq_key": "aab"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:06+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.5",
+        "uniq_key": "aac"
+      }
+    },
+    {
+      "Line": {
+        "Labels": {
+          "type": "testlog"
+        },
+        "Raw": "xxheader VALUE2 trailing stuff"
+      },
+      "MarshaledTime": "2020-01-01T10:00:06+00:00",
+      "Meta": {
+        "source_ip": "1.2.3.5",
         "uniq_key": "aad"
-      }
-    },
-    {
-      "Line": {
-        "Labels": {
-          "type": "testlog"
-        },
-        "Raw": "xxheader VALUE2 trailing stuff"
-      },
-      "MarshaledTime": "2020-01-01T10:00:02+00:00",
-      "Meta": {
-        "source_ip": "1.2.3.4",
-        "uniq_key": "aae"
-      }
-    },
-    {
-      "Line": {
-        "Labels": {
-          "type": "testlog"
-        },
-        "Raw": "xxheader VALUE2 trailing stuff"
-      },
-      "MarshaledTime": "2020-01-01T10:00:02+00:00",
-      "Meta": {
-        "source_ip": "1.2.3.4",
-        "uniq_key": "aaf"
       }
     }
   ],
@@ -109,16 +175,16 @@
     {
       "Alert": {
         "sources": {
-          "1.2.3.4": {
+          "1.2.3.5": {
               "scope": "Ip",
-              "value": "1.2.3.4",
+              "value": "1.2.3.5",
             
-            "ip": "1.2.3.4"
+            "ip": "1.2.3.5"
           }
         },
         "Alert" : {
         "scenario": "test/simple-leaky",
-        "events_count": 6
+        "events_count": 4
         }
        
       }


### PR DESCRIPTION
In the existing implementation, `distinct` effectiveness is directly related to the `cache_size` parameter. The `distinct` parses in "live" the queue of objects to determine the uniqueness. For a scenario such as `crawl-http-non-statics`, this can have a "huge" impact in terms of potential false-positives. This PR adds its own cache to the `distinct` filters, so that it's not impacted by the cache_size.

