### PR TITLE
Fix static build

### DIFF
--- a/.github/workflows/bats-mysql-static.yml
+++ b/.github/workflows/bats-mysql-static.yml
@@ -1,0 +1,96 @@
+name: Functional tests (MySQL - Static Build)
+
+on:
+  workflow_call:
+    inputs:
+      database_image:
+        required: true
+        type: string
+
+env:
+  PREFIX_TEST_NAMES_WITH_FILE: true
+
+jobs:
+
+  build:
+    name: "Build + tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      database:
+        image: ${{ inputs.database_image }}
+        env:
+          MYSQL_ROOT_PASSWORD: "secret"
+        ports:
+          - 3306:3306
+
+    steps:
+
+    - name: "Force machineid"
+      run: |
+          sudo chmod +w /etc/machine-id
+          echo githubciXXXXXXXXXXXXXXXXXXXXXXXX | sudo tee /etc/machine-id
+
+    - name: "Set up Go 1.19"
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+      id: go
+
+    - name: "Check out CrowdSec repository"
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+
+    - name: "Install bats dependencies"
+      run: |
+        sudo apt -qq -y -o=Dpkg::Use-Pty=0 install build-essential daemonize jq netcat-openbsd
+        go install github.com/mikefarah/yq/v4@latest
+        go install github.com/cloudflare/cfssl/cmd/cfssl@master
+        go install github.com/cloudflare/cfssl/cmd/cfssljson@master
+        sudo cp -u ~/go/bin/yq ~/go/bin/cfssl ~/go/bin/cfssljson /usr/local/bin/
+
+    - name: "Build crowdsec and fixture"
+      run: |
+        make clean bats-build-static bats-fixture
+      env:
+        DB_BACKEND: mysql
+        MYSQL_HOST: 127.0.0.1
+        MYSQL_PORT: 3306
+        MYSQL_PASSWORD: "secret"
+        MYSQL_USER: root
+
+    - name: "Run tests"
+      run: make bats-test
+      env:
+        DB_BACKEND: mysql
+        MYSQL_HOST: 127.0.0.1
+        MYSQL_PORT: 3306
+        MYSQL_PASSWORD: "secret"
+        MYSQL_USER: root
+
+    #
+    # In case you need to inspect the database status after the failure of a given test
+    #
+    # - name: "Run specified tests"
+    #   run: ./tests/run-tests tests/bats/<filename>.bats -f "<test name>"
+
+    - name: Show database dump
+      run: ./tests/instance-db dump /dev/fd/1
+      env:
+        DB_BACKEND: mysql
+        MYSQL_HOST: 127.0.0.1
+        MYSQL_PORT: 3306
+        MYSQL_PASSWORD: "secret"
+        MYSQL_USER: root
+      if: ${{ always() }}
+
+    - name: "Show crowdsec logs"
+      run:
+        for file in $(find ./tests/local/var/log -type f); do echo ">>>>> $file"; cat $file; echo; done
+      if: ${{ always() }}
+
+    - name: "Show database logs"
+      run: docker logs "${{ job.services.database.id }}"
+      if: ${{ always() }}

--- a/.github/workflows/bats-postgres-static.yml
+++ b/.github/workflows/bats-postgres-static.yml
@@ -1,0 +1,99 @@
+name: Functional tests (Postgres - Static Build)
+
+on:
+  workflow_call:
+
+env:
+  PREFIX_TEST_NAMES_WITH_FILE: true
+
+jobs:
+
+  build:
+    name: "Build + tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      database:
+        image: postgres:latest
+        env:
+          POSTGRES_PASSWORD: "secret"
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready -u postgres
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+
+    - name: "Force machineid"
+      run: |
+          sudo chmod +w /etc/machine-id
+          echo githubciXXXXXXXXXXXXXXXXXXXXXXXX | sudo tee /etc/machine-id
+
+    - name: "Set up Go 1.19"
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+      id: go
+
+    - name: "Check out CrowdSec repository"
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+
+    - name: "Install bats dependencies"
+      run: |
+        sudo apt -qq -y -o=Dpkg::Use-Pty=0 install build-essential daemonize jq netcat-openbsd
+        go install github.com/mikefarah/yq/v4@latest
+        go install github.com/cloudflare/cfssl/cmd/cfssl@master
+        go install github.com/cloudflare/cfssl/cmd/cfssljson@master
+        sudo cp -u ~/go/bin/yq ~/go/bin/cfssl ~/go/bin/cfssljson /usr/local/bin/
+
+    - name: "Build crowdsec and fixture (DB_BACKEND: pgx)"
+      run: |
+        make clean bats-build-static bats-fixture
+      env:
+        DB_BACKEND: pgx
+        PGHOST: 127.0.0.1
+        PGPORT: 5432
+        PGPASSWORD: "secret"
+        PGUSER: postgres
+
+    - name: "Run tests (DB_BACKEND: pgx)"
+      run: make bats-test
+      env:
+        DB_BACKEND: pgx
+        PGHOST: 127.0.0.1
+        PGPORT: 5432
+        PGPASSWORD: "secret"
+        PGUSER: postgres
+
+    - name: "Build crowdsec and fixture (DB_BACKEND: postgres)"
+      run: make clean bats-build bats-fixture
+      env:
+        DB_BACKEND: postgres
+        PGHOST: 127.0.0.1
+        PGPORT: 5432
+        PGPASSWORD: "secret"
+        PGUSER: postgres
+
+    - name: "Run tests (DB_BACKEND: postgres)"
+      run: make bats-test
+      env:
+        DB_BACKEND: postgres
+        PGHOST: 127.0.0.1
+        PGPORT: 5432
+        PGPASSWORD: "secret"
+        PGUSER: postgres
+
+    - name: "Show crowdsec logs"
+      run:
+        for file in $(find ./tests/local/var/log -type f); do echo ">>>>> $file"; cat $file; echo; done
+      if: ${{ always() }}
+
+    - name: "Show database logs"
+      run: docker logs "${{ job.services.database.id }}"
+      if: ${{ always() }}

--- a/.github/workflows/bats-sqlite-coverage-static.yml
+++ b/.github/workflows/bats-sqlite-coverage-static.yml
@@ -1,0 +1,80 @@
+name: Functional tests (sqlite - Static Build)
+
+on:
+  workflow_call:
+
+env:
+  PREFIX_TEST_NAMES_WITH_FILE: true
+  TEST_COVERAGE: true
+
+jobs:
+
+  build:
+    name: "Build + tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+
+    - name: "Force machineid"
+      run: |
+          sudo chmod +w /etc/machine-id
+          echo githubciXXXXXXXXXXXXXXXXXXXXXXXX | sudo tee /etc/machine-id
+
+    - name: "Set up Go 1.19"
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+      id: go
+
+    - name: "Check out CrowdSec repository"
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+
+    - name: "Install bats dependencies"
+      run: |
+        sudo apt -qq -y -o=Dpkg::Use-Pty=0 install build-essential daemonize jq netcat-openbsd
+        go install github.com/mikefarah/yq/v4@latest
+        go install github.com/cloudflare/cfssl/cmd/cfssl@master
+        go install github.com/cloudflare/cfssl/cmd/cfssljson@master
+        sudo cp -u ~/go/bin/yq ~/go/bin/cfssl ~/go/bin/cfssljson /usr/local/bin/
+        go install github.com/wadey/gocovmerge@latest
+        sudo cp -u ~/go/bin/gocovmerge /usr/local/bin/
+
+    - name: "Build crowdsec and fixture"
+      run: |
+        make clean bats-build-static bats-fixture
+
+    - name: "Run tests"
+      run: make bats-test
+
+    #
+    # In case you need to inspect the database status after the failure of a given test
+    #
+    # - name: "Run specified tests"
+    #   run: ./tests/run-tests tests/bats/<filename>.bats -f "<test name>"
+
+    - name: "Show database dump"
+      run: |
+        ./tests/instance-crowdsec stop
+        sqlite3 ./tests/local/var/lib/crowdsec/data/crowdsec.db '.dump'
+      if: ${{ always() }}
+
+    - name: "Show crowdsec logs"
+      run:
+        for file in $(find ./tests/local/var/log -type f); do echo ">>>>> $file"; cat $file; echo; done
+      if: ${{ always() }}
+
+    - name: Upload crowdsec coverage to codecov
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./tests/local/var/lib/coverage/coverage-crowdsec.out
+        flags: func-crowdsec
+
+    - name: Upload cscli coverage to codecov
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./tests/local/var/lib/coverage/coverage-cscli.out
+        flags: func-cscli

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -26,6 +26,9 @@ jobs:
   sqlite:
     uses: ./.github/workflows/bats-sqlite-coverage.yml
 
+  sqlite-static:
+    uses: ./.github/workflows/bats-sqlite-coverage-static.yml
+
   # Jobs for Postgres (and sometimes MySQL) can have failing tests on GitHub
   # CI, but they pass when run on devs' machines or in the release checks. We
   # disable them here by default. Remove the if..false to enable them.
@@ -35,13 +38,26 @@ jobs:
     with:
       database_image: mariadb:latest
 
+  mariadb-static:
+    uses: ./.github/workflows/bats-mysql-static.yml
+    with:
+      database_image: mariadb:latest
+
   mysql:
     uses: ./.github/workflows/bats-mysql.yml
     with:
       database_image: mysql:latest
 
+  mysql-static:
+    uses: ./.github/workflows/bats-mysql-static.yml
+    with:
+      database_image: mysql:latest
+
   postgres:
     uses: ./.github/workflows/bats-postgres.yml
+
+  postgres-static:
+    uses: ./.github/workflows/bats-postgres-static.yml
 
   hub:
     uses: ./.github/workflows/bats-hub.yml

--- a/.github/workflows/go-tests-windows.yml
+++ b/.github/workflows/go-tests-windows.yml
@@ -18,7 +18,9 @@ jobs:
   build:
     name: "Build + tests"
     runs-on: windows-2022
-
+    strategy:
+      matrix:
+        build-type: ["build", "static"]
     steps:
 
     - name: "Set up Go 1.19"
@@ -35,7 +37,7 @@ jobs:
 
     - name: Build
       run: |
-        make build
+        make ${{ matrix.build-type }}
 
     - name: Run tests
       run: |

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -33,6 +33,9 @@ jobs:
   build:
     name: "Build + tests"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build-type: ["build", "static"]
     services:
       localstack:
         image: localstack/localstack:0.13.3
@@ -122,7 +125,7 @@ jobs:
 
     - name: Build
       run: |
-        make build
+        make ${{ matrix.build-type }}
 
     - name: Run tests
       run: |

--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,17 @@ cscli: goversion
 cscli-bincover: goversion
 	@GOARCH=$(GOARCH) GOOS=$(GOOS) $(MAKE) -C $(CSCLI_FOLDER) build-bincover --no-print-directory
 
+cscli-bincover_static: goversion
+	@GOARCH=$(GOARCH) GOOS=$(GOOS) $(MAKE) -C $(CSCLI_FOLDER) build-bincover_static --no-print-directory
+
 crowdsec: goversion
 	@$(MAKE) -C $(CROWDSEC_FOLDER) build --no-print-directory GOARCH=$(GOARCH) GOOS=$(GOOS) RM="$(RM)" WIN_IGNORE_ERR="$(WIN_IGNORE_ERR)" CP="$(CP)" CPR="$(CPR)" MKDIR="$(MKDIR)"
 
 crowdsec-bincover: goversion
 	@GOARCH=$(GOARCH) GOOS=$(GOOS) $(MAKE) -C $(CROWDSEC_FOLDER) build-bincover --no-print-directory
+
+crowdsec-bincover_static: goversion
+	@GOARCH=$(GOARCH) GOOS=$(GOOS) $(MAKE) -C $(CROWDSEC_FOLDER) build-bincover_static --no-print-directory
 
 http-plugin: goversion
 	@$(MAKE) -C $(HTTP_PLUGIN_FOLDER) build --no-print-directory GOARCH=$(GOARCH) GOOS=$(GOOS) RM="$(RM)" WIN_IGNORE_ERR="$(WIN_IGNORE_ERR)" CP="$(CP)" CPR="$(CPR)" MKDIR="$(MKDIR)"

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ LD_OPTS_VARS= \
 -X 'github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultDataDir=$(DEFAULT_DATADIR)'
 
 export LD_OPTS=-ldflags "-s -w $(LD_OPTS_VARS)"
-export LD_OPTS_STATIC=-ldflags "-s -w $(LD_OPTS_VARS) -extldflags '-static'"
+export LD_OPTS_STATIC=-ldflags "-s -w $(LD_OPTS_VARS) -extldflags '-static'" -tags netgo,osusergo,sqlite_omit_load_extension
 
 GOCMD=go
 GOTEST=$(GOCMD) test

--- a/cmd/crowdsec-cli/Makefile
+++ b/cmd/crowdsec-cli/Makefile
@@ -27,7 +27,7 @@ build-bincover: clean
 	$(GOTEST) . -tags testrunmain -coverpkg=$(go list github.com/crowdsecurity/crowdsec/... | grep -v -e 'pkg/database' -e 'plugins/notifications' -e 'pkg/protobufs' -e 'pkg/cwversions' -e 'pkg/cstest' -e 'pkg/models') -covermode=atomic $(LD_OPTS) -c -o $(BINARY_NAME_COVER)
 
 static: clean
-	@$(GOBUILD) $(LD_OPTS_STATIC) -o $(BINARY_NAME) -a -tags netgo
+	@$(GOBUILD) $(LD_OPTS_STATIC) -o $(BINARY_NAME) -a
 
 .PHONY: install
 install: install-conf install-bin

--- a/cmd/crowdsec-cli/Makefile
+++ b/cmd/crowdsec-cli/Makefile
@@ -26,6 +26,10 @@ build: clean
 build-bincover: clean
 	$(GOTEST) . -tags testrunmain -coverpkg=$(go list github.com/crowdsecurity/crowdsec/... | grep -v -e 'pkg/database' -e 'plugins/notifications' -e 'pkg/protobufs' -e 'pkg/cwversions' -e 'pkg/cstest' -e 'pkg/models') -covermode=atomic $(LD_OPTS) -c -o $(BINARY_NAME_COVER)
 
+build-bincover_static: clean
+	$(GOTEST) . -tags testrunmain -coverpkg=$(go list github.com/crowdsecurity/crowdsec/... | grep -v -e 'pkg/database' -e 'plugins/notifications' -e 'pkg/protobufs' -e 'pkg/cwversions' -e 'pkg/cstest' -e 'pkg/models') -covermode=atomic $(LD_OPTS_STATIC) -c -o $(BINARY_NAME_COVER)
+
+
 static: clean
 	@$(GOBUILD) $(LD_OPTS_STATIC) -o $(BINARY_NAME) -a
 

--- a/cmd/crowdsec/Makefile
+++ b/cmd/crowdsec/Makefile
@@ -31,6 +31,9 @@ build: clean
 build-bincover: clean
 	$(GOTEST) . -tags testrunmain -coverpkg=$(go list github.com/crowdsecurity/crowdsec/... | grep -v -e 'pkg/database' -e 'plugins/notifications' -e 'pkg/protobufs' -e 'pkg/cwversions' -e 'pkg/cstest' -e 'pkg/models') -covermode=atomic $(LD_OPTS) -c -o $(CROWDSEC_BIN_COVER)
 
+build-bincover_static: clean
+	$(GOTEST) . -tags testrunmain -coverpkg=$(go list github.com/crowdsecurity/crowdsec/... | grep -v -e 'pkg/database' -e 'plugins/notifications' -e 'pkg/protobufs' -e 'pkg/cwversions' -e 'pkg/cstest' -e 'pkg/models') -covermode=atomic $(LD_OPTS_STATIC) -c -o $(CROWDSEC_BIN_COVER)
+
 static: clean
 	$(GOBUILD) $(LD_OPTS_STATIC) -o $(CROWDSEC_BIN) -a
 

--- a/cmd/crowdsec/Makefile
+++ b/cmd/crowdsec/Makefile
@@ -32,7 +32,7 @@ build-bincover: clean
 	$(GOTEST) . -tags testrunmain -coverpkg=$(go list github.com/crowdsecurity/crowdsec/... | grep -v -e 'pkg/database' -e 'plugins/notifications' -e 'pkg/protobufs' -e 'pkg/cwversions' -e 'pkg/cstest' -e 'pkg/models') -covermode=atomic $(LD_OPTS) -c -o $(CROWDSEC_BIN_COVER)
 
 static: clean
-	$(GOBUILD) $(LD_OPTS_STATIC) -o $(CROWDSEC_BIN) -a -tags netgo
+	$(GOBUILD) $(LD_OPTS_STATIC) -o $(CROWDSEC_BIN) -a
 
 test:
 	$(GOTEST) $(LD_OPTS) -v ./...

--- a/plugins/notifications/dummy/Makefile
+++ b/plugins/notifications/dummy/Makefile
@@ -20,4 +20,4 @@ build: clean
 	@$(GOBUILD) $(LD_OPTS) -o $(BINARY_NAME)
 
 static: clean
-	$(GOBUILD) $(LD_OPTS_STATIC) -o $(BINARY_NAME) -a -tags netgo
+	$(GOBUILD) $(LD_OPTS_STATIC) -o $(BINARY_NAME) -a

--- a/plugins/notifications/email/Makefile
+++ b/plugins/notifications/email/Makefile
@@ -20,4 +20,4 @@ build: clean
 	@$(GOBUILD) $(LD_OPTS) -o $(BINARY_NAME)
 
 static: clean
-	$(GOBUILD) $(LD_OPTS_STATIC) -o $(BINARY_NAME) -a -tags netgo
+	$(GOBUILD) $(LD_OPTS_STATIC) -o $(BINARY_NAME) -a

--- a/plugins/notifications/http/Makefile
+++ b/plugins/notifications/http/Makefile
@@ -20,4 +20,4 @@ build: clean
 	$(GOBUILD) $(LD_OPTS) -o $(BINARY_NAME)
 
 static: clean
-	$(GOBUILD) $(LD_OPTS_STATIC) -o $(BINARY_NAME) -a -tags netgo
+	$(GOBUILD) $(LD_OPTS_STATIC) -o $(BINARY_NAME) -a

--- a/plugins/notifications/slack/Makefile
+++ b/plugins/notifications/slack/Makefile
@@ -20,4 +20,4 @@ clean:
 
 
 static: clean
-	$(GOBUILD) $(LD_OPTS_STATIC) -o $(BINARY_NAME) -a -tags netgo
+	$(GOBUILD) $(LD_OPTS_STATIC) -o $(BINARY_NAME) -a

--- a/plugins/notifications/splunk/Makefile
+++ b/plugins/notifications/splunk/Makefile
@@ -21,4 +21,4 @@ clean:
 	@$(RM) $(BINARY_NAME) $(WIN_IGNORE_ERR)
 
 static: clean
-	$(GOBUILD) $(LD_OPTS_STATIC) -o $(BINARY_NAME) -a -tags netgo
+	$(GOBUILD) $(LD_OPTS_STATIC) -o $(BINARY_NAME) -a

--- a/tests/bats.mk
+++ b/tests/bats.mk
@@ -63,6 +63,8 @@ endef
 
 bats-all: bats-clean bats-build bats-fixture bats-test bats-test-hub
 
+bats-all-static: bats-clean bats-build-static bats-fixture bats-test bats-test-hub
+
 # Source this to run the scripts outside of the Makefile
 # Old versions of make don't have $(file) directive
 bats-environment: export ENV:=$(ENV)
@@ -80,6 +82,14 @@ bats-build: bats-environment bats-check-requirements
 	@install -m 0755 cmd/crowdsec/crowdsec cmd/crowdsec-cli/cscli $(BIN_DIR)/
 	@install -m 0755 plugins/notifications/*/notification-* $(PLUGIN_DIR)/
 	@BINCOVER_TESTING=$(BINCOVER_TESTING) DEFAULT_CONFIGDIR=$(CONFIG_DIR) DEFAULT_DATADIR=$(DATA_DIR) $(MAKE) goversion crowdsec-bincover cscli-bincover
+	@install -m 0755 cmd/crowdsec/crowdsec.cover cmd/crowdsec-cli/cscli.cover $(BIN_DIR)/
+
+bats-build-static: bats-environment bats-check-requirements
+	@mkdir -p $(BIN_DIR) $(LOG_DIR) $(PID_DIR) $(PLUGIN_DIR)
+	@BINCOVER_TESTING=$(BINCOVER_TESTING) DEFAULT_CONFIGDIR=$(CONFIG_DIR) DEFAULT_DATADIR=$(DATA_DIR) $(MAKE) goversion crowdsec_static cscli_static plugins_static
+	@install -m 0755 cmd/crowdsec/crowdsec cmd/crowdsec-cli/cscli $(BIN_DIR)/
+	@install -m 0755 plugins/notifications/*/notification-* $(PLUGIN_DIR)/
+	@BINCOVER_TESTING=$(BINCOVER_TESTING) DEFAULT_CONFIGDIR=$(CONFIG_DIR) DEFAULT_DATADIR=$(DATA_DIR) $(MAKE) goversion crowdsec-bincover_static cscli-bincover_static
 	@install -m 0755 cmd/crowdsec/crowdsec.cover cmd/crowdsec-cli/cscli.cover $(BIN_DIR)/
 
 # Create a reusable package with initial configuration + data


### PR DESCRIPTION
We were not specifying the proper build tags when building crowdsec statically, which meant a static crowdsec was still trying to open the libc and this led to errors when running on  systems with a libc older than the one used on the build machine.

This PR makes sure we use the Go version of `os.user` (this means that crowdsec will not able to perform lookup against LDAP for example when checking the plugins permissions when built statically, but this is most likely a very rare usecase)  and `net` (see https://pkg.go.dev/net#hdr-Name_Resolution for the impact) to avoid any dependencies of the libc when building statically.
It also disable SQLite extension support to remove compile time warnings (but this was not used anyway)