### PR TITLE
acually postoverflow _before_ reprocessing

### DIFF
--- a/cmd/crowdsec/output.go
+++ b/cmd/crowdsec/output.go
@@ -144,10 +144,6 @@ LOOP:
 				buckets.Bucket_map.Delete(event.Overflow.Mapkey)
 				break
 			}
-			if event.Overflow.Reprocess {
-				log.Debugf("Overflow being reprocessed.")
-				input <- event
-			}
 			/* process post overflow parser nodes */
 			event, err := parser.Parse(postOverflowCTX, event, postOverflowNodes)
 			if err != nil {
@@ -157,6 +153,10 @@ LOOP:
 			if event.Overflow.Whitelisted {
 				log.Printf("[%s] is whitelisted, skip.", *event.Overflow.Alert.Message)
 				continue
+			}
+			if event.Overflow.Reprocess {
+				log.Debugf("Overflow being reprocessed.")
+				input <- event
 			}
 			if dumpStates {
 				continue


### PR DESCRIPTION
This PR fixes postoverflow behaviour.

In fact actually reprocessing event is done before postoverflow. So if event go through both reprocessing and postoverflow, it gets reprocessed without the postoverflow enrichement. Hence in practice this leads to enforce our users to make a choice between postorverflow and reprocessing. Having some enrichment at postoverflow time can be handy to process through a new scenario.

Making it get through postoverflow before reprocessing will allow the event to get enriched before getting reprocessed. This will allow more flexible postoverflow and reprocessing stuff for users.

As for the impact, this reprocessing stuff is only used in the ban-defcon-drop-range scenario, which is not impacted by this change.