### PR TITLE
avoid double output (error + log fatal) and automatic --help after each error

### DIFF
--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -113,6 +113,8 @@ func main() {
 It is meant to allow you to manage bans, parsers/scenarios/etc, api and generally manage you crowdsec setup.`,
 		ValidArgs:         validArgs,
 		DisableAutoGenTag: true,
+		SilenceErrors:     true,
+		SilenceUsage:      true,
 		/*TBD examples*/
 	}
 	var cmdDocGen = &cobra.Command{

--- a/tests/bats/01_base.bats
+++ b/tests/bats/01_base.bats
@@ -31,6 +31,13 @@ declare stderr
     assert_output --partial "Usage:"
     assert_output --partial "cscli [command]"
     assert_output --partial "Available Commands:"
+
+    # no "usage" output after every error
+    run -1 --separate-stderr cscli blahblah
+    run -0 echo "${stderr}"
+    # error is displayed as log entry, not with print
+    assert_output --partial 'level=fatal msg="unknown command \"blahblah\" for \"cscli\""'
+    refute_output --partial 'unknown command "blahblah" for "cscli"'
 }
 
 @test "${FILE} cscli version" {
@@ -208,12 +215,12 @@ declare stderr
     run -1 --separate-stderr cscli alerts list
     run -0 echo "${stderr}"
     assert_output --partial 'parsing api url'
-    assert_output --partial 'invalid port ":-80" after host'
+    assert_output --partial 'invalid port \":-80\" after host'
 
     run -1 --separate-stderr cscli decisions list
     run -0 echo "${stderr}"
     assert_output --partial 'parsing api url'
-    assert_output --partial 'invalid port ":-80" after host'
+    assert_output --partial 'invalid port \":-80\" after host'
 }
 
 @test "${FILE} cscli metrics" {


### PR DESCRIPTION
Errors being in log format may be harder to read or parse while using interactive / scripted tools, so if we want to change I'm not opposed. But this PR keeps the behavior consistent with bin/crowdsec. 

Related: https://github.com/spf13/cobra/issues/914