### PR TITLE
print cscli usage in color, fix windows terminal detection

### DIFF
--- a/cmd/crowdsec-cli/alerts.go
+++ b/cmd/crowdsec-cli/alerts.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/go-openapi/strfmt"
-	colorable "github.com/mattn/go-colorable"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -86,7 +86,7 @@ func AlertsToTable(alerts *models.GetAlertsResponse, printMachine bool) error {
 			fmt.Println("No active alerts")
 			return nil
 		}
-		alertsTable(colorable.NewColorableStdout(), alerts, printMachine)
+		alertsTable(color.Output, alerts, printMachine)
 	}
 	return nil
 }
@@ -110,12 +110,12 @@ func DisplayOneAlert(alert *models.Alert, withDetail bool) error {
 		fmt.Printf(" - Begin      : %s\n", *alert.StartAt)
 		fmt.Printf(" - End        : %s\n\n", *alert.StopAt)
 
-		alertDecisionsTable(colorable.NewColorableStdout(), alert)
+		alertDecisionsTable(color.Output, alert)
 
 		if withDetail {
 			fmt.Printf("\n - Events  :\n")
 			for _, event := range alert.Events {
-				alertEventTable(colorable.NewColorableStdout(), event)
+				alertEventTable(color.Output, event)
 			}
 		}
 	}

--- a/cmd/crowdsec-cli/bouncers.go
+++ b/cmd/crowdsec-cli/bouncers.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"time"
 
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -92,7 +92,7 @@ Note: This command requires database direct access, so is intended to be run on 
 		Args:              cobra.ExactArgs(0),
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, arg []string) {
-			err := getBouncers(colorable.NewColorableStdout(), dbClient)
+			err := getBouncers(color.Output, dbClient)
 			if err != nil {
 				log.Fatalf("unable to list bouncers: %s", err)
 			}

--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -6,17 +6,17 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
-	"github.com/go-openapi/strfmt"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-
-	"gopkg.in/yaml.v2"
 )
 
 var CAPIURLPrefix string = "v2"

--- a/cmd/crowdsec-cli/collections.go
+++ b/cmd/crowdsec-cli/collections.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -173,7 +173,7 @@ func NewCollectionsCmd() *cobra.Command {
 		Args:              cobra.ExactArgs(0),
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			ListItems(colorable.NewColorableStdout(), []string{cwhub.COLLECTIONS}, args, false, true, all)
+			ListItems(color.Output, []string{cwhub.COLLECTIONS}, args, false, true, all)
 		},
 	}
 	cmdCollectionsList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List disabled items as well")

--- a/cmd/crowdsec-cli/config.go
+++ b/cmd/crowdsec-cli/config.go
@@ -8,15 +8,14 @@ import (
 	"path/filepath"
 
 	"github.com/antonmedv/expr"
-
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 )
 
 type OldAPICfg struct {

--- a/cmd/crowdsec-cli/console.go
+++ b/cmd/crowdsec-cli/console.go
@@ -10,8 +10,8 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/fatih/color"
 	"github.com/go-openapi/strfmt"
-	colorable "github.com/mattn/go-colorable"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -194,7 +194,7 @@ Disable given information push to the central API.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			switch csConfig.Cscli.Output {
 			case "human":
-				cmdConsoleStatusTable(colorable.NewColorableStdout(), *csConfig)
+				cmdConsoleStatusTable(color.Output, *csConfig)
 			case "json":
 				data, err := json.MarshalIndent(csConfig.API.Server.ConsoleConfig, "", "  ")
 				if err != nil {

--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -13,11 +13,11 @@ import (
 	"unicode"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/crowdsecurity/crowdsec/pkg/metabase"
-
 	"github.com/pbnjay/memory"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/crowdsecurity/crowdsec/pkg/metabase"
 )
 
 var (

--- a/cmd/crowdsec-cli/decisions.go
+++ b/cmd/crowdsec-cli/decisions.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/go-openapi/strfmt"
 	"github.com/jszwec/csvutil"
-	colorable "github.com/mattn/go-colorable"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -97,7 +97,7 @@ func DecisionsToTable(alerts *models.GetAlertsResponse, printMachine bool) error
 			fmt.Println("No active decisions")
 			return nil
 		}
-		decisionsTable(colorable.NewColorableStdout(), alerts, printMachine)
+		decisionsTable(color.Output, alerts, printMachine)
 		if skipped > 0 {
 			fmt.Printf("%d duplicated entries skipped\n", skipped)
 		}

--- a/cmd/crowdsec-cli/explain.go
+++ b/cmd/crowdsec-cli/explain.go
@@ -8,10 +8,11 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/crowdsecurity/crowdsec/pkg/cstest"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/crowdsecurity/crowdsec/pkg/cstest"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 func NewExplainCmd() *cobra.Command {

--- a/cmd/crowdsec-cli/hub.go
+++ b/cmd/crowdsec-cli/hub.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -57,7 +57,7 @@ cscli hub update # Download list of available configurations from the hub
 				log.Info(v)
 			}
 			cwhub.DisplaySummary()
-			ListItems(colorable.NewColorableStdout(), []string{
+			ListItems(color.Output, []string{
 				cwhub.COLLECTIONS, cwhub.PARSERS, cwhub.SCENARIOS, cwhub.PARSERS_OVFLW,
 			}, args, true, false, all)
 		},

--- a/cmd/crowdsec-cli/hubtest.go
+++ b/cmd/crowdsec-cli/hubtest.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/enescakir/emoji"
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -273,7 +273,7 @@ cscli hubtest create my-scenario-test --parsers crowdsecurity/nginx --scenarios 
 				}
 			}
 			if csConfig.Cscli.Output == "human" {
-				hubTestResultTable(colorable.NewColorableStdout(), testResult)
+				hubTestResultTable(color.Output, testResult)
 			} else if csConfig.Cscli.Output == "json" {
 				jsonResult := make(map[string][]string, 0)
 				jsonResult["success"] = make([]string, 0)
@@ -355,7 +355,7 @@ cscli hubtest create my-scenario-test --parsers crowdsecurity/nginx --scenarios 
 
 			switch csConfig.Cscli.Output {
 			case "human":
-				hubTestListTable(colorable.NewColorableStdout(), HubTest.Tests)
+				hubTestListTable(color.Output, HubTest.Tests)
 			case "json":
 				j, err := json.MarshalIndent(HubTest.Tests, " ", "  ")
 				if err != nil {
@@ -430,11 +430,11 @@ cscli hubtest create my-scenario-test --parsers crowdsecurity/nginx --scenarios 
 
 			if csConfig.Cscli.Output == "human" {
 				if showParserCov || showAll {
-					hubTestParserCoverageTable(colorable.NewColorableStdout(), parserCoverage)
+					hubTestParserCoverageTable(color.Output, parserCoverage)
 				}
 
 				if showScenarioCov || showAll {
-					hubTestScenarioCoverageTable(colorable.NewColorableStdout(), scenarioCoverage)
+					hubTestScenarioCoverageTable(color.Output, scenarioCoverage)
 				}
 				fmt.Println()
 				if showParserCov || showAll {

--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -7,16 +7,17 @@ import (
 	"os"
 	"strings"
 
-	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
-	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
-	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
-	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
-	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
+
+	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
+	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
+	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
+	"github.com/crowdsecurity/crowdsec/pkg/models"
 )
 
 var LAPIURLPrefix string = "v1"

--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/enescakir/emoji"
+	"github.com/fatih/color"
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
-	colorable "github.com/mattn/go-colorable"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -189,7 +189,7 @@ Note: This command requires database direct access, so is intended to be run on 
 			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			err := getAgents(colorable.NewColorableStdout(), dbClient)
+			err := getAgents(color.Output, dbClient)
 			if err != nil {
 				log.Fatalf("unable to list machines: %s", err)
 			}

--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+	cc "github.com/ivanpirog/coloredcobra"
 
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
@@ -140,6 +141,16 @@ It is meant to allow you to manage bans, parsers/scenarios/etc, api and generall
 		SilenceUsage:      true,
 		/*TBD examples*/
 	}
+
+	cc.Init(&cc.Config{
+		RootCmd:       rootCmd,
+		Headings:      cc.Yellow,
+		Commands:      cc.Green + cc.Bold,
+		Example:       cc.Italic,
+		ExecName:      cc.Bold,
+		Flags:         cc.Green,
+	})
+
 	var cmdDocGen = &cobra.Command{
 		Use:               "doc",
 		Short:             "Generate the documentation in `./doc/`. Directory must exist.",

--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 
 	"github.com/confluentinc/bincover"
+	"github.com/fatih/color"
+	cc "github.com/ivanpirog/coloredcobra"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
-	cc "github.com/ivanpirog/coloredcobra"
 
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
@@ -143,13 +144,14 @@ It is meant to allow you to manage bans, parsers/scenarios/etc, api and generall
 	}
 
 	cc.Init(&cc.Config{
-		RootCmd:       rootCmd,
-		Headings:      cc.Yellow,
-		Commands:      cc.Green + cc.Bold,
-		Example:       cc.Italic,
-		ExecName:      cc.Bold,
-		Flags:         cc.Green,
+		RootCmd:  rootCmd,
+		Headings: cc.Yellow,
+		Commands: cc.Green + cc.Bold,
+		Example:  cc.Italic,
+		ExecName: cc.Bold,
+		Flags:    cc.Green,
 	})
+	rootCmd.SetOut(color.Output)
 
 	var cmdDocGen = &cobra.Command{
 		Use:               "doc",
@@ -178,7 +180,7 @@ It is meant to allow you to manage bans, parsers/scenarios/etc, api and generall
 
 	rootCmd.PersistentFlags().StringVarP(&ConfigFilePath, "config", "c", csconfig.DefaultConfigPath("config.yaml"), "path to crowdsec config file")
 	rootCmd.PersistentFlags().StringVarP(&OutputFormat, "output", "o", "", "Output format: human, json, raw.")
-	rootCmd.PersistentFlags().StringVarP(&OutputColor, "color", "", csconfig.ColorDefault(), "Output color: yes, no, auto.")
+	rootCmd.PersistentFlags().StringVarP(&OutputColor, "color", "", "auto", "Output color: yes, no, auto.")
 	rootCmd.PersistentFlags().BoolVar(&dbg_lvl, "debug", false, "Set logging to debug.")
 	rootCmd.PersistentFlags().BoolVar(&nfo_lvl, "info", false, "Set logging to info.")
 	rootCmd.PersistentFlags().BoolVar(&wrn_lvl, "warning", false, "Set logging to warning.")

--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -144,12 +144,16 @@ It is meant to allow you to manage bans, parsers/scenarios/etc, api and generall
 	}
 
 	cc.Init(&cc.Config{
-		RootCmd:  rootCmd,
+		RootCmd: rootCmd,
 		Headings: cc.Yellow,
 		Commands: cc.Green + cc.Bold,
-		Example:  cc.Italic,
+		CmdShortDescr: cc.Cyan,
+		Example: cc.Italic,
 		ExecName: cc.Bold,
-		Flags:    cc.Green,
+		Aliases: cc.Bold + cc.Italic,
+		FlagsDataType: cc.White,
+		Flags: cc.Green,
+		FlagsDescr: cc.Cyan,
 	})
 	rootCmd.SetOut(color.Output)
 

--- a/cmd/crowdsec-cli/main_test.go
+++ b/cmd/crowdsec-cli/main_test.go
@@ -3,9 +3,9 @@
 package main
 
 import (
-	"github.com/confluentinc/bincover"
-
 	"testing"
+
+	"github.com/confluentinc/bincover"
 )
 
 func TestBincoverRunMain(t *testing.T) {

--- a/cmd/crowdsec-cli/metrics.go
+++ b/cmd/crowdsec-cli/metrics.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prom2json"
 	log "github.com/sirupsen/logrus"
@@ -276,7 +276,7 @@ func NewMetricsCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
-			err := FormatPrometheusMetrics(colorable.NewColorableStdout(), prometheusURL+"/metrics", csConfig.Cscli.Output)
+			err := FormatPrometheusMetrics(color.Output, prometheusURL+"/metrics", csConfig.Cscli.Output)
 			if err != nil {
 				log.Fatalf("could not fetch prometheus metrics: %s", err)
 			}

--- a/cmd/crowdsec-cli/notifications.go
+++ b/cmd/crowdsec-cli/notifications.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/go-openapi/strfmt"
-	colorable "github.com/mattn/go-colorable"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -68,7 +68,7 @@ func NewNotificationsCmd() *cobra.Command {
 			}
 
 			if csConfig.Cscli.Output == "human" {
-				notificationListTable(colorable.NewColorableStdout(), ncfgs)
+				notificationListTable(color.Output, ncfgs)
 			} else if csConfig.Cscli.Output == "json" {
 				x, err := json.MarshalIndent(ncfgs, "", " ")
 				if err != nil {

--- a/cmd/crowdsec-cli/parsers.go
+++ b/cmd/crowdsec-cli/parsers.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -164,7 +164,7 @@ cscli parsers remove crowdsecurity/sshd-logs
 cscli parser list crowdsecurity/xxx`,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			ListItems(colorable.NewColorableStdout(), []string{cwhub.PARSERS}, args, false, true, all)
+			ListItems(color.Output, []string{cwhub.PARSERS}, args, false, true, all)
 		},
 	}
 	cmdParsersList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List disabled items as well")

--- a/cmd/crowdsec-cli/postoverflows.go
+++ b/cmd/crowdsec-cli/postoverflows.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -162,7 +162,7 @@ func NewPostOverflowsCmd() *cobra.Command {
 cscli postoverflows list crowdsecurity/xxx`,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			ListItems(colorable.NewColorableStdout(), []string{cwhub.PARSERS_OVFLW}, args, false, true, all)
+			ListItems(color.Output, []string{cwhub.PARSERS_OVFLW}, args, false, true, all)
 		},
 	}
 	cmdPostOverflowsList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List disabled items as well")

--- a/cmd/crowdsec-cli/scenarios.go
+++ b/cmd/crowdsec-cli/scenarios.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -167,7 +167,7 @@ cscli scenarios remove crowdsecurity/ssh-bf
 cscli scenarios list crowdsecurity/xxx`,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			ListItems(colorable.NewColorableStdout(), []string{cwhub.SCENARIOS}, args, false, true, all)
+			ListItems(color.Output, []string{cwhub.SCENARIOS}, args, false, true, all)
 		},
 	}
 	cmdScenariosList.PersistentFlags().BoolVarP(&all, "all", "a", false, "List disabled items as well")

--- a/cmd/crowdsec-cli/simulation.go
+++ b/cmd/crowdsec-cli/simulation.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
+
+	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 )
 
 func addToExclusion(name string) error {

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prom2json"
 	log "github.com/sirupsen/logrus"
@@ -304,18 +304,18 @@ func ShowMetrics(hubItem *cwhub.Item) {
 	switch hubItem.Type {
 	case cwhub.PARSERS:
 		metrics := GetParserMetric(prometheusURL, hubItem.Name)
-		parserMetricsTable(colorable.NewColorableStdout(), hubItem.Name, metrics)
+		parserMetricsTable(color.Output, hubItem.Name, metrics)
 	case cwhub.SCENARIOS:
 		metrics := GetScenarioMetric(prometheusURL, hubItem.Name)
-		scenarioMetricsTable(colorable.NewColorableStdout(), hubItem.Name, metrics)
+		scenarioMetricsTable(color.Output, hubItem.Name, metrics)
 	case cwhub.COLLECTIONS:
 		for _, item := range hubItem.Parsers {
 			metrics := GetParserMetric(prometheusURL, item)
-			parserMetricsTable(colorable.NewColorableStdout(), item, metrics)
+			parserMetricsTable(color.Output, item, metrics)
 		}
 		for _, item := range hubItem.Scenarios {
 			metrics := GetScenarioMetric(prometheusURL, item)
-			scenarioMetricsTable(colorable.NewColorableStdout(), item, metrics)
+			scenarioMetricsTable(color.Output, item, metrics)
 		}
 		for _, item := range hubItem.Collections {
 			hubItem = cwhub.GetItem(cwhub.COLLECTIONS, item)

--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,7 @@ require (
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/ivanpirog/coloredcobra v1.0.1 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,7 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creachadair/staticfile v0.1.3/go.mod h1:a3qySzCIXEprDGxk6tSxSI+dBBdLzqeBOMhZ+o2d3pM=
@@ -438,6 +439,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/ivanpirog/coloredcobra v1.0.1 h1:aURSdEmlR90/tSiWS0dMjdwOvCVUeYLfltLfbgNxrN4=
+github.com/ivanpirog/coloredcobra v1.0.1/go.mod h1:iho4nEKcnwZFiniGSdcgdvRgZNjxm+h20acv8vqmN6Q=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -721,6 +724,7 @@ github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
 github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/pkg/csconfig/config.go
+++ b/pkg/csconfig/config.go
@@ -95,7 +95,7 @@ func NewDefaultConfig() *Config {
 
 	cscliCfg := CscliCfg{
 		Output: "human",
-		Color:  ColorDefault(),
+		Color:  "auto",
 	}
 
 	apiCfg := APICfg{

--- a/pkg/csconfig/cscli.go
+++ b/pkg/csconfig/cscli.go
@@ -1,9 +1,5 @@
 package csconfig
 
-import (
-	"runtime"
-)
-
 /*cscli specific config, such as hub directory*/
 type CscliCfg struct {
 	Output             string            `yaml:"output,omitempty"`
@@ -17,13 +13,6 @@ type CscliCfg struct {
 	HubIndexFile       string            `yaml:"-"`
 	SimulationFilePath string            `yaml:"-"`
 	PrometheusUrl      string            `yaml:"prometheus_uri"`
-}
-
-func ColorDefault() string {
-	if runtime.GOOS == "windows" {
-		return "no"
-	}
-	return "auto"
 }
 
 func (c *Config) LoadCSCLI() error {


### PR DESCRIPTION
With this, usage of cscli is colored except when in a pipe (tested linux, windows cmd, powershell 7.x).
Same behavior with the tables, and if color is disabled, so are unicode characters.
I took the opportunity to reorganize the imports in cmd/crowdsec-cli

![Screenshot from 2022-10-12 16-59-45](https://user-images.githubusercontent.com/92726601/195377933-c014949f-0f40-42f3-bb4c-512ebf3a1561.png)
