### PR TITLE
Fix 1737

### DIFF
--- a/pkg/models/helpers.go
+++ b/pkg/models/helpers.go
@@ -41,6 +41,15 @@ func (e *Event) GetMeta(key string) string {
 	return ""
 }
 
+func (a *Alert) GetMeta(key string) string {
+	for _, meta := range a.Meta {
+		if meta.Key == key {
+			return meta.Value
+		}
+	}
+	return ""
+}
+
 func (s Source) GetValue() string {
 	if s.Value == nil {
 		return ""

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -55,8 +55,10 @@ func (e *Event) GetType() string {
 func (e *Event) GetMeta(key string) string {
 	if e.Type == OVFLW {
 		for _, alert := range e.Overflow.APIAlerts {
-			if alert.GetMeta(key) != "" {
-				return alert.GetMeta(key)
+			for _, event := range alert.Events {
+				if event.GetMeta(key) != "" {
+					return event.GetMeta(key)
+				}
 			}
 		}
 	} else if e.Type == LOG {

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -52,6 +52,23 @@ func (e *Event) GetType() string {
 	}
 }
 
+func (e *Event) GetMeta(key string) string {
+	if e.Type == OVFLW {
+		for _, alert := range e.Overflow.APIAlerts {
+			if alert.GetMeta(key) != "" {
+				return alert.GetMeta(key)
+			}
+		}
+	} else if e.Type == LOG {
+		for k, v := range e.Meta {
+			if k == key {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
 //Move in leakybuckets
 const (
 	Undefined = ""


### PR DESCRIPTION
fix https://github.com/crowdsecurity/crowdsec/issues/1737 by adding a `GetMeta()` func in the scope of `pkg/types` for `*types.Event`. It makes it avaible from the postoverflow point of view.

And there's no point adding `GetType()` in `*models.Event` because:
* the object definition doesn't hold the type
* this is accessible from profiles' expr and from the API and this makes no sens at that place.