### PR TITLE
[fix issue 1484] Allow to send email without auth again

### DIFF
--- a/plugins/notifications/email/email.yaml
+++ b/plugins/notifications/email/email.yaml
@@ -25,10 +25,10 @@ format: |
 smtp_host:            # example: smtp.gmail.com
 smtp_username:        # Replace with your actual username
 smtp_password:        # Replace with your actual password
-smtp_port:            # Common values are any of [25, 465, 587, 2525]
+#smtp_port: 25        # Common value for port is one of [25, 465, 587, 2525]
 auth_type:            # Valid choices are "none", "crammd5", "login", "plain"
 sender_name: "CrowdSec"
-sender_email:         # example: foo@gmail.com
+#sender_email: "crowdsec@©rowdsec.local"
 email_subject: "CrowdSec Notification"
 receiver_emails:
 # - email1@gmail.com

--- a/plugins/notifications/email/email.yaml
+++ b/plugins/notifications/email/email.yaml
@@ -25,10 +25,10 @@ format: |
 smtp_host:            # example: smtp.gmail.com
 smtp_username:        # Replace with your actual username
 smtp_password:        # Replace with your actual password
-#smtp_port: 25        # Common value for port is one of [25, 465, 587, 2525]
+smtp_port:            # Common values are any of [25, 465, 587, 2525]
 auth_type:            # Valid choices are "none", "crammd5", "login", "plain"
 sender_name: "CrowdSec"
-#sender_email: "crowdsec@©rowdsec.local"
+sender_email:         # example: foo@gmail.com
 email_subject: "CrowdSec Notification"
 receiver_emails:
 # - email1@gmail.com

--- a/plugins/notifications/email/main.go
+++ b/plugins/notifications/email/main.go
@@ -53,11 +53,12 @@ type EmailPlugin struct {
 
 func (n *EmailPlugin) Configure(ctx context.Context, config *protobufs.Config) (*protobufs.Empty, error) {
 	d := PluginConfig{
-		SMTPPort:       587,
+		SMTPPort:       25,
 		SenderName:     "Crowdsec",
 		EmailSubject:   "Crowdsec notification",
 		EncryptionType: "ssltls",
 		AuthType:       "login",
+		SenderEmail:    "crowdsec@crowdsec.local",
 	}
 
 	if err := yaml.Unmarshal(config.Config, &d); err != nil {
@@ -70,10 +71,6 @@ func (n *EmailPlugin) Configure(ctx context.Context, config *protobufs.Config) (
 
 	if d.SMTPHost == "" {
 		return nil, fmt.Errorf("SMTP host is not set")
-	}
-
-	if d.SenderEmail == "" {
-		return nil, fmt.Errorf("Sender email is not set")
 	}
 
 	if d.ReceiverEmails == nil || len(d.ReceiverEmails) == 0 {

--- a/plugins/notifications/email/main.go
+++ b/plugins/notifications/email/main.go
@@ -72,14 +72,6 @@ func (n *EmailPlugin) Configure(ctx context.Context, config *protobufs.Config) (
 		return nil, fmt.Errorf("SMTP host is not set")
 	}
 
-	if d.SMTPUsername == "" {
-		return nil, fmt.Errorf("SMTP username is not set")
-	}
-
-	if d.SMTPPassword == "" {
-		return nil, fmt.Errorf("SMTP password is not set")
-	}
-
 	if d.SenderEmail == "" {
 		return nil, fmt.Errorf("Sender email is not set")
 	}


### PR DESCRIPTION
We can now send email without auth