### PR TITLE
Add config option to enable or not local API and agent

### DIFF
--- a/pkg/csconfig/api.go
+++ b/pkg/csconfig/api.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/crowdsecurity/crowdsec/pkg/yamlpatch"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -136,6 +137,7 @@ func toValidCIDR(ip string) string {
 
 /*local api service configuration*/
 type LocalApiServerCfg struct {
+	Enable                 *bool               `yaml:"enable"`
 	ListenURI              string              `yaml:"listen_uri,omitempty"` //127.0.0.1:8080
 	TLS                    *TLSCfg             `yaml:"tls"`
 	DbConfig               *DatabaseCfg        `yaml:"-"`
@@ -169,7 +171,11 @@ type TLSCfg struct {
 }
 
 func (c *Config) LoadAPIServer() error {
-	if c.API.Server != nil && !c.DisableAPI {
+	if c.API.Server.Enable == nil {
+		// if the option is not present, it is enabled by default
+		c.API.Server.Enable = types.BoolPtr(true)
+	}
+	if c.API.Server != nil && !c.DisableAPI && *c.API.Server.Enable {
 		if err := c.LoadCommon(); err != nil {
 			return fmt.Errorf("loading common configuration: %s", err)
 		}

--- a/pkg/csconfig/api.go
+++ b/pkg/csconfig/api.go
@@ -179,15 +179,18 @@ func (c *Config) LoadAPIServer() error {
 	if c.API.Server == nil {
 		log.Warning("crowdsec local API is disabled because its configuration is not present")
 		c.DisableAPI = true
+		return nil
 	}
 
 	if c.API.Server.Enable == nil {
 		// if the option is not present, it is enabled by default
 		c.API.Server.Enable = types.BoolPtr(true)
 	}
+
 	if !*c.API.Server.Enable {
 		log.Warning("crowdsec local API is disabled because 'enable' is set to false")
 		c.DisableAPI = true
+		return nil
 	}
 
 	if c.DisableAPI {

--- a/pkg/csconfig/api_test.go
+++ b/pkg/csconfig/api_test.go
@@ -201,6 +201,7 @@ func TestLoadAPIServer(t *testing.T) {
 				DisableAPI: false,
 			},
 			expectedResult: &LocalApiServerCfg{
+				Enable:    types.BoolPtr(true),
 				ListenURI: "http://crowdsec.api",
 				TLS:       nil,
 				DbConfig: &DatabaseCfg{
@@ -244,6 +245,7 @@ func TestLoadAPIServer(t *testing.T) {
 				DisableAPI: false,
 			},
 			expectedResult: &LocalApiServerCfg{
+				Enable:   types.BoolPtr(true),
 				LogDir:   LogDirFullPath,
 				LogMedia: "stdout",
 			},

--- a/pkg/csconfig/crowdsec_service.go
+++ b/pkg/csconfig/crowdsec_service.go
@@ -5,12 +5,14 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
 /*Configurations needed for crowdsec to load parser/scenarios/... + acquisition*/
 type CrowdsecServiceCfg struct {
+	Enable              *bool  `yaml:"enable"`
 	AcquisitionFilePath string `yaml:"acquisition_path,omitempty"`
 	AcquisitionDirPath  string `yaml:"acquisition_dir,omitempty"`
 
@@ -43,6 +45,18 @@ func (c *Config) LoadCrowdsec() error {
 		c.DisableAgent = true
 		return nil
 	}
+
+	if c.Crowdsec.Enable == nil {
+		// if the option is not present, it is enabled by default
+		c.Crowdsec.Enable = types.BoolPtr(true)
+	}
+
+	if !*c.Crowdsec.Enable {
+		log.Warning("crowdsec agent is disabled")
+		c.DisableAgent = true
+		return nil
+	}
+
 	if c.Crowdsec.AcquisitionFilePath != "" {
 		log.Debugf("non-empty acquisition file path %s", c.Crowdsec.AcquisitionFilePath)
 		if _, err := os.Stat(c.Crowdsec.AcquisitionFilePath); err != nil {

--- a/pkg/csconfig/crowdsec_service_test.go
+++ b/pkg/csconfig/crowdsec_service_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -71,6 +72,7 @@ func TestLoadCrowdsec(t *testing.T) {
 				},
 			},
 			expectedResult: &CrowdsecServiceCfg{
+				Enable:               types.BoolPtr(true),
 				AcquisitionDirPath:   "",
 				AcquisitionFilePath:  acquisFullPath,
 				ConfigDir:            configDirFullPath,
@@ -107,6 +109,7 @@ func TestLoadCrowdsec(t *testing.T) {
 				},
 			},
 			expectedResult: &CrowdsecServiceCfg{
+				Enable:               types.BoolPtr(true),
 				AcquisitionDirPath:   acquisDirFullPath,
 				AcquisitionFilePath:  acquisFullPath,
 				ConfigDir:            configDirFullPath,
@@ -139,6 +142,7 @@ func TestLoadCrowdsec(t *testing.T) {
 				Crowdsec: &CrowdsecServiceCfg{},
 			},
 			expectedResult: &CrowdsecServiceCfg{
+				Enable:               types.BoolPtr(true),
 				BucketsRoutinesCount: 1,
 				ParserRoutinesCount:  1,
 				OutputRoutinesCount:  1,
@@ -169,6 +173,7 @@ func TestLoadCrowdsec(t *testing.T) {
 				},
 			},
 			expectedResult: &CrowdsecServiceCfg{
+				Enable:               types.BoolPtr(true),
 				AcquisitionFilePath:  "./tests/acquis_not_exist.yaml",
 				BucketsRoutinesCount: 0,
 				ParserRoutinesCount:  0,


### PR DESCRIPTION
Add an option configuration `enable` at the `api.server` and `crowdsec_service` level to respectively enable/disable the crowdsec local API and the crowdsec agent.

Fix #1723 