### PR TITLE
Check is TLS == "true" before to enable in LAPI

### DIFF
--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -90,7 +90,7 @@ if [ "$GID" != "" ]; then
     fi
 fi
 
-if [ "$USE_TLS" != "" ]; then
+if [ "${USE_TLS,,}" == "true" ]; then
     yq -i eval ".api.server.tls.cert_file = \"$CERT_FILE\"" "$CS_CONFIG_FILE"
     yq -i eval ".api.server.tls.key_file = \"$KEY_FILE\"" "$CS_CONFIG_FILE"
     yq -i eval '... comments=""' "$CS_CONFIG_FILE"


### PR DESCRIPTION
We need to check if TLS is true before to enable in LAPI, see https://github.com/crowdsecurity/crowdsec/issues/1794