### PR TITLE
change warning to debug when directories are missing in hub sync

### DIFF
--- a/pkg/cwhub/loader.go
+++ b/pkg/cwhub/loader.go
@@ -29,7 +29,7 @@ func parser_visit(path string, f os.DirEntry, err error) error {
 	var stage string
 
 	if err != nil {
-		log.Warningf("error while syncing hub dir: %v", err)
+		log.Debugf("while syncing hub dir: %s", err)
 		// there is a path error, we ignore the file
 		return nil
 	}


### PR DESCRIPTION
to avoid this

cscli hub update
INFO[18-10-2022 10:07:37 AM] Wrote new 474882 bytes index to /home/marco/src/crowdsec/tests/local/etc/crowdsec/hub/.index.json
WARN[18-10-2022 10:07:37 AM] error while syncing hub dir: lstat /home/marco/src/crowdsec/tests/local/etc/crowdsec/postoverflows: no such file or directory
WARN[18-10-2022 10:07:37 AM] error while syncing hub dir: lstat /home/marco/src/crowdsec/tests/local/etc/crowdsec/hub/postoverflows: no such file or directory
WARN[18-10-2022 10:07:37 AM] error while syncing hub dir: lstat /home/marco/src/crowdsec/tests/local/etc/crowdsec/postoverflows: no such file or directory
WARN[18-10-2022 10:07:37 AM] error while syncing hub dir: lstat /home/marco/src/crowdsec/tests/local/etc/crowdsec/hub/postoverflows: no such file or directory