### PR TITLE
Allow to override statics in hubtest.

### DIFF
--- a/cmd/crowdsec-cli/explain.go
+++ b/cmd/crowdsec-cli/explain.go
@@ -41,6 +41,7 @@ cscli explain --dsn "file://myfile.log" --type nginx
 				fmt.Printf("Please provide --type flag\n")
 				os.Exit(1)
 			}
+			var f *os.File
 
 			// we create a temporary log file if a log line has been provided
 			if logLine != "" {
@@ -83,6 +84,7 @@ cscli explain --dsn "file://myfile.log" --type nginx
 
 			// rm the temporary log file if only a log line was provided
 			if logLine != "" {
+				f.Close()
 				if err := os.Remove(logFile); err != nil {
 					log.Fatalf("unable to remove tmp log file '%s': %+v", logFile, err)
 				}

--- a/pkg/cstest/hubtest_item.go
+++ b/pkg/cstest/hubtest_item.go
@@ -10,18 +10,21 @@ import (
 
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
+	"github.com/crowdsecurity/crowdsec/pkg/parser"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
 type HubTestItemConfig struct {
-	Parsers       []string          `yaml:"parsers"`
-	Scenarios     []string          `yaml:"scenarios"`
-	PostOVerflows []string          `yaml:"postoverflows"`
-	LogFile       string            `yaml:"log_file"`
-	LogType       string            `yaml:"log_type"`
-	Labels        map[string]string `yaml:"labels"`
-	IgnoreParsers bool              `yaml:"ignore_parsers"` // if we test a scenario, we don't want to assert on Parser
+	Parsers         []string           `yaml:"parsers"`
+	Scenarios       []string           `yaml:"scenarios"`
+	PostOVerflows   []string           `yaml:"postoverflows"`
+	LogFile         string             `yaml:"log_file"`
+	LogType         string             `yaml:"log_type"`
+	Labels          map[string]string  `yaml:"labels"`
+	IgnoreParsers   bool               `yaml:"ignore_parsers"`   // if we test a scenario, we don't want to assert on Parser
+	OverrideStatics []types.ExtraField `yaml:"override_statics"` //Allow to override statics. Executed before s00
 }
 
 type HubIndex struct {
@@ -374,6 +377,22 @@ func (t *HubTestItem) InstallHub() error {
 			if !customPostoverflowExist {
 				return fmt.Errorf("couldn't find custom postoverflow '%s' in the following location: %+v", postoverflow, t.CustomItemsLocation)
 			}
+		}
+	}
+
+	if len(t.Config.OverrideStatics) > 0 {
+		n := parser.Node{
+			Name:    "overrides",
+			Filter:  "1==1",
+			Statics: t.Config.OverrideStatics,
+		}
+		b, err := yaml.Marshal(n)
+		if err != nil {
+			return fmt.Errorf("unable to marshal overrides: %s", err)
+		}
+		tgtFilename := fmt.Sprintf("%s/parsers/s00-raw/00_overrides.yaml", t.RuntimePath)
+		if err := os.WriteFile(tgtFilename, b, os.ModePerm); err != nil {
+			return fmt.Errorf("unable to write overrides to '%s': %s", tgtFilename, err)
 		}
 	}
 


### PR DESCRIPTION
In order to test most of the windows scenarios, we need to be able to override `evt.Line.Module`.

This PR add support for a `override_statics` parameter in hub test.

If set, it will create a fake parser in the s00 stage that will be run first, and will contain a `statics` key with all the override defined by the user.