### PR TITLE
Fix windows installer removing patterns folder on upgrade

### DIFF
--- a/make_installer.ps1
+++ b/make_installer.ps1
@@ -15,6 +15,6 @@ if ($version.Contains("-"))
 
 Remove-Item -Force -Recurse -Path .\msi -ErrorAction SilentlyContinue
 #we only harvest the patterns dir, as we want to handle differently some yaml files in the config directory, and I really don't want to write xlst filters to exclude the files :(
-heat.exe dir config\patterns -nologo -cg CrowdsecPatterns -dr PatternsDir -g1 -gg -sf -srd -scom -sreg -out "msi\fragment.wxs"
+heat.exe dir config\patterns -nologo -cg CrowdsecPatterns -dr PatternsDir -g1 -ag -sf -srd -scom -sreg -out "msi\fragment.wxs"
 candle.exe -arch x64 -dSourceDir=config\patterns -dVersion="$version" -out msi\ msi\fragment.wxs windows\installer\WixUI_HK.wxs windows\installer\product.wxs
 light.exe -b .\config\patterns -ext WixUIExtension -ext WixUtilExtension -sacl -spdb  -out crowdsec_$version.msi msi\fragment.wixobj msi\WixUI_HK.wixobj msi\product.wixobj


### PR DESCRIPTION
Prevent the windows installer from removing the `patterns` folder on upgrade.

This only fix the issues for future releases, upgrade from 1.3.4 to 1.4.0 will require the user to:
 - Uninstall 1.3.4 and install 1.4.0
 - Or install 1.4.0 and rerun the MSI to repair the installation.