### PR TITLE
cscli machines delete: return an error if machines doesn't exist

### DIFF
--- a/cmd/crowdsec-cli/bouncers.go
+++ b/cmd/crowdsec-cli/bouncers.go
@@ -164,7 +164,7 @@ cscli bouncers add MyBouncerName -k %s`, generatePassword(32)),
 			for _, bouncerID := range args {
 				err := dbClient.DeleteBouncer(bouncerID)
 				if err != nil {
-					log.Fatalf("unable to delete bouncer: %s", err)
+					log.Fatalf("unable to delete bouncer '%s': %s", bouncerID, err)
 				}
 				log.Infof("bouncer '%s' deleted successfully", bouncerID)
 			}

--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -322,7 +322,7 @@ cscli machines add MyTestMachine --password MyPassword
 			for _, machineID := range args {
 				err := dbClient.DeleteWatcher(machineID)
 				if err != nil {
-					log.Errorf("unable to delete machine: %s", err)
+					log.Errorf("unable to delete machine '%s': %s", machineID, err)
 					return
 				}
 				log.Infof("machine '%s' deleted successfully", machineID)

--- a/pkg/database/bouncers.go
+++ b/pkg/database/bouncers.go
@@ -47,19 +47,24 @@ func (c *Client) CreateBouncer(name string, ipAddr string, apiKey string, authTy
 		if ent.IsConstraintError(err) {
 			return nil, fmt.Errorf("bouncer %s already exists", name)
 		}
-		return nil, fmt.Errorf("unable to save api key in database: %s", err)
+		return nil, fmt.Errorf("unable to create bouncer: %s", err)
 	}
 	return bouncer, nil
 }
 
 func (c *Client) DeleteBouncer(name string) error {
-	_, err := c.Ent.Bouncer.
+	nbDeleted, err := c.Ent.Bouncer.
 		Delete().
 		Where(bouncer.NameEQ(name)).
 		Exec(c.CTX)
 	if err != nil {
-		return fmt.Errorf("unable to save api key in database: %s", err)
+		return err
 	}
+
+	if nbDeleted == 0 {
+		return fmt.Errorf("bouncer doesn't exist")
+	}
+
 	return nil
 }
 
@@ -68,7 +73,7 @@ func (c *Client) UpdateBouncerLastPull(lastPull time.Time, ID int) error {
 		SetLastPull(lastPull).
 		Save(c.CTX)
 	if err != nil {
-		return fmt.Errorf("unable to update machine in database: %s", err)
+		return fmt.Errorf("unable to update machine last pull in database: %s", err)
 	}
 	return nil
 }

--- a/pkg/database/machines.go
+++ b/pkg/database/machines.go
@@ -152,7 +152,7 @@ func (c *Client) UpdateMachineIP(ipAddr string, ID int) error {
 		SetIpAddress(ipAddr).
 		Save(c.CTX)
 	if err != nil {
-		return fmt.Errorf("unable to update machine in database: %s", err)
+		return fmt.Errorf("unable to update machine IP in database: %s", err)
 	}
 	return nil
 }
@@ -162,7 +162,7 @@ func (c *Client) UpdateMachineVersion(ipAddr string, ID int) error {
 		SetVersion(ipAddr).
 		Save(c.CTX)
 	if err != nil {
-		return fmt.Errorf("unable to update machine in database: %s", err)
+		return fmt.Errorf("unable to update machine version in database: %s", err)
 	}
 	return nil
 }

--- a/pkg/database/machines.go
+++ b/pkg/database/machines.go
@@ -105,13 +105,18 @@ func (c *Client) QueryPendingMachine() ([]*ent.Machine, error) {
 }
 
 func (c *Client) DeleteWatcher(name string) error {
-	_, err := c.Ent.Machine.
+	nbDeleted, err := c.Ent.Machine.
 		Delete().
 		Where(machine.MachineIdEQ(name)).
 		Exec(c.CTX)
 	if err != nil {
-		return fmt.Errorf("unable to save api key in database: %s", err)
+		return err
 	}
+
+	if nbDeleted == 0 {
+		return fmt.Errorf("machine doesn't exist")
+	}
+
 	return nil
 }
 

--- a/tests/bats/10_bouncers.bats
+++ b/tests/bats/10_bouncers.bats
@@ -53,6 +53,6 @@ teardown() {
 @test "delete the bouncer multiple times, even if it does not exist" {
     run -0 cscli bouncers add ciTestBouncer
     run -0 cscli bouncers delete ciTestBouncer
-    run -0 cscli bouncers delete ciTestBouncer
+    run -1 cscli bouncers delete ciTestBouncer
     run -0 cscli bouncers delete foobarbaz
 }

--- a/tests/bats/10_bouncers.bats
+++ b/tests/bats/10_bouncers.bats
@@ -54,5 +54,5 @@ teardown() {
     run -0 cscli bouncers add ciTestBouncer
     run -0 cscli bouncers delete ciTestBouncer
     run -1 cscli bouncers delete ciTestBouncer
-    run -0 cscli bouncers delete foobarbaz
+    run -1 cscli bouncers delete foobarbaz
 }


### PR DESCRIPTION
Fix #1688

```bash
sudo cscli machines delete test      
ERRO[28-07-2022 03:10:34 PM] unable to delete machine 'test': machine doesn't exist
```

```bash
sudo cscli bouncers delete test
FATA[28-07-2022 03:31:03 PM] unable to delete bouncer 'test': bouncer doesn't exist
```