### PR TITLE
make: accept BUILD_VENDOR_FLAGS variable

### DIFF
--- a/cmd/crowdsec-cli/Makefile
+++ b/cmd/crowdsec-cli/Makefile
@@ -21,7 +21,7 @@ BIN_PREFIX = $(PREFIX)"/usr/local/bin/"
 all: clean build
 
 build: clean
-	$(GOBUILD) $(LD_OPTS) -o $(BINARY_NAME)
+	$(GOBUILD) $(LD_OPTS) $(BUILD_VENDOR_FLAGS) -o $(BINARY_NAME)
 
 build-bincover: clean
 	$(GOTEST) . -tags testrunmain -coverpkg=$(go list github.com/crowdsecurity/crowdsec/... | grep -v -e 'pkg/database' -e 'plugins/notifications' -e 'pkg/protobufs' -e 'pkg/cwversions' -e 'pkg/cstest' -e 'pkg/models') -covermode=atomic $(LD_OPTS) -c -o $(BINARY_NAME_COVER)

--- a/cmd/crowdsec/Makefile
+++ b/cmd/crowdsec/Makefile
@@ -26,7 +26,7 @@ SYSTEMD_PATH_FILE = "/etc/systemd/system/crowdsec.service"
 all: clean test build
 
 build: clean
-	$(GOBUILD) $(LD_OPTS) -o $(CROWDSEC_BIN)
+	$(GOBUILD) $(LD_OPTS) $(BUILD_VENDOR_FLAGS) -o $(CROWDSEC_BIN)
 
 build-bincover: clean
 	$(GOTEST) . -tags testrunmain -coverpkg=$(go list github.com/crowdsecurity/crowdsec/... | grep -v -e 'pkg/database' -e 'plugins/notifications' -e 'pkg/protobufs' -e 'pkg/cwversions' -e 'pkg/cstest' -e 'pkg/models') -covermode=atomic $(LD_OPTS) -c -o $(CROWDSEC_BIN_COVER)

--- a/plugins/notifications/dummy/Makefile
+++ b/plugins/notifications/dummy/Makefile
@@ -14,7 +14,7 @@ GOGET = $(GOCMD) get
 BINARY_NAME = notification-dummy$(EXT)
 
 build: clean
-	$(GOBUILD) $(LD_OPTS) -o $(BINARY_NAME)
+	$(GOBUILD) $(LD_OPTS) $(BUILD_VENDOR_FLAGS) -o $(BINARY_NAME)
 
 clean:
 	@$(RM) $(BINARY_NAME) $(WIN_IGNORE_ERR)

--- a/plugins/notifications/email/Makefile
+++ b/plugins/notifications/email/Makefile
@@ -14,7 +14,7 @@ GOGET = $(GOCMD) get
 BINARY_NAME = notification-email$(EXT)
 
 build: clean
-	$(GOBUILD) $(LD_OPTS) -o $(BINARY_NAME)
+	$(GOBUILD) $(LD_OPTS) $(BUILD_VENDOR_FLAGS) -o $(BINARY_NAME)
 
 clean:
 	@$(RM) $(BINARY_NAME) $(WIN_IGNORE_ERR)

--- a/plugins/notifications/http/Makefile
+++ b/plugins/notifications/http/Makefile
@@ -14,7 +14,7 @@ GOGET = $(GOCMD) get
 BINARY_NAME = notification-http$(EXT)
 
 build: clean
-	$(GOBUILD) $(LD_OPTS) -o $(BINARY_NAME)
+	$(GOBUILD) $(LD_OPTS) $(BUILD_VENDOR_FLAGS) -o $(BINARY_NAME)
 
 clean:
 	@$(RM) $(BINARY_NAME) $(WIN_IGNORE_ERR)

--- a/plugins/notifications/slack/Makefile
+++ b/plugins/notifications/slack/Makefile
@@ -14,7 +14,7 @@ GOGET = $(GOCMD) get
 BINARY_NAME = notification-slack$(EXT)
 
 build: clean
-	$(GOBUILD) $(LD_OPTS) -o $(BINARY_NAME)
+	$(GOBUILD) $(LD_OPTS) $(BUILD_VENDOR_FLAGS) -o $(BINARY_NAME)
 
 clean:
 	@$(RM) $(BINARY_NAME) $(WIN_IGNORE_ERR)

--- a/plugins/notifications/splunk/Makefile
+++ b/plugins/notifications/splunk/Makefile
@@ -14,7 +14,7 @@ GOGET = $(GOCMD) get
 BINARY_NAME = notification-splunk$(EXT)
 
 build: clean
-	$(GOBUILD) $(LD_OPTS) -o $(BINARY_NAME)
+	$(GOBUILD) $(LD_OPTS) $(BUILD_VENDOR_FLAGS) -o $(BINARY_NAME)
 
 clean:
 	@$(RM) $(BINARY_NAME) $(WIN_IGNORE_ERR)


### PR DESCRIPTION
this is used for freebsd, to avoid patching the makefile on the fly