### PR TITLE
fix(ci): create hub badges, repository dispatch only on crowdsecurity/crowdsec

### DIFF
--- a/.github/workflows/bats-hub.yml
+++ b/.github/workflows/bats-hub.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: "Create Parsers badge"
       uses: schneegans/dynamic-badges-action@v1.1.0
-      if: ${{ github.ref == 'refs/heads/master' }}
+      if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'crowdsecurity' }}
       with:
         auth: ${{ secrets.GIST_BADGES_SECRET }}
         gistID: ${{ secrets.GIST_BADGES_ID }}
@@ -67,7 +67,7 @@ jobs:
 
     - name: "Create Scenarios badge"
       uses: schneegans/dynamic-badges-action@v1.1.0
-      if: ${{ github.ref == 'refs/heads/master' }}
+      if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'crowdsecurity' }}
       with:
         auth: ${{ secrets.GIST_BADGES_SECRET }}
         gistID: ${{ secrets.GIST_BADGES_ID }}

--- a/.github/workflows/dispatch_ci_hub.yaml
+++ b/.github/workflows/dispatch_ci_hub.yaml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1
+        if: ${{ github.repository_owner == 'crowdsecurity' }}
         with:
           token: ${{ secrets.DISPATCH_TOKEN }}
           event-type: trigger_ci_hub

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.dylib
 *~
 .pc
+.vscode
 
 # Test binaries, built with `go test -c`
 *.test


### PR DESCRIPTION
This avoids workflow errors when working in a fork.