### PR TITLE
Add ispconfig to apache2

### DIFF
--- a/wizard.sh
+++ b/wizard.sh
@@ -166,7 +166,7 @@ log_input_tags[smb]='type: smb'
 log_input_tags[linux]="type: syslog"
 
 declare -A log_locations
-log_locations[apache2]='/var/log/apache2/*.log,/var/log/*httpd*.log,/var/log/httpd/*log'
+log_locations[apache2]='/var/log/apache2/*.log,/var/log/*httpd*.log,/var/log/httpd/*log,/var/log/ispconfig/httpd/access.log'
 log_locations[nginx]='/var/log/nginx/*.log,/usr/local/openresty/nginx/logs/*.log'
 log_locations[sshd]='/var/log/auth.log,/var/log/sshd.log,/var/log/secure'
 log_locations[rsyslog]='/var/log/syslog'


### PR DESCRIPTION
Fix: #574 
Since the poss_path is split on the last ```/``` character and find is recursive by default we shouldnt need to place a wildcard in the log file path. I have tested this and seems to be working, however, if the original issue owners are around they can test it on a system that would be great.