### PR TITLE
test multiple notification events with the same plugin

### DIFF
--- a/plugins/notifications/dummy/dummy.yaml
+++ b/plugins/notifications/dummy/dummy.yaml
@@ -20,3 +20,9 @@ format: |
 #
 # output_file:        # notifications will be appended here. optional
 
+---
+
+# type: dummy
+# name: dummy_second_notification
+# ...
+

--- a/plugins/notifications/email/email.yaml
+++ b/plugins/notifications/email/email.yaml
@@ -37,3 +37,9 @@ receiver_emails:
 # One of "ssltls", "none"
 encryption_type: ssltls
 
+---
+
+# type: email
+# name: email_second_notification
+# ...
+

--- a/plugins/notifications/http/http.yaml
+++ b/plugins/notifications/http/http.yaml
@@ -28,3 +28,9 @@ method: POST
 
 # skip_tls_verification:  # true or false. Default is false
 
+---
+
+# type: http
+# name: http_second_notification
+# ...
+

--- a/plugins/notifications/slack/slack.yaml
+++ b/plugins/notifications/slack/slack.yaml
@@ -28,3 +28,9 @@ format: |
 
 webhook: <WEBHOOK_URL>
 
+---
+
+# type: slack
+# name: slack_second_notification
+# ...
+

--- a/plugins/notifications/splunk/splunk.yaml
+++ b/plugins/notifications/splunk/splunk.yaml
@@ -19,3 +19,10 @@ format: |
 
 url: <SPLUNK_HTTP_URL>
 token: <SPLUNK_TOKEN>
+
+---
+
+# type: splunk
+# name: splunk_second_notification
+# ...
+

--- a/tests/bats/71_dummy_plugin.bats
+++ b/tests/bats/71_dummy_plugin.bats
@@ -12,14 +12,29 @@ setup_file() {
     tempfile=$(TMPDIR="${BATS_FILE_TMPDIR}" mktemp)
     export tempfile
 
+    tempfile2=$(TMPDIR="${BATS_FILE_TMPDIR}" mktemp)
+    export tempfile2
+
+    DUMMY_YAML="$(config_yq '.config_paths.notification_dir')/dummy.yaml"
+
     yq e '
        .group_wait="5s" |
        .group_threshold=2 |
-       .output_file=strenv(tempfile)
-       ' -i "$(config_yq '.config_paths.notification_dir')/dummy.yaml"
+       .output_file=strenv(tempfile) |
+       .format="{{.|toJson}}"
+       ' -i "${DUMMY_YAML}"
+
+    cat <<- EOT >> "${DUMMY_YAML}"
+	---
+	type: dummy
+	name: dummy_2
+	log_level: info
+	format: secondfile
+	output_file: ${tempfile2}
+	EOT
 
     yq e '
-       .notifications=["dummy_default"] |
+       .notifications=["dummy_default","dummy_2"] |
        .filters=["Alert.GetScope() == \"Ip\""]
        ' -i "$(config_yq '.api.server.profiles_path')"
 
@@ -33,6 +48,7 @@ setup_file() {
 
 teardown_file() {
     load "../lib/teardown_file.sh"
+    rm -f "${tempfile}" "${tempfile2}"
 }
 
 setup() {
@@ -42,7 +58,7 @@ setup() {
 
 #----------
 
-@test "$FILE add two bans" {
+@test "${FILE} add two bans" {
     run -0 cscli decisions add --ip 1.2.3.4 --duration 30s
     assert_output --partial 'Decision successfully added'
 
@@ -51,8 +67,13 @@ setup() {
     sleep 2
 }
 
-@test "$FILE expected 1 notification" {
+@test "${FILE} expected 1 notification" {
     run -0 cat "${tempfile}"
     assert_output --partial 1.2.3.4
     assert_output --partial 1.2.3.5
+}
+
+@test "${FILE} second notification works too" {
+    run -0 cat "${tempfile2}"
+    assert_output --partial secondfile
 }


### PR DESCRIPTION
While looking how to apply yaml.local to the plugin configurations, it occurred to me that we support multiple documents in the same YAML files. It makes sense but I was not aware.
I am adding tests and updating the configuration files to be explicit about it. We could also mention it in the docs.

