### PR TITLE
rename pkg/cstest -> pkg/hubtest

### DIFF
--- a/.github/workflows/bats-postgres.yml
+++ b/.github/workflows/bats-postgres.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 20
     services:
       database:
-        image: postgres:latest
+        image: postgres:14
         env:
           POSTGRES_PASSWORD: "secret"
         ports:

--- a/cmd/crowdsec-cli/explain.go
+++ b/cmd/crowdsec-cli/explain.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/crowdsecurity/crowdsec/pkg/cstest"
+	"github.com/crowdsecurity/crowdsec/pkg/hubtest"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
@@ -21,7 +21,7 @@ func NewExplainCmd() *cobra.Command {
 	var dsn string
 	var logLine string
 	var logType string
-	var opts cstest.DumpOpts
+	var opts hubtest.DumpOpts
 	var err error
 
 	var cmdExplain = &cobra.Command{
@@ -122,20 +122,20 @@ tail -n 5 myfile.log | cscli explain --type nginx -f -
 					log.Fatalf("unable to remove tmp log file '%s': %+v", tmpFile, err)
 				}
 			}
-			parserDumpFile := filepath.Join(dir, cstest.ParserResultFileName)
-			bucketStateDumpFile := filepath.Join(dir, cstest.BucketPourResultFileName)
+			parserDumpFile := filepath.Join(dir, hubtest.ParserResultFileName)
+			bucketStateDumpFile := filepath.Join(dir, hubtest.BucketPourResultFileName)
 
-			parserDump, err := cstest.LoadParserDump(parserDumpFile)
+			parserDump, err := hubtest.LoadParserDump(parserDumpFile)
 			if err != nil {
 				log.Fatalf("unable to load parser dump result: %s", err)
 			}
 
-			bucketStateDump, err := cstest.LoadBucketPourDump(bucketStateDumpFile)
+			bucketStateDump, err := hubtest.LoadBucketPourDump(bucketStateDumpFile)
 			if err != nil {
 				log.Fatalf("unable to load bucket dump result: %s", err)
 			}
 
-			cstest.DumpTree(*parserDump, *bucketStateDump, opts)
+			hubtest.DumpTree(*parserDump, *bucketStateDump, opts)
 		},
 	}
 	cmdExplain.PersistentFlags().StringVarP(&logFile, "file", "f", "", "Log file to test")

--- a/cmd/crowdsec-cli/hubtest.go
+++ b/cmd/crowdsec-cli/hubtest.go
@@ -15,11 +15,11 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/crowdsecurity/crowdsec/pkg/cstest"
+	"github.com/crowdsecurity/crowdsec/pkg/hubtest"
 )
 
 var (
-	HubTest cstest.HubTest
+	HubTest hubtest.HubTest
 )
 
 func NewHubTestCmd() *cobra.Command {
@@ -37,7 +37,7 @@ func NewHubTestCmd() *cobra.Command {
 		DisableAutoGenTag: true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			var err error
-			HubTest, err = cstest.NewHubTest(hubPath, crowdsecPath, cscliPath)
+			HubTest, err = hubtest.NewHubTest(hubPath, crowdsecPath, cscliPath)
 			if err != nil {
 				log.Fatalf("unable to load hubtest: %+v", err)
 			}
@@ -86,7 +86,7 @@ cscli hubtest create my-scenario-test --parsers crowdsecurity/nginx --scenarios 
 			logFile.Close()
 
 			// create empty parser assertion file
-			parserAssertFilePath := filepath.Join(testPath, cstest.ParserAssertFileName)
+			parserAssertFilePath := filepath.Join(testPath, hubtest.ParserAssertFileName)
 			parserAssertFile, err := os.Create(parserAssertFilePath)
 			if err != nil {
 				log.Fatal(err)
@@ -94,7 +94,7 @@ cscli hubtest create my-scenario-test --parsers crowdsecurity/nginx --scenarios 
 			parserAssertFile.Close()
 
 			// create empty scenario assertion file
-			scenarioAssertFilePath := filepath.Join(testPath, cstest.ScenarioAssertFileName)
+			scenarioAssertFilePath := filepath.Join(testPath, hubtest.ScenarioAssertFileName)
 			scenarioAssertFile, err := os.Create(scenarioAssertFilePath)
 			if err != nil {
 				log.Fatal(err)
@@ -112,7 +112,7 @@ cscli hubtest create my-scenario-test --parsers crowdsecurity/nginx --scenarios 
 				postoverflows = append(postoverflows, "")
 			}
 
-			configFileData := &cstest.HubTestItemConfig{
+			configFileData := &hubtest.HubTestItemConfig{
 				Parsers:       parsers,
 				Scenarios:     scenarios,
 				PostOVerflows: postoverflows,
@@ -336,8 +336,8 @@ cscli hubtest create my-scenario-test --parsers crowdsecurity/nginx --scenarios 
 				fmt.Printf("  Test name                   :  %s\n", test.Name)
 				fmt.Printf("  Test path                   :  %s\n", test.Path)
 				fmt.Printf("  Log file                    :  %s\n", filepath.Join(test.Path, test.Config.LogFile))
-				fmt.Printf("  Parser assertion file       :  %s\n", filepath.Join(test.Path, cstest.ParserAssertFileName))
-				fmt.Printf("  Scenario assertion file     :  %s\n", filepath.Join(test.Path, cstest.ScenarioAssertFileName))
+				fmt.Printf("  Parser assertion file       :  %s\n", filepath.Join(test.Path, hubtest.ParserAssertFileName))
+				fmt.Printf("  Scenario assertion file     :  %s\n", filepath.Join(test.Path, hubtest.ScenarioAssertFileName))
 				fmt.Printf("  Configuration File          :  %s\n", filepath.Join(test.Path, "config.yaml"))
 			}
 		},
@@ -381,8 +381,8 @@ cscli hubtest create my-scenario-test --parsers crowdsecurity/nginx --scenarios 
 				log.Fatalf("unable to load all tests: %+v", err)
 			}
 			var err error
-			scenarioCoverage := []cstest.ScenarioCoverage{}
-			parserCoverage := []cstest.ParserCoverage{}
+			scenarioCoverage := []hubtest.ScenarioCoverage{}
+			parserCoverage := []hubtest.ParserCoverage{}
 			scenarioCoveragePercent := 0
 			parserCoveragePercent := 0
 
@@ -526,8 +526,8 @@ cscli hubtest create my-scenario-test --parsers crowdsecurity/nginx --scenarios 
 						log.Fatalf("unable to load scenario result after run: %s", err)
 					}
 				}
-				opts := cstest.DumpOpts{}
-				cstest.DumpTree(*test.ParserAssert.TestData, *test.ScenarioAssert.PourData, opts)
+				opts := hubtest.DumpOpts{}
+				hubtest.DumpTree(*test.ParserAssert.TestData, *test.ScenarioAssert.PourData, opts)
 			}
 		},
 	}

--- a/cmd/crowdsec-cli/hubtest_table.go
+++ b/cmd/crowdsec-cli/hubtest_table.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aquasecurity/table"
 	"github.com/enescakir/emoji"
 
-	"github.com/crowdsecurity/crowdsec/pkg/cstest"
+	"github.com/crowdsecurity/crowdsec/pkg/hubtest"
 )
 
 func hubTestResultTable(out io.Writer, testResult map[string]bool) {
@@ -28,7 +28,7 @@ func hubTestResultTable(out io.Writer, testResult map[string]bool) {
 	t.Render()
 }
 
-func hubTestListTable(out io.Writer, tests []*cstest.HubTestItem) {
+func hubTestListTable(out io.Writer, tests []*hubtest.HubTestItem) {
 	t := newLightTable(out)
 	t.SetHeaders("Name", "Path")
 	t.SetHeaderAlignment(table.AlignLeft, table.AlignLeft)
@@ -41,7 +41,7 @@ func hubTestListTable(out io.Writer, tests []*cstest.HubTestItem) {
 	t.Render()
 }
 
-func hubTestParserCoverageTable(out io.Writer, coverage []cstest.ParserCoverage) {
+func hubTestParserCoverageTable(out io.Writer, coverage []hubtest.ParserCoverage) {
 	t := newLightTable(out)
 	t.SetHeaders("Parser", "Status", "Number of tests")
 	t.SetHeaderAlignment(table.AlignLeft, table.AlignLeft, table.AlignLeft)
@@ -60,7 +60,7 @@ func hubTestParserCoverageTable(out io.Writer, coverage []cstest.ParserCoverage)
 	t.Render()
 }
 
-func hubTestScenarioCoverageTable(out io.Writer, coverage []cstest.ScenarioCoverage) {
+func hubTestScenarioCoverageTable(out io.Writer, coverage []hubtest.ScenarioCoverage) {
 	t := newLightTable(out)
 	t.SetHeaders("Scenario", "Status", "Number of tests")
 	t.SetHeaderAlignment(table.AlignLeft, table.AlignLeft, table.AlignLeft)

--- a/pkg/cstest/utils.go
+++ b/pkg/cstest/utils.go
@@ -1,114 +1,11 @@
 package cstest
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func Copy(sourceFile string, destinationFile string) error {
-	input, err := os.ReadFile(sourceFile)
-	if err != nil {
-		return err
-	}
-
-	err = os.WriteFile(destinationFile, input, 0644)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// checkPathNotContained returns an error if 'subpath' is inside 'path'
-func checkPathNotContained(path string, subpath string) error {
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return err
-	}
-
-	absSubPath, err := filepath.Abs(subpath)
-	if err != nil {
-		return err
-	}
-
-	current := absSubPath
-	for {
-		if current == absPath {
-			return fmt.Errorf("cannot copy a folder onto itself")
-		}
-		up := filepath.Dir(current)
-		if current == up {
-			break
-		}
-		current = up
-	}
-	return nil
-}
-
-func CopyDir(src string, dest string) error {
-	err := checkPathNotContained(src, dest)
-	if err != nil {
-		return err
-	}
-
-	f, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-
-	file, err := f.Stat()
-	if err != nil {
-		return err
-	}
-	if !file.IsDir() {
-		return fmt.Errorf("Source " + file.Name() + " is not a directory!")
-	}
-
-	err = os.MkdirAll(dest, 0755)
-	if err != nil {
-		return err
-	}
-
-	files, err := os.ReadDir(src)
-	if err != nil {
-		return err
-	}
-
-	for _, f := range files {
-
-		if f.IsDir() {
-
-			err = CopyDir(src+"/"+f.Name(), dest+"/"+f.Name())
-			if err != nil {
-				return err
-			}
-
-		}
-
-		if !f.IsDir() {
-
-			content, err := os.ReadFile(src + "/" + f.Name())
-			if err != nil {
-				return err
-
-			}
-
-			err = os.WriteFile(dest+"/"+f.Name(), content, 0755)
-			if err != nil {
-				return err
-
-			}
-
-		}
-
-	}
-
-	return nil
-}
 
 func AssertErrorContains(t *testing.T, err error, expectedErr string) {
 	t.Helper()

--- a/pkg/hubtest/coverage.go
+++ b/pkg/hubtest/coverage.go
@@ -1,4 +1,4 @@
-package cstest
+package hubtest
 
 import (
 	"bufio"

--- a/pkg/hubtest/hubtest.go
+++ b/pkg/hubtest/hubtest.go
@@ -1,4 +1,4 @@
-package cstest
+package hubtest
 
 import (
 	"fmt"

--- a/pkg/hubtest/hubtest_item.go
+++ b/pkg/hubtest/hubtest_item.go
@@ -1,4 +1,4 @@
-package cstest
+package hubtest
 
 import (
 	"fmt"

--- a/pkg/hubtest/parser_assert.go
+++ b/pkg/hubtest/parser_assert.go
@@ -1,4 +1,4 @@
-package cstest
+package hubtest
 
 import (
 	"bufio"

--- a/pkg/hubtest/scenario_assert.go
+++ b/pkg/hubtest/scenario_assert.go
@@ -1,4 +1,4 @@
-package cstest
+package hubtest
 
 import (
 	"bufio"

--- a/pkg/hubtest/utils.go
+++ b/pkg/hubtest/utils.go
@@ -1,0 +1,107 @@
+package hubtest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func Copy(sourceFile string, destinationFile string) error {
+	input, err := os.ReadFile(sourceFile)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(destinationFile, input, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkPathNotContained returns an error if 'subpath' is inside 'path'
+func checkPathNotContained(path string, subpath string) error {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+
+	absSubPath, err := filepath.Abs(subpath)
+	if err != nil {
+		return err
+	}
+
+	current := absSubPath
+	for {
+		if current == absPath {
+			return fmt.Errorf("cannot copy a folder onto itself")
+		}
+		up := filepath.Dir(current)
+		if current == up {
+			break
+		}
+		current = up
+	}
+	return nil
+}
+
+func CopyDir(src string, dest string) error {
+	err := checkPathNotContained(src, dest)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+
+	file, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	if !file.IsDir() {
+		return fmt.Errorf("Source " + file.Name() + " is not a directory!")
+	}
+
+	err = os.MkdirAll(dest, 0755)
+	if err != nil {
+		return err
+	}
+
+	files, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+
+		if f.IsDir() {
+
+			err = CopyDir(src+"/"+f.Name(), dest+"/"+f.Name())
+			if err != nil {
+				return err
+			}
+
+		}
+
+		if !f.IsDir() {
+
+			content, err := os.ReadFile(src + "/" + f.Name())
+			if err != nil {
+				return err
+
+			}
+
+			err = os.WriteFile(dest+"/"+f.Name(), content, 0755)
+			if err != nil {
+				return err
+
+			}
+
+		}
+
+	}
+
+	return nil
+}

--- a/pkg/hubtest/utils_test.go
+++ b/pkg/hubtest/utils_test.go
@@ -1,4 +1,4 @@
-package cstest
+package hubtest
 
 import (
 	"testing"


### PR DESCRIPTION
keep pkg/cstest for generic helper functions
this also avoids circular imports in test files