### PR TITLE
fix the ssltls by actually doing ssltls.

### DIFF
--- a/plugins/notifications/email/main.go
+++ b/plugins/notifications/email/main.go
@@ -27,8 +27,9 @@ var AuthStringToType map[string]mail.AuthType = map[string]mail.AuthType{
 }
 
 var EncryptionStringToType map[string]mail.Encryption = map[string]mail.Encryption{
-	"ssltls": mail.EncryptionSTARTTLS,
-	"none":   mail.EncryptionNone,
+	"ssltls":   mail.EncryptionSSLTLS,
+	"starttls": mail.EncryptionSTARTTLS,
+	"none":     mail.EncryptionNone,
 }
 
 type PluginConfig struct {


### PR DESCRIPTION
**BEWARE: THIS IS A BREAKING CHANGE**

The acual situation is the following:
* in the `email.yaml` plugin configuration file, ssltls configuration option leads to do a starttls encryption.
* it's not possible to actually use ssltls encryption of the underlying mail library

After some discussion with @blotus we agreed that the least bad change to do is to enfoce a breaking change. People that do actually use ssltls option to do starttls will see their configuration break on upgrade. Sorry, but we think there's no smarter move.

This will fix https://github.com/crowdsecurity/crowdsec/issues/1623
