### PR TITLE
Allow to set static to a pointer and add IsIPV6 helper

### DIFF
--- a/pkg/exprhelpers/exprlib.go
+++ b/pkg/exprhelpers/exprlib.go
@@ -188,6 +188,7 @@ func IsIPV6(ip string) bool {
 		return false
 	}
 
+	// If it's a valid IP and can't be converted to IPv4 then it is an IPv6
 	return ipParsed.To4() == nil
 }
 

--- a/pkg/exprhelpers/exprlib.go
+++ b/pkg/exprhelpers/exprlib.go
@@ -58,6 +58,7 @@ func GetExprEnv(ctx map[string]interface{}) map[string]interface{} {
 		"XMLGetAttributeValue": XMLGetAttributeValue,
 		"XMLGetNodeValue":      XMLGetNodeValue,
 		"IpToRange":            IpToRange,
+		"IsIPV6":               IsIPV6,
 	}
 	for k, v := range ctx {
 		ExprLib[k] = v
@@ -178,6 +179,16 @@ func IpInRange(ip string, ipRange string) bool {
 		return true
 	}
 	return false
+}
+
+func IsIPV6(ip string) bool {
+	ipParsed := net.ParseIP(ip)
+	if ipParsed == nil {
+		log.Debugf("'%s' is not a valid IP", ip)
+		return false
+	}
+
+	return ipParsed.To4() == nil
 }
 
 func IpToRange(ip string, cidr string) string {

--- a/pkg/parser/runtime.go
+++ b/pkg/parser/runtime.go
@@ -64,7 +64,7 @@ func SetTargetByName(target string, value string, evt *types.Event) bool {
 		case reflect.Struct:
 			tmp := iter.FieldByName(f)
 			if !tmp.IsValid() {
-				log.Errorf("%s IsValid false", f)
+				log.Debugf("'%s' is not a valid target because '%s' is not valid", target, f)
 				return false
 			}
 			if tmp.Kind() == reflect.Ptr {


### PR DESCRIPTION
This PRs add 2 things:

 - We can now set a static where the `target` is a Pointer
 - Adding an expr helper to check if an IP address is in V6 format
 
This will allow to solve this issue: https://github.com/crowdsecurity/crowdsec/issues/402

Example:

We can use the following postoverflow that will replace the `Alert.Source.Value` with the IPV6 range (`/64` for our example):

```yaml
onsuccess: next_stage
filter: "evt.Overflow.Alert.Remediation == true && IsIPV6(evt.Overflow.Alert.Source.IP)"
name: crowdsecurity/ipv6
description: ""
statics:
  - target: evt.Overflow.Alert.Source.Value
    expression: IpToRange(evt.Overflow.Alert.Source.IP, "/64")
  - target: evt.Overflow.Alert.Source.Scope
    value: Range
```

And then the use following profile to generate decisions on ranges:
```yaml
name: default_range_remediation
debug: true
filters:
 - Alert.Remediation == true && Alert.GetScope() == "Range"
decisions:
 - type: ban
   duration: 4h
   scope: range
on_success: break
```





