### PR TITLE
GetExprEnv usage optimization

### DIFF
--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -268,6 +269,8 @@ func main() {
 	)
 
 	defer types.CatchPanic("crowdsec/main")
+
+	runtime.SetBlockProfileRate(1)
 
 	log.Debugf("os.Args: %v", os.Args)
 

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime"
 	"sort"
 	"strings"
 
@@ -269,8 +268,6 @@ func main() {
 	)
 
 	defer types.CatchPanic("crowdsec/main")
-
-	runtime.SetBlockProfileRate(1)
 
 	log.Debugf("os.Args: %v", os.Args)
 

--- a/pkg/parser/node.go
+++ b/pkg/parser/node.go
@@ -111,10 +111,12 @@ func (n *Node) process(p *types.Event, ctx UnixParserCtx) (bool, error) {
 	var NodeHasOKGrok bool
 	clog := n.Logger
 
+	cachedExprEnv := exprhelpers.GetExprEnv(map[string]interface{}{"evt": p})
+
 	clog.Tracef("Event entering node")
 	if n.RunTimeFilter != nil {
 		//Evaluate node's filter
-		output, err := expr.Run(n.RunTimeFilter, exprhelpers.GetExprEnv(map[string]interface{}{"evt": p}))
+		output, err := expr.Run(n.RunTimeFilter, cachedExprEnv)
 		if err != nil {
 			clog.Warningf("failed to run filter : %v", err)
 			clog.Debugf("Event leaving node : ko")
@@ -124,7 +126,7 @@ func (n *Node) process(p *types.Event, ctx UnixParserCtx) (bool, error) {
 		switch out := output.(type) {
 		case bool:
 			if n.Debug {
-				n.ExprDebugger.Run(clog, out, exprhelpers.GetExprEnv(map[string]interface{}{"evt": p}))
+				n.ExprDebugger.Run(clog, out, cachedExprEnv)
 			}
 			if !out {
 				clog.Debugf("Event leaving node : ko (failed filter)")
@@ -188,7 +190,7 @@ func (n *Node) process(p *types.Event, ctx UnixParserCtx) (bool, error) {
 	}
 	/* run whitelist expression tests anyway */
 	for eidx, e := range n.Whitelist.B_Exprs {
-		output, err := expr.Run(e.Filter, exprhelpers.GetExprEnv(map[string]interface{}{"evt": p}))
+		output, err := expr.Run(e.Filter, cachedExprEnv)
 		if err != nil {
 			clog.Warningf("failed to run whitelist expr : %v", err)
 			clog.Debugf("Event leaving node : ko")
@@ -197,7 +199,7 @@ func (n *Node) process(p *types.Event, ctx UnixParserCtx) (bool, error) {
 		switch out := output.(type) {
 		case bool:
 			if n.Debug {
-				e.ExprDebugger.Run(clog, out, exprhelpers.GetExprEnv(map[string]interface{}{"evt": p}))
+				e.ExprDebugger.Run(clog, out, cachedExprEnv)
 			}
 			if out {
 				clog.Debugf("Event is whitelisted by expr, reason [%s]", n.Whitelist.Reason)
@@ -238,7 +240,7 @@ func (n *Node) process(p *types.Event, ctx UnixParserCtx) (bool, error) {
 				NodeState = false
 			}
 		} else if n.Grok.RunTimeValue != nil {
-			output, err := expr.Run(n.Grok.RunTimeValue, exprhelpers.GetExprEnv(map[string]interface{}{"evt": p}))
+			output, err := expr.Run(n.Grok.RunTimeValue, cachedExprEnv)
 			if err != nil {
 				clog.Warningf("failed to run RunTimeValue : %v", err)
 				NodeState = false

--- a/pkg/parser/node.go
+++ b/pkg/parser/node.go
@@ -106,12 +106,12 @@ func (n *Node) validate(pctx *UnixParserCtx, ectx EnricherCtx) error {
 	return nil
 }
 
-func (n *Node) process(p *types.Event, ctx UnixParserCtx) (bool, error) {
+func (n *Node) process(p *types.Event, ctx UnixParserCtx, expressionEnv map[string]interface{}) (bool, error) {
 	var NodeState bool
 	var NodeHasOKGrok bool
 	clog := n.Logger
 
-	cachedExprEnv := exprhelpers.GetExprEnv(map[string]interface{}{"evt": p})
+	cachedExprEnv := expressionEnv
 
 	clog.Tracef("Event entering node")
 	if n.RunTimeFilter != nil {
@@ -287,7 +287,7 @@ func (n *Node) process(p *types.Event, ctx UnixParserCtx) (bool, error) {
 	//Iterate on leafs
 	if len(n.LeavesNodes) > 0 {
 		for _, leaf := range n.LeavesNodes {
-			ret, err := leaf.process(p, ctx)
+			ret, err := leaf.process(p, ctx, cachedExprEnv)
 			if err != nil {
 				clog.Tracef("\tNode (%s) failed : %v", leaf.rn, err)
 				clog.Debugf("Event leaving node : ko")

--- a/pkg/parser/runtime.go
+++ b/pkg/parser/runtime.go
@@ -257,6 +257,8 @@ func Parse(ctx UnixParserCtx, xp types.Event, nodes []Node) (types.Event, error)
 		log.Tracef("INPUT '%s'", event.Line.Raw)
 	}
 
+	cachedExprEnv := exprhelpers.GetExprEnv(map[string]interface{}{"evt": &event})
+
 	if ParseDump {
 		if StageParseCache == nil {
 			StageParseCache = make(map[string]map[string][]ParserResult)
@@ -300,7 +302,7 @@ func Parse(ctx UnixParserCtx, xp types.Event, nodes []Node) (types.Event, error)
 			if ctx.Profiling {
 				node.Profiling = true
 			}
-			ret, err := node.process(&event, ctx)
+			ret, err := node.process(&event, ctx, cachedExprEnv)
 			if err != nil {
 				clog.Fatalf("Error while processing node : %v", err)
 			}

--- a/pkg/parser/runtime.go
+++ b/pkg/parser/runtime.go
@@ -111,12 +111,14 @@ func (n *Node) ProcessStatics(statics []types.ExtraField, event *types.Event) er
 	var value string
 	clog := n.Logger
 
+	cachedExprEnv := exprhelpers.GetExprEnv(map[string]interface{}{"evt": event})
+
 	for _, static := range statics {
 		value = ""
 		if static.Value != "" {
 			value = static.Value
 		} else if static.RunTimeValue != nil {
-			output, err := expr.Run(static.RunTimeValue, exprhelpers.GetExprEnv(map[string]interface{}{"evt": event}))
+			output, err := expr.Run(static.RunTimeValue, cachedExprEnv)
 			if err != nil {
 				clog.Warningf("failed to run RunTimeValue : %v", err)
 				continue


### PR DESCRIPTION
`GetExprEnv` is provided to `expr` evaluation very often. Try to cache it to improve performance