### PR TITLE
do not spew.Sdump() the invalid node on error

### DIFF
--- a/pkg/parser/node.go
+++ b/pkg/parser/node.go
@@ -545,12 +545,13 @@ func (n *Node) compile(pctx *UnixParserCtx, ectx EnricherCtx) error {
 
 	if !valid {
 		/* node is empty, error force return */
-		n.Logger.Infof("Node is empty: %s", spew.Sdump(n))
+		n.Logger.Error("Node is empty or invalid, abort")
 		n.Stage = ""
+		return fmt.Errorf("Node is empty")
 	}
+
 	if err := n.validate(pctx, ectx); err != nil {
 		return err
-		//n.logger.Fatalf("Node is invalid : %s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
  - `spew.Sdump` leads to huge memory usage, especially if the parsers refers ie. datafile
  - Abort crowdsec load when it happens to avoid hiding the error
  - fix #1547 
