### PR TITLE
Memory check for cscli dashboard setup

### DIFF
--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -112,16 +112,20 @@ cscli dashboard setup -l 0.0.0.0 -p 443 --password <password>
 				}
 			}
 			var answer bool
-			if valid, err := checkSystemMemory(); err == nil && !valid && !forceYes {
-				prompt := &survey.Confirm{
-					Message: "Metabase requires 1-2GB of RAM, your system is below this requirement continue ?",
-					Default: true,
-				}
-				if err := survey.AskOne(prompt, &answer); err != nil {
-					log.Fatalf("unable to ask about RAM check: %s", err)
-				}
-				if !answer {
-					log.Fatal("Unable to continue due to RAM requirement")
+			if valid, err := checkSystemMemory(); err == nil && !valid {
+				if !forceYes {
+					prompt := &survey.Confirm{
+						Message: "Metabase requires 1-2GB of RAM, your system is below this requirement continue ?",
+						Default: true,
+					}
+					if err := survey.AskOne(prompt, &answer); err != nil {
+						log.Fatalf("unable to ask about RAM check: %s", err)
+					}
+					if !answer {
+						log.Fatal("Unable to continue due to RAM requirement")
+					}
+				} else {
+					log.Warnf("Metabase requires 1-2GB of RAM, your system is below this requirement, however, force yes was provided")
 				}
 			}
 			groupExist := false

--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -112,17 +112,17 @@ cscli dashboard setup -l 0.0.0.0 -p 443 --password <password>
 				}
 			}
 			var answer bool
-			if valid, err := checkSystemMemory(); err == nil && !valid {
+			if valid, err := checkSystemMemory(); err == nil && !valid && !forceYes {
 				prompt := &survey.Confirm{
-					Message: fmt.Sprintf("Metabase requires 1-2GB of RAM, your system is below this requirement continue ?"),
+					Message: "Metabase requires 1-2GB of RAM, your system is below this requirement continue ?",
 					Default: true,
 				}
 				if err := survey.AskOne(prompt, &answer); err != nil {
 					log.Fatalf("unable to ask about RAM check: %s", err)
 				}
-			}
-			if !answer && !forceYes {
-				log.Fatal("Unable to continue due to RAM requirement")
+				if !answer {
+					log.Fatal("Unable to continue due to RAM requirement")
+				}
 			}
 			groupExist := false
 			dockerGroup, err := user.LookupGroup(crowdsecGroup)

--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"os/user"
@@ -13,6 +14,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/crowdsecurity/crowdsec/pkg/metabase"
 
+	"github.com/pbnjay/memory"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -31,6 +33,8 @@ var (
 	crowdsecGroup         = "crowdsec"
 
 	forceYes bool
+
+	recMem = uint64(math.Pow(2, 30))
 
 	/*informations needed to setup a random password on user's behalf*/
 )
@@ -80,6 +84,9 @@ cscli dashboard remove
 				if metabase.IsContainerExist(oldContainerID) {
 					metabaseContainerID = oldContainerID
 				}
+			}
+			if recMem >= memory.TotalMemory() {
+				log.Warnf("Metabase container requires 1-2gb of RAM, your system is below this requirement")
 			}
 		},
 	}

--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -125,7 +125,7 @@ cscli dashboard setup -l 0.0.0.0 -p 443 --password <password>
 						log.Fatal("Unable to continue due to RAM requirement")
 					}
 				} else {
-					log.Warnf("Metabase requires 1-2GB of RAM, your system is below this requirement, however, force yes was provided")
+					log.Warnf("Metabase requires 1-2GB of RAM, your system is below this requirement, however, force yes flag was provided")
 				}
 			}
 			groupExist := false

--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -119,7 +119,7 @@ cscli dashboard setup -l 0.0.0.0 -p 443 --password <password>
 						Default: true,
 					}
 					if err := survey.AskOne(prompt, &answer); err != nil {
-						log.Fatalf("unable to ask about RAM check: %s", err)
+						log.Warnf("unable to ask about RAM check: %s", err)
 					}
 					if !answer {
 						log.Fatal("Unable to continue due to RAM requirement")

--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -125,7 +125,7 @@ cscli dashboard setup -l 0.0.0.0 -p 443 --password <password>
 						log.Fatal("Unable to continue due to RAM requirement")
 					}
 				} else {
-					log.Warnf("Metabase requires 1-2GB of RAM, your system is below this requirement, however, force yes flag was provided")
+					log.Warnf("Metabase requires 1-2GB of RAM, your system is below this requirement")
 				}
 			}
 			groupExist := false

--- a/go.mod
+++ b/go.mod
@@ -138,6 +138,7 @@ require (
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2-0.20211117181255-693428a734f5 // indirect
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.30.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -612,6 +612,8 @@ github.com/oschwald/geoip2-golang v1.4.0/go.mod h1:8QwxJvRImBH+Zl6Aa6MaIcs5YdlZS
 github.com/oschwald/maxminddb-golang v1.6.0/go.mod h1:DUJFucBg2cvqx42YmDa/+xHvb0elJtOm3o4aFQ/nb/w=
 github.com/oschwald/maxminddb-golang v1.8.0 h1:Uh/DSnGoxsyp/KYbY1AuP0tYEwfs0sCph9p/UMXK/Hk=
 github.com/oschwald/maxminddb-golang v1.8.0/go.mod h1:RXZtst0N6+FY/3qCNmZMBApR19cdQj43/NM9VkrNAis=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=


### PR DESCRIPTION
If total memory < 1GB and force-yes is not provided the user can answer Y/n to continue running the Metabase container if the force-yes flag is provided it will just warn the user that Metabase container requires 1-2GB

Please note the current calculation of memory is set to 1GB as per issue, however, in crowdsec documentation it states 1-2GB

EDIT: The free system memory function was acting a bit strange on my VM it listed only 57MB free instead of 570MB so for the first implementation I thought total memory can be an improvement.

I have done some more testing and the free memory is correct for my VM after system allocation. I can update this PR with the check for free system memory check as well, however, I will wait for feedback.

#826