### PR TITLE
Cscli explain use temp dir

### DIFF
--- a/cmd/crowdsec-cli/explain.go
+++ b/cmd/crowdsec-cli/explain.go
@@ -19,7 +19,6 @@ func NewExplainCmd() *cobra.Command {
 	var logLine string
 	var logType string
 	var opts cstest.DumpOpts
-	var useCWD bool
 
 	var cmdExplain = &cobra.Command{
 		Use:   "explain",
@@ -44,17 +43,7 @@ cscli explain --dsn "file://myfile.log" --type nginx
 			}
 
 			var f *os.File
-			var dir string
-
-			if !useCWD {
-				dir = os.TempDir()
-			} else {
-				var err error
-				dir, err = os.Getwd()
-				if err != nil {
-					dir = "./"
-				}
-			}
+			dir := os.TempDir()
 
 			// we create a temporary log file if a log line has been provided
 			if logLine != "" {
@@ -125,7 +114,6 @@ cscli explain --dsn "file://myfile.log" --type nginx
 	cmdExplain.PersistentFlags().StringVarP(&logType, "type", "t", "", "Type of the acquisition to test")
 	cmdExplain.PersistentFlags().BoolVarP(&opts.Details, "verbose", "v", false, "Display individual changes")
 	cmdExplain.PersistentFlags().BoolVar(&opts.SkipOk, "failures", false, "Only show failed lines")
-	cmdExplain.PersistentFlags().BoolVar(&useCWD, "useCWD", false, "Use current directory instead of tmp location")
 
 	return cmdExplain
 }

--- a/cmd/crowdsec-cli/explain.go
+++ b/cmd/crowdsec-cli/explain.go
@@ -43,10 +43,11 @@ cscli explain --dsn "file://myfile.log" --type nginx
 			}
 
 			var f *os.File
+			tmpDir := os.TempDir()
 
 			// we create a temporary log file if a log line has been provided
 			if logLine != "" {
-				logFile = "./cscli_test_tmp.log"
+				logFile = filepath.Join(tmpDir, "cscli_test_tmp.log")
 				f, err := os.Create(logFile) // nolint: govet
 				if err != nil {
 					log.Fatal(err)
@@ -77,6 +78,7 @@ cscli explain --dsn "file://myfile.log" --type nginx
 
 			cmdArgs := []string{"-c", ConfigFilePath, "-type", logType, "-dsn", dsn, "-dump-data", "./", "-no-api"}
 			crowdsecCmd := exec.Command("crowdsec", cmdArgs...)
+			crowdsecCmd.Dir = tmpDir
 			output, err := crowdsecCmd.CombinedOutput()
 			if err != nil {
 				fmt.Println(string(output))
@@ -90,8 +92,8 @@ cscli explain --dsn "file://myfile.log" --type nginx
 					log.Fatalf("unable to remove tmp log file '%s': %+v", logFile, err)
 				}
 			}
-			parserDumpFile := filepath.Join("./", cstest.ParserResultFileName)
-			bucketStateDumpFile := filepath.Join("./", cstest.BucketPourResultFileName)
+			parserDumpFile := filepath.Join(tmpDir, cstest.ParserResultFileName)
+			bucketStateDumpFile := filepath.Join(tmpDir, cstest.BucketPourResultFileName)
 
 			parserDump, err := cstest.LoadParserDump(parserDumpFile)
 			if err != nil {

--- a/cmd/crowdsec-cli/explain.go
+++ b/cmd/crowdsec-cli/explain.go
@@ -125,7 +125,7 @@ cscli explain --dsn "file://myfile.log" --type nginx
 	cmdExplain.PersistentFlags().StringVarP(&logType, "type", "t", "", "Type of the acquisition to test")
 	cmdExplain.PersistentFlags().BoolVarP(&opts.Details, "verbose", "v", false, "Display individual changes")
 	cmdExplain.PersistentFlags().BoolVar(&opts.SkipOk, "failures", false, "Only show failed lines")
-	cmdExplain.PersistentFlags().BoolVarP(&useCWD, "useCWD", "cwd", false, "Use current directory instead of tmp location")
+	cmdExplain.PersistentFlags().BoolVar(&useCWD, "useCWD", false, "Use current directory instead of tmp location")
 
 	return cmdExplain
 }


### PR DESCRIPTION
@blotus had a user via discord that ran ```cscli explain``` inside parsers folders which led to crowdsec failing to load as the YAML files left over are invalid format. Best to have all file output go-to temp directory of the host OS, I did add a flag for CWD if a user needs it.