### PR TITLE
Add -a options in cscli alerts list

### DIFF
--- a/cmd/crowdsec-cli/alerts.go
+++ b/cmd/crowdsec-cli/alerts.go
@@ -231,6 +231,7 @@ func NewAlertsCmd() *cobra.Command {
 		Since:          new(string),
 		Until:          new(string),
 		TypeEquals:     new(string),
+		IncludeCAPI:    new(bool),
 	}
 	limit = new(int)
 	contained := new(bool)
@@ -283,6 +284,11 @@ cscli alerts list --type ban`,
 					*alertListFilter.Since = fmt.Sprintf("%d%s", days*24, "h")
 				}
 			}
+
+			if *alertListFilter.IncludeCAPI {
+				*alertListFilter.Limit = 0
+			}
+
 			if *alertListFilter.TypeEquals == "" {
 				alertListFilter.TypeEquals = nil
 			}
@@ -316,6 +322,7 @@ cscli alerts list --type ban`,
 		},
 	}
 	cmdAlertsList.Flags().SortFlags = false
+	cmdAlertsList.Flags().BoolVarP(alertListFilter.IncludeCAPI, "all", "a", false, "Include decisions from Central API")
 	cmdAlertsList.Flags().StringVar(alertListFilter.Until, "until", "", "restrict to alerts older than until (ie. 4h, 30d)")
 	cmdAlertsList.Flags().StringVar(alertListFilter.Since, "since", "", "restrict to alerts newer than since (ie. 4h, 30d)")
 	cmdAlertsList.Flags().StringVarP(alertListFilter.IPEquals, "ip", "i", "", "restrict to alerts from this source ip (shorthand for --scope ip --value <IP>)")

--- a/tests/bats/01_base.bats
+++ b/tests/bats/01_base.bats
@@ -73,7 +73,7 @@ declare stderr
 @test "cscli alerts list: at startup returns at least one entry: community pull" {
     is_db_postgres && skip
     # it should have been received while preparing the fixture
-    run -0 cscli alerts list -o json
+    run -0 cscli alerts list -a -o json
     run -0 jq -r '. | length' <(output)
     refute_output 0
 

--- a/tests/lib/config/config-global
+++ b/tests/lib/config/config-global
@@ -65,7 +65,7 @@ make_init_data() {
         sleep 2
         [[ $("${CSCLI}" alerts list -o json) != "null" ]] && break
     done
-    [[ $("${CSCLI}" alerts list -o json) != "null" ]] || die "could not get community data"
+    [[ $("${CSCLI}" alerts list -a -o json) != "null" ]] || die "could not get community data"
 
     "${TEST_DIR}/instance-crowdsec" stop
 

--- a/tests/lib/config/config-local
+++ b/tests/lib/config/config-local
@@ -114,7 +114,7 @@ make_init_data() {
         sleep 2
         [[ $("${CSCLI}" alerts list -o json) != "null" ]] && break
     done
-    [[ $("${CSCLI}" alerts list -o json) != "null" ]] || die "could not get community data"
+    [[ $("${CSCLI}" alerts list -a -o json) != "null" ]] || die "could not get community data"
 
     "${TEST_DIR}/instance-crowdsec" stop
 


### PR DESCRIPTION
Add `-a` options to `cscli alerts list` to include alerts from the community blocklist or not