### PR TITLE
acquisition: validate datasources before configuration (static checks)

### DIFF
--- a/pkg/acquisition/acquisition.go
+++ b/pkg/acquisition/acquisition.go
@@ -155,7 +155,7 @@ func LoadAcquisitionFromFile(config *csconfig.CrowdsecServiceCfg) ([]DataSource,
 			var idx int
 			err = dec.Decode(&sub)
 			if err != nil {
-				if ! errors.Is(err, io.EOF) {
+				if !errors.Is(err, io.EOF) {
 					return nil, fmt.Errorf("failed to yaml decode %s: %w", acquisFile, err)
 				}
 				log.Tracef("End of yaml file")

--- a/pkg/acquisition/acquisition.go
+++ b/pkg/acquisition/acquisition.go
@@ -64,7 +64,7 @@ func DataSourceConfigure(commonConfig configuration.DataSourceCommonCfg) (*DataS
 	// once to DataSourceCommonCfg, and then later to the dedicated type of the datasource
 	yamlConfig, err := yaml.Marshal(commonConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to marshal back interface: %v", err)
+		return nil, fmt.Errorf("unable to marshal back interface: %w", err)
 	}
 	if dataSrc := GetDataSourceIface(commonConfig.Source); dataSrc != nil {
 		/* this logger will then be used by the datasource at runtime */
@@ -96,9 +96,8 @@ func DataSourceConfigure(commonConfig configuration.DataSourceCommonCfg) (*DataS
 	return nil, fmt.Errorf("cannot find source %s", commonConfig.Source)
 }
 
-//detectBackwardCompatAcquis : try to magically detect the type for backward compat (type was not mandatory then)
+// detectBackwardCompatAcquis: try to magically detect the type for backward compat (type was not mandatory then)
 func detectBackwardCompatAcquis(sub configuration.DataSourceCommonCfg) string {
-
 	if _, ok := sub.Config["filename"]; ok {
 		return "file"
 	}

--- a/pkg/acquisition/acquisition.go
+++ b/pkg/acquisition/acquisition.go
@@ -1,10 +1,16 @@
 package acquisition
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+	tomb "gopkg.in/tomb.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
 	cloudwatchacquisition "github.com/crowdsecurity/crowdsec/pkg/acquisition/modules/cloudwatch"
@@ -17,19 +23,14 @@ import (
 	wineventlogacquisition "github.com/crowdsecurity/crowdsec/pkg/acquisition/modules/wineventlog"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
-	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
-
-	tomb "gopkg.in/tomb.v2"
 )
 
 // The interface each datasource must implement
 type DataSource interface {
 	GetMetrics() []prometheus.Collector                         // Returns pointers to metrics that are managed by the module
 	GetAggregMetrics() []prometheus.Collector                   // Returns pointers to metrics that are managed by the module (aggregated mode, limits cardinality)
-	Configure([]byte, *log.Entry) error                         // Configure the datasource
+	UnmarshalConfig([]byte) error                               // Decode and pre-validate the YAML datasource - anything that can be checked before runtime
+	Configure([]byte, *log.Entry) error                         // Complete the YAML datasource configuration and perform runtime checks.
 	ConfigureByDSN(string, map[string]string, *log.Entry) error // Configure the datasource
 	GetMode() string                                            // Get the mode (TAIL, CAT or SERVER)
 	GetName() string                                            // Get the name of the module
@@ -39,66 +40,37 @@ type DataSource interface {
 	Dump() interface{}
 }
 
-var AcquisitionSources = []struct {
-	name  string
-	iface func() DataSource
-}{
-	{
-		name:  "file",
-		iface: func() DataSource { return &fileacquisition.FileSource{} },
-	},
-	{
-		name:  "journalctl",
-		iface: func() DataSource { return &journalctlacquisition.JournalCtlSource{} },
-	},
-	{
-		name:  "cloudwatch",
-		iface: func() DataSource { return &cloudwatchacquisition.CloudwatchSource{} },
-	},
-	{
-		name:  "syslog",
-		iface: func() DataSource { return &syslogacquisition.SyslogSource{} },
-	},
-	{
-		name:  "docker",
-		iface: func() DataSource { return &dockeracquisition.DockerSource{} },
-	},
-	{
-		name:  "kinesis",
-		iface: func() DataSource { return &kinesisacquisition.KinesisSource{} },
-	},
-	{
-		name:  "wineventlog",
-		iface: func() DataSource { return &wineventlogacquisition.WinEventLogSource{} },
-	},
-	{
-		name:  "kafka",
-		iface: func() DataSource { return &kafkaacquisition.KafkaSource{} },
-	},
+var AcquisitionSources = map[string]func() DataSource{
+	"file":        func() DataSource { return &fileacquisition.FileSource{} },
+	"journalctl":  func() DataSource { return &journalctlacquisition.JournalCtlSource{} },
+	"cloudwatch":  func() DataSource { return &cloudwatchacquisition.CloudwatchSource{} },
+	"syslog":      func() DataSource { return &syslogacquisition.SyslogSource{} },
+	"docker":      func() DataSource { return &dockeracquisition.DockerSource{} },
+	"kinesis":     func() DataSource { return &kinesisacquisition.KinesisSource{} },
+	"wineventlog": func() DataSource { return &wineventlogacquisition.WinEventLogSource{} },
+	"kafka":       func() DataSource { return &kafkaacquisition.KafkaSource{} },
 }
 
 func GetDataSourceIface(dataSourceType string) DataSource {
-	for _, source := range AcquisitionSources {
-		if source.name == dataSourceType {
-			return source.iface()
-		}
+	source := AcquisitionSources[dataSourceType]
+	if source == nil {
+		return nil
 	}
-	return nil
+	return source()
 }
 
 func DataSourceConfigure(commonConfig configuration.DataSourceCommonCfg) (*DataSource, error) {
-
-	//we dump it back to []byte, because we want to decode the yaml blob twice :
-	//once to DataSourceCommonCfg, and then later to the dedicated type of the datasource
+	// we dump it back to []byte, because we want to decode the yaml blob twice:
+	// once to DataSourceCommonCfg, and then later to the dedicated type of the datasource
 	yamlConfig, err := yaml.Marshal(commonConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to marshal back interface")
+		return nil, fmt.Errorf("unable to marshal back interface: %v", err)
 	}
 	if dataSrc := GetDataSourceIface(commonConfig.Source); dataSrc != nil {
 		/* this logger will then be used by the datasource at runtime */
 		clog := log.New()
 		if err := types.ConfigureLogger(clog); err != nil {
-			return nil, errors.Wrap(err, "while configuring datasource logger")
+			return nil, fmt.Errorf("while configuring datasource logger: %w", err)
 		}
 		if commonConfig.LogLevel != nil {
 			clog.SetLevel(*commonConfig.LogLevel)
@@ -112,11 +84,11 @@ func DataSourceConfigure(commonConfig configuration.DataSourceCommonCfg) (*DataS
 		subLogger := clog.WithFields(customLog)
 		/* check eventual dependencies are satisfied (ie. journald will check journalctl availability) */
 		if err := dataSrc.CanRun(); err != nil {
-			return nil, errors.Wrapf(err, "datasource %s cannot be run", commonConfig.Source)
+			return nil, fmt.Errorf("datasource %s cannot be run: %w", commonConfig.Source, err)
 		}
 		/* configure the actual datasource */
 		if err := dataSrc.Configure(yamlConfig, subLogger); err != nil {
-			return nil, errors.Wrapf(err, "failed to configure datasource %s", commonConfig.Source)
+			return nil, fmt.Errorf("failed to configure datasource %s: %w", commonConfig.Source, err)
 
 		}
 		return &dataSrc, nil
@@ -153,14 +125,14 @@ func LoadAcquisitionFromDSN(dsn string, labels map[string]string) ([]DataSource,
 	/* this logger will then be used by the datasource at runtime */
 	clog := log.New()
 	if err := types.ConfigureLogger(clog); err != nil {
-		return nil, errors.Wrap(err, "while configuring datasource logger")
+		return nil, fmt.Errorf("while configuring datasource logger: %w", err)
 	}
 	subLogger := clog.WithFields(log.Fields{
 		"type": dsn,
 	})
 	err := dataSrc.ConfigureByDSN(dsn, labels, subLogger)
 	if err != nil {
-		return nil, errors.Wrapf(err, "while configuration datasource for %s", dsn)
+		return nil, fmt.Errorf("while configuration datasource for %s: %w", dsn, err)
 	}
 	sources = append(sources, dataSrc)
 	return sources, nil
@@ -168,7 +140,6 @@ func LoadAcquisitionFromDSN(dsn string, labels map[string]string) ([]DataSource,
 
 // LoadAcquisitionFromFile unmarshals the configuration item and checks its availability
 func LoadAcquisitionFromFile(config *csconfig.CrowdsecServiceCfg) ([]DataSource, error) {
-
 	var sources []DataSource
 
 	for _, acquisFile := range config.AcquisitionFiles {
@@ -185,7 +156,7 @@ func LoadAcquisitionFromFile(config *csconfig.CrowdsecServiceCfg) ([]DataSource,
 			err = dec.Decode(&sub)
 			if err != nil {
 				if ! errors.Is(err, io.EOF) {
-					return nil, errors.Wrapf(err, "failed to yaml decode %s", acquisFile)
+					return nil, fmt.Errorf("failed to yaml decode %s: %w", acquisFile, err)
 				}
 				log.Tracef("End of yaml file")
 				break
@@ -212,7 +183,7 @@ func LoadAcquisitionFromFile(config *csconfig.CrowdsecServiceCfg) ([]DataSource,
 			}
 			src, err := DataSourceConfigure(sub)
 			if err != nil {
-				return nil, errors.Wrapf(err, "while configuring datasource of type %s from %s (position: %d)", sub.Source, acquisFile, idx)
+				return nil, fmt.Errorf("while configuring datasource of type %s from %s (position: %d): %w", sub.Source, acquisFile, idx, err)
 			}
 			sources = append(sources, *src)
 			idx += 1
@@ -232,9 +203,9 @@ func GetMetrics(sources []DataSource, aggregated bool) error {
 		for _, metric := range metrics {
 			if err := prometheus.Register(metric); err != nil {
 				if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-					return errors.Wrapf(err, "could not register metrics for datasource %s", sources[i].GetName())
+					return fmt.Errorf("could not register metrics for datasource %s: %w", sources[i].GetName(), err)
 				}
-				//ignore the error
+				// ignore the error
 			}
 		}
 

--- a/pkg/acquisition/acquisition_test.go
+++ b/pkg/acquisition/acquisition_test.go
@@ -309,8 +309,8 @@ func (f *MockCat) Configure(cfg []byte, logger *log.Entry) error {
 }
 
 func (f *MockCat) UnmarshalConfig(cfg []byte) error { return nil }
-func (f *MockCat) GetName() string { return "mock_cat" }
-func (f *MockCat) GetMode() string { return "cat" }
+func (f *MockCat) GetName() string                  { return "mock_cat" }
+func (f *MockCat) GetMode() string                  { return "cat" }
 func (f *MockCat) OneShotAcquisition(out chan types.Event, tomb *tomb.Tomb) error {
 	for i := 0; i < 10; i++ {
 		evt := types.Event{}
@@ -349,8 +349,8 @@ func (f *MockTail) Configure(cfg []byte, logger *log.Entry) error {
 }
 
 func (f *MockTail) UnmarshalConfig(cfg []byte) error { return nil }
-func (f *MockTail) GetName() string { return "mock_tail" }
-func (f *MockTail) GetMode() string { return "tail" }
+func (f *MockTail) GetName() string                  { return "mock_tail" }
+func (f *MockTail) GetMode() string                  { return "tail" }
 func (f *MockTail) OneShotAcquisition(out chan types.Event, tomb *tomb.Tomb) error {
 	return fmt.Errorf("can't run in cat mode")
 }

--- a/pkg/acquisition/acquisition_test.go
+++ b/pkg/acquisition/acquisition_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -26,10 +25,19 @@ type MockSource struct {
 	logger                            *log.Entry
 }
 
+func (f *MockSource) UnmarshalConfig(cfg []byte) error {
+	err := yaml.UnmarshalStrict(cfg, &f)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (f *MockSource) Configure(cfg []byte, logger *log.Entry) error {
 	f.logger = logger
-	if err := yaml.UnmarshalStrict(cfg, &f); err != nil {
-		return errors.Wrap(err, "while unmarshaling to reader specific config")
+	if err := f.UnmarshalConfig(cfg); err != nil {
+		return err
 	}
 	if f.Mode == "" {
 		f.Mode = configuration.CAT_MODE
@@ -65,24 +73,10 @@ func (f *MockSourceCantRun) GetName() string { return "mock_cant_run" }
 // appendMockSource is only used to add mock source for tests
 func appendMockSource() {
 	if GetDataSourceIface("mock") == nil {
-		mock := struct {
-			name  string
-			iface func() DataSource
-		}{
-			name:  "mock",
-			iface: func() DataSource { return &MockSource{} },
-		}
-		AcquisitionSources = append(AcquisitionSources, mock)
+		AcquisitionSources["mock"] = func() DataSource { return &MockSource{} }
 	}
 	if GetDataSourceIface("mock_cant_run") == nil {
-		mock := struct {
-			name  string
-			iface func() DataSource
-		}{
-			name:  "mock_cant_run",
-			iface: func() DataSource { return &MockSourceCantRun{} },
-		}
-		AcquisitionSources = append(AcquisitionSources, mock)
+		AcquisitionSources["mock_cant_run"] = func() DataSource { return &MockSourceCantRun{} }
 	}
 }
 
@@ -313,6 +307,8 @@ func (f *MockCat) Configure(cfg []byte, logger *log.Entry) error {
 	}
 	return nil
 }
+
+func (f *MockCat) UnmarshalConfig(cfg []byte) error { return nil }
 func (f *MockCat) GetName() string { return "mock_cat" }
 func (f *MockCat) GetMode() string { return "cat" }
 func (f *MockCat) OneShotAcquisition(out chan types.Event, tomb *tomb.Tomb) error {
@@ -351,6 +347,8 @@ func (f *MockTail) Configure(cfg []byte, logger *log.Entry) error {
 	}
 	return nil
 }
+
+func (f *MockTail) UnmarshalConfig(cfg []byte) error { return nil }
 func (f *MockTail) GetName() string { return "mock_tail" }
 func (f *MockTail) GetMode() string { return "tail" }
 func (f *MockTail) OneShotAcquisition(out chan types.Event, tomb *tomb.Tomb) error {
@@ -482,6 +480,7 @@ type MockSourceByDSN struct {
 	logger                            *log.Entry //nolint: unused
 }
 
+func (f *MockSourceByDSN) UnmarshalConfig(cfg []byte) error                        { return nil }
 func (f *MockSourceByDSN) Configure(cfg []byte, logger *log.Entry) error           { return nil }
 func (f *MockSourceByDSN) GetMode() string                                         { return f.Mode }
 func (f *MockSourceByDSN) OneShotAcquisition(chan types.Event, *tomb.Tomb) error   { return nil }
@@ -524,14 +523,7 @@ func TestConfigureByDSN(t *testing.T) {
 	}
 
 	if GetDataSourceIface("mockdsn") == nil {
-		mock := struct {
-			name  string
-			iface func() DataSource
-		}{
-			name:  "mockdsn",
-			iface: func() DataSource { return &MockSourceByDSN{} },
-		}
-		AcquisitionSources = append(AcquisitionSources, mock)
+		AcquisitionSources["mockdsn"] = func() DataSource { return &MockSourceByDSN{} }
 	}
 
 	for _, tc := range tests {

--- a/pkg/acquisition/modules/cloudwatch/cloudwatch.go
+++ b/pkg/acquisition/modules/cloudwatch/cloudwatch.go
@@ -101,61 +101,85 @@ var (
 	def_AwsConfigDir            = ""
 )
 
-func (cw *CloudwatchSource) Configure(cfg []byte, logger *log.Entry) error {
-	cwConfig := CloudwatchSourceConfiguration{}
-	targetStream := "*"
-	if err := yaml.UnmarshalStrict(cfg, &cwConfig); err != nil {
-		return errors.Wrap(err, "Cannot parse CloudwatchSource configuration")
+func (cw *CloudwatchSource) UnmarshalConfig(yamlConfig []byte) error {
+	cw.Config = CloudwatchSourceConfiguration{}
+	if err := yaml.UnmarshalStrict(yamlConfig, &cw.Config); err != nil {
+		return fmt.Errorf("cannot parse CloudwatchSource configuration: %w", err)
 	}
-	cw.Config = cwConfig
+
 	if len(cw.Config.GroupName) == 0 {
 		return fmt.Errorf("group_name is mandatory for CloudwatchSource")
 	}
-	cw.logger = logger.WithField("group", cw.Config.GroupName)
+
 	if cw.Config.Mode == "" {
 		cw.Config.Mode = configuration.TAIL_MODE
 	}
-	logger.Debugf("Starting configuration for Cloudwatch group %s", cw.Config.GroupName)
 
 	if cw.Config.DescribeLogStreamsLimit == nil {
 		cw.Config.DescribeLogStreamsLimit = &def_DescribeLogStreamsLimit
 	}
-	logger.Tracef("describelogstreams_limit set to %d", *cw.Config.DescribeLogStreamsLimit)
+
 	if cw.Config.PollNewStreamInterval == nil {
 		cw.Config.PollNewStreamInterval = &def_PollNewStreamInterval
 	}
-	logger.Tracef("poll_new_stream_interval set to %v", *cw.Config.PollNewStreamInterval)
+
 	if cw.Config.MaxStreamAge == nil {
 		cw.Config.MaxStreamAge = &def_MaxStreamAge
 	}
-	logger.Tracef("max_stream_age set to %v", *cw.Config.MaxStreamAge)
+
 	if cw.Config.PollStreamInterval == nil {
 		cw.Config.PollStreamInterval = &def_PollStreamInterval
 	}
-	logger.Tracef("poll_stream_interval set to %v", *cw.Config.PollStreamInterval)
+
 	if cw.Config.StreamReadTimeout == nil {
 		cw.Config.StreamReadTimeout = &def_StreamReadTimeout
 	}
-	logger.Tracef("stream_read_timeout set to %v", *cw.Config.StreamReadTimeout)
+
 	if cw.Config.GetLogEventsPagesLimit == nil {
 		cw.Config.GetLogEventsPagesLimit = &def_GetLogEventsPagesLimit
 	}
-	logger.Tracef("getlogeventspages_limit set to %v", *cw.Config.GetLogEventsPagesLimit)
+
 	if cw.Config.AwsApiCallTimeout == nil {
 		cw.Config.AwsApiCallTimeout = &def_AwsApiCallTimeout
 	}
-	logger.Tracef("aws_api_timeout set to %v", *cw.Config.AwsApiCallTimeout)
-	if *cw.Config.MaxStreamAge > *cw.Config.StreamReadTimeout {
-		logger.Warningf("max_stream_age > stream_read_timeout, stream might keep being opened/closed")
-	}
+
 	if cw.Config.AwsConfigDir == nil {
 		cw.Config.AwsConfigDir = &def_AwsConfigDir
 	}
-	logger.Tracef("aws_config_dir set to %s", *cw.Config.AwsConfigDir)
+
+	return nil
+}
+
+
+
+
+func (cw *CloudwatchSource) Configure(yamlConfig []byte, logger *log.Entry) error {
+	err := cw.UnmarshalConfig(yamlConfig)
+	if err != nil {
+		return err
+	}
+
+	cw.logger = logger.WithField("group", cw.Config.GroupName)
+
+	// XXX the following must be logger or cw.logger?
+	cw.logger.Debugf("Starting configuration for Cloudwatch group %s", cw.Config.GroupName)
+	cw.logger.Tracef("describelogstreams_limit set to %d", *cw.Config.DescribeLogStreamsLimit)
+	cw.logger.Tracef("poll_new_stream_interval set to %v", *cw.Config.PollNewStreamInterval)
+	cw.logger.Tracef("max_stream_age set to %v", *cw.Config.MaxStreamAge)
+	cw.logger.Tracef("poll_stream_interval set to %v", *cw.Config.PollStreamInterval)
+	cw.logger.Tracef("stream_read_timeout set to %v", *cw.Config.StreamReadTimeout)
+	cw.logger.Tracef("getlogeventspages_limit set to %v", *cw.Config.GetLogEventsPagesLimit)
+	cw.logger.Tracef("aws_api_timeout set to %v", *cw.Config.AwsApiCallTimeout)
+
+	if *cw.Config.MaxStreamAge > *cw.Config.StreamReadTimeout {
+		cw.logger.Warningf("max_stream_age > stream_read_timeout, stream might keep being opened/closed")
+	}
+	cw.logger.Tracef("aws_config_dir set to %s", *cw.Config.AwsConfigDir)
+
 	if *cw.Config.AwsConfigDir != "" {
 		_, err := os.Stat(*cw.Config.AwsConfigDir)
 		if err != nil {
-			logger.Errorf("can't read aws_config_dir '%s' got err %s", *cw.Config.AwsConfigDir, err)
+			cw.logger.Errorf("can't read aws_config_dir '%s' got err %s", *cw.Config.AwsConfigDir, err)
 			return fmt.Errorf("can't read aws_config_dir %s got err %s ", *cw.Config.AwsConfigDir, err)
 		}
 		os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
@@ -164,7 +188,7 @@ func (cw *CloudwatchSource) Configure(cfg []byte, logger *log.Entry) error {
 		os.Setenv("AWS_SHARED_CREDENTIALS_FILE", fmt.Sprintf("%s/credentials", *cw.Config.AwsConfigDir))
 	} else {
 		if cw.Config.AwsRegion == nil {
-			logger.Errorf("aws_region is not specified, specify it or aws_config_dir")
+			cw.logger.Errorf("aws_region is not specified, specify it or aws_config_dir")
 			return fmt.Errorf("aws_region is not specified, specify it or aws_config_dir")
 		}
 		os.Setenv("AWS_REGION", *cw.Config.AwsRegion)
@@ -174,6 +198,8 @@ func (cw *CloudwatchSource) Configure(cfg []byte, logger *log.Entry) error {
 		return err
 	}
 	cw.streamIndexes = make(map[string]string)
+
+	targetStream := "*"
 	if cw.Config.StreamRegexp != nil {
 		if _, err := regexp.Compile(*cw.Config.StreamRegexp); err != nil {
 			return errors.Wrapf(err, "error while compiling regexp '%s'", *cw.Config.StreamRegexp)
@@ -183,7 +209,7 @@ func (cw *CloudwatchSource) Configure(cfg []byte, logger *log.Entry) error {
 		targetStream = *cw.Config.StreamName
 	}
 
-	logger.Infof("Adding cloudwatch group '%s' (stream:%s) to datasources", cw.Config.GroupName, targetStream)
+	cw.logger.Infof("Adding cloudwatch group '%s' (stream:%s) to datasources", cw.Config.GroupName, targetStream)
 	return nil
 }
 

--- a/pkg/acquisition/modules/cloudwatch/cloudwatch.go
+++ b/pkg/acquisition/modules/cloudwatch/cloudwatch.go
@@ -12,17 +12,17 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
-	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
-	"github.com/crowdsecurity/crowdsec/pkg/parser"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/tomb.v2"
 	"gopkg.in/yaml.v2"
 
-	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
+	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
+	"github.com/crowdsecurity/crowdsec/pkg/parser"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 var openedStreams = prometheus.NewGaugeVec(
@@ -149,9 +149,6 @@ func (cw *CloudwatchSource) UnmarshalConfig(yamlConfig []byte) error {
 
 	return nil
 }
-
-
-
 
 func (cw *CloudwatchSource) Configure(yamlConfig []byte, logger *log.Entry) error {
 	err := cw.UnmarshalConfig(yamlConfig)

--- a/pkg/acquisition/modules/cloudwatch/cloudwatch.go
+++ b/pkg/acquisition/modules/cloudwatch/cloudwatch.go
@@ -161,7 +161,6 @@ func (cw *CloudwatchSource) Configure(yamlConfig []byte, logger *log.Entry) erro
 
 	cw.logger = logger.WithField("group", cw.Config.GroupName)
 
-	// XXX the following must be logger or cw.logger?
 	cw.logger.Debugf("Starting configuration for Cloudwatch group %s", cw.Config.GroupName)
 	cw.logger.Tracef("describelogstreams_limit set to %d", *cw.Config.DescribeLogStreamsLimit)
 	cw.logger.Tracef("poll_new_stream_interval set to %v", *cw.Config.PollNewStreamInterval)

--- a/pkg/acquisition/modules/docker/docker.go
+++ b/pkg/acquisition/modules/docker/docker.go
@@ -10,18 +10,19 @@ import (
 	"strings"
 	"time"
 
-	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
-	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
-	"github.com/crowdsecurity/dlog"
 	dockerTypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/tomb.v2"
 	"gopkg.in/yaml.v2"
+
+	"github.com/crowdsecurity/dlog"
+
+	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
+	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 var linesRead = prometheus.NewCounterVec(
@@ -129,7 +130,7 @@ func (d *DockerSource) Configure(yamlConfig []byte, logger *log.Entry) error {
 	d.logger = logger
 
 	err := d.UnmarshalConfig(yamlConfig)
-	if err !=  nil {
+	if err != nil {
 		return err
 	}
 

--- a/pkg/acquisition/modules/docker/docker.go
+++ b/pkg/acquisition/modules/docker/docker.go
@@ -67,24 +67,22 @@ type ContainerConfig struct {
 	Tty    bool
 }
 
-func (d *DockerSource) Configure(Config []byte, logger *log.Entry) error {
-	var err error
-
+func (d *DockerSource) UnmarshalConfig(yamlConfig []byte) error {
 	d.Config = DockerConfiguration{
 		FollowStdout:  true, // default
 		FollowStdErr:  true, // default
 		CheckInterval: "1s", // default
 	}
-	d.logger = logger
 
-	d.runningContainerState = make(map[string]*ContainerConfig)
-
-	err = yaml.UnmarshalStrict(Config, &d.Config)
+	err := yaml.UnmarshalStrict(yamlConfig, &d.Config)
 	if err != nil {
 		return errors.Wrap(err, "Cannot parse DockerAcquisition configuration")
 	}
 
-	d.logger.Tracef("DockerAcquisition configuration: %+v", d.Config)
+	if d.logger != nil {
+		d.logger.Tracef("DockerAcquisition configuration: %+v", d.Config)
+	}
+
 	if len(d.Config.ContainerName) == 0 && len(d.Config.ContainerID) == 0 && len(d.Config.ContainerIDRegexp) == 0 && len(d.Config.ContainerNameRegexp) == 0 {
 		return fmt.Errorf("no containers names or containers ID configuration provided")
 	}
@@ -100,7 +98,6 @@ func (d *DockerSource) Configure(Config []byte, logger *log.Entry) error {
 	if d.Config.Mode != configuration.CAT_MODE && d.Config.Mode != configuration.TAIL_MODE {
 		return fmt.Errorf("unsupported mode %s for docker datasource", d.Config.Mode)
 	}
-	d.logger.Tracef("Actual DockerAcquisition configuration %+v", d.Config)
 
 	for _, cont := range d.Config.ContainerNameRegexp {
 		d.compiledContainerName = append(d.compiledContainerName, regexp.MustCompile(cont))
@@ -108,11 +105,6 @@ func (d *DockerSource) Configure(Config []byte, logger *log.Entry) error {
 
 	for _, cont := range d.Config.ContainerIDRegexp {
 		d.compiledContainerID = append(d.compiledContainerID, regexp.MustCompile(cont))
-	}
-
-	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-	if err != nil {
-		return err
 	}
 
 	if d.Config.Since == "" {
@@ -130,17 +122,37 @@ func (d *DockerSource) Configure(Config []byte, logger *log.Entry) error {
 		d.containerLogsOptions.Until = d.Config.Until
 	}
 
+	return nil
+}
+
+func (d *DockerSource) Configure(yamlConfig []byte, logger *log.Entry) error {
+	d.logger = logger
+
+	err := d.UnmarshalConfig(yamlConfig)
+	if err !=  nil {
+		return err
+	}
+
+	d.runningContainerState = make(map[string]*ContainerConfig)
+
+	d.logger.Tracef("Actual DockerAcquisition configuration %+v", d.Config)
+
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return err
+	}
+
 	if d.Config.DockerHost != "" {
-		if err := client.WithHost(d.Config.DockerHost)(dockerClient); err != nil {
+		err = client.WithHost(d.Config.DockerHost)(dockerClient)
+		if err != nil {
 			return err
 		}
 	}
 	d.Client = dockerClient
 
 	_, err = d.Client.Info(context.Background())
-
 	if err != nil {
-		return errors.Wrapf(err, "failed to configure docker datasource %s", d.Config.DockerHost)
+		return fmt.Errorf("failed to configure docker datasource %s: %w", d.Config.DockerHost, err)
 	}
 
 	return nil

--- a/pkg/acquisition/modules/file/file.go
+++ b/pkg/acquisition/modules/file/file.go
@@ -13,9 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
-	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/fsnotify/fsnotify"
 	"github.com/nxadm/tail"
 	"github.com/pkg/errors"
@@ -23,6 +20,10 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/tomb.v2"
 	"gopkg.in/yaml.v2"
+
+	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
+	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 var linesRead = prometheus.NewCounterVec(

--- a/pkg/acquisition/modules/file/file_test.go
+++ b/pkg/acquisition/modules/file/file_test.go
@@ -7,14 +7,15 @@ import (
 	"testing"
 	"time"
 
-	fileacquisition "github.com/crowdsecurity/crowdsec/pkg/acquisition/modules/file"
-	"github.com/crowdsecurity/crowdsec/pkg/cstest"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/tomb.v2"
+
+	fileacquisition "github.com/crowdsecurity/crowdsec/pkg/acquisition/modules/file"
+	"github.com/crowdsecurity/crowdsec/pkg/cstest"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 func TestBadConfiguration(t *testing.T) {

--- a/pkg/acquisition/modules/file/file_test.go
+++ b/pkg/acquisition/modules/file/file_test.go
@@ -42,7 +42,7 @@ func TestBadConfiguration(t *testing.T) {
 			name: "bad exclude regexp",
 			config: `filenames: ["asd.log"]
 exclude_regexps: ["as[a-$d"]`,
-			expectedErr: "Could not compile regexp as",
+			expectedErr: "could not compile regexp as",
 		},
 	}
 

--- a/pkg/acquisition/modules/journalctl/journalctl.go
+++ b/pkg/acquisition/modules/journalctl/journalctl.go
@@ -9,15 +9,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
-	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
-
 	"gopkg.in/tomb.v2"
 	"gopkg.in/yaml.v2"
+
+	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
+	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 type JournalCtlConfiguration struct {
@@ -189,7 +189,6 @@ func (j *JournalCtlSource) UnmarshalConfig(yamlConfig []byte) error {
 
 	return nil
 }
-
 
 func (j *JournalCtlSource) Configure(yamlConfig []byte, logger *log.Entry) error {
 	j.logger = logger

--- a/pkg/acquisition/modules/journalctl/journalctl.go
+++ b/pkg/acquisition/modules/journalctl/journalctl.go
@@ -163,28 +163,42 @@ func (j *JournalCtlSource) GetAggregMetrics() []prometheus.Collector {
 	return []prometheus.Collector{linesRead}
 }
 
-func (j *JournalCtlSource) Configure(yamlConfig []byte, logger *log.Entry) error {
-	config := JournalCtlConfiguration{}
-	j.logger = logger
-	err := yaml.UnmarshalStrict(yamlConfig, &config)
+func (j *JournalCtlSource) UnmarshalConfig(yamlConfig []byte) error {
+	j.config = JournalCtlConfiguration{}
+	err := yaml.UnmarshalStrict(yamlConfig, &j.config)
 	if err != nil {
-		return errors.Wrap(err, "Cannot parse JournalCtlSource configuration")
+		return fmt.Errorf("cannot parse JournalCtlSource configuration: %w", err)
 	}
-	if config.Mode == "" {
-		config.Mode = configuration.TAIL_MODE
+
+	if j.config.Mode == "" {
+		j.config.Mode = configuration.TAIL_MODE
 	}
+
 	var args []string
-	if config.Mode == configuration.TAIL_MODE {
+	if j.config.Mode == configuration.TAIL_MODE {
 		args = journalctlArgstreaming
 	} else {
 		args = journalctlArgsOneShot
 	}
-	if len(config.Filters) == 0 {
+
+	if len(j.config.Filters) == 0 {
 		return fmt.Errorf("journalctl_filter is required")
 	}
-	j.args = append(args, config.Filters...)
-	j.src = fmt.Sprintf("journalctl-%s", strings.Join(config.Filters, "."))
-	j.config = config
+	j.args = append(args, j.config.Filters...)
+	j.src = fmt.Sprintf("journalctl-%s", strings.Join(j.config.Filters, "."))
+
+	return nil
+}
+
+
+func (j *JournalCtlSource) Configure(yamlConfig []byte, logger *log.Entry) error {
+	j.logger = logger
+
+	err := j.UnmarshalConfig(yamlConfig)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/acquisition/modules/kafka/kafka.go
+++ b/pkg/acquisition/modules/kafka/kafka.go
@@ -10,15 +10,16 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
-	"github.com/crowdsecurity/crowdsec/pkg/leakybucket"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/segmentio/kafka-go"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/tomb.v2"
 	"gopkg.in/yaml.v2"
+
+	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
+	"github.com/crowdsecurity/crowdsec/pkg/leakybucket"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 var (
@@ -54,7 +55,7 @@ type KafkaSource struct {
 	Reader *kafka.Reader
 }
 
-func (k* KafkaSource) UnmarshalConfig(yamlConfig []byte) error {
+func (k *KafkaSource) UnmarshalConfig(yamlConfig []byte) error {
 	k.Config = KafkaConfiguration{}
 
 	err := yaml.UnmarshalStrict(yamlConfig, &k.Config)
@@ -76,8 +77,6 @@ func (k* KafkaSource) UnmarshalConfig(yamlConfig []byte) error {
 
 	return err
 }
-
-
 
 func (k *KafkaSource) Configure(yamlConfig []byte, logger *log.Entry) error {
 	k.logger = logger

--- a/pkg/acquisition/modules/kafka/kafka.go
+++ b/pkg/acquisition/modules/kafka/kafka.go
@@ -54,35 +54,53 @@ type KafkaSource struct {
 	Reader *kafka.Reader
 }
 
-func (k *KafkaSource) Configure(Config []byte, logger *log.Entry) error {
-	var err error
-
+func (k* KafkaSource) UnmarshalConfig(yamlConfig []byte) error {
 	k.Config = KafkaConfiguration{}
-	k.logger = logger
-	err = yaml.UnmarshalStrict(Config, &k.Config)
+
+	err := yaml.UnmarshalStrict(yamlConfig, &k.Config)
 	if err != nil {
-		return errors.Wrapf(err, "cannot parse %s datasource configuration", dataSourceName)
+		return fmt.Errorf("cannot parse %s datasource configuration: %w", dataSourceName, err)
 	}
+
 	if len(k.Config.Brokers) == 0 {
 		return fmt.Errorf("cannot create a %s reader with an empty list of broker addresses", dataSourceName)
 	}
+
 	if k.Config.Topic == "" {
 		return fmt.Errorf("cannot create a %s reader with am empty topic", dataSourceName)
 	}
+
 	if k.Config.Mode == "" {
 		k.Config.Mode = configuration.TAIL_MODE
 	}
+
+	return err
+}
+
+
+
+func (k *KafkaSource) Configure(yamlConfig []byte, logger *log.Entry) error {
+	k.logger = logger
+
+	err := k.UnmarshalConfig(yamlConfig)
+	if err != nil {
+		return err
+	}
+
 	dialer, err := k.Config.NewDialer()
 	if err != nil {
 		return errors.Wrapf(err, "cannot create %s dialer", dataSourceName)
 	}
+
 	k.Reader, err = k.Config.NewReader(dialer)
 	if err != nil {
 		return errors.Wrapf(err, "cannote create %s reader", dataSourceName)
 	}
+
 	if k.Reader == nil {
 		return fmt.Errorf("cannot create %s reader", dataSourceName)
 	}
+
 	return nil
 }
 

--- a/pkg/acquisition/modules/kinesis/kinesis.go
+++ b/pkg/acquisition/modules/kinesis/kinesis.go
@@ -13,14 +13,15 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"
-	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
-	"github.com/crowdsecurity/crowdsec/pkg/leakybucket"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/tomb.v2"
 	"gopkg.in/yaml.v2"
+
+	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
+	"github.com/crowdsecurity/crowdsec/pkg/leakybucket"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 type KinesisConfiguration struct {

--- a/pkg/acquisition/modules/syslog/syslog.go
+++ b/pkg/acquisition/modules/syslog/syslog.go
@@ -6,18 +6,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/tomb.v2"
+	"gopkg.in/yaml.v2"
+
 	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
 	"github.com/crowdsecurity/crowdsec/pkg/acquisition/modules/syslog/internal/parser/rfc3164"
 	"github.com/crowdsecurity/crowdsec/pkg/acquisition/modules/syslog/internal/parser/rfc5424"
 	syslogserver "github.com/crowdsecurity/crowdsec/pkg/acquisition/modules/syslog/internal/server"
 	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
-	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	log "github.com/sirupsen/logrus"
-
-	"gopkg.in/tomb.v2"
-	"gopkg.in/yaml.v2"
 )
 
 type SyslogConfiguration struct {
@@ -116,7 +116,6 @@ func (s *SyslogSource) UnmarshalConfig(yamlConfig []byte) error {
 
 	return nil
 }
-
 
 func (s *SyslogSource) Configure(yamlConfig []byte, logger *log.Entry) error {
 	s.logger = logger

--- a/pkg/acquisition/modules/wineventlog/wineventlog.go
+++ b/pkg/acquisition/modules/wineventlog/wineventlog.go
@@ -14,6 +14,10 @@ import (
 
 type WinEventLogSource struct{}
 
+func (w *WinEventLogSource) UnmarshalConfig(yamlConfig []byte) error {
+	return nil
+}
+
 func (w *WinEventLogSource) Configure(yamlConfig []byte, logger *log.Entry) error {
 	return nil
 }

--- a/pkg/acquisition/modules/wineventlog/wineventlog.go
+++ b/pkg/acquisition/modules/wineventlog/wineventlog.go
@@ -5,11 +5,12 @@ package wineventlogacquisition
 import (
 	"errors"
 
-	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/tomb.v2"
+
+	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 type WinEventLogSource struct{}

--- a/pkg/acquisition/modules/wineventlog/wineventlog_windows.go
+++ b/pkg/acquisition/modules/wineventlog/wineventlog_windows.go
@@ -9,9 +9,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
-	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/google/winops/winlog"
 	"github.com/google/winops/winlog/wevtapi"
 	"github.com/prometheus/client_golang/prometheus"
@@ -19,6 +16,10 @@ import (
 	"golang.org/x/sys/windows"
 	"gopkg.in/tomb.v2"
 	"gopkg.in/yaml.v2"
+
+	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
+	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 type WinEventLogConfiguration struct {

--- a/pkg/cstest/utils.go
+++ b/pkg/cstest/utils.go
@@ -1,7 +1,9 @@
 package cstest
 
 import (
+	"strings"
 	"testing"
+	"text/template"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,4 +29,21 @@ func RequireErrorContains(t *testing.T, err error, expectedErr string) {
 	}
 
 	require.NoError(t, err)
+}
+
+// Interpolate fills a string template with the given values, can be map or struct.
+// example: Interpolate("{{.Name}}", map[string]string{"Name": "JohnDoe"})
+func Interpolate(s string, data interface{}) (string, error) {
+	tmpl, err := template.New("").Parse(s)
+	if err != nil {
+		return "", err
+	}
+
+	var b strings.Builder
+	err = tmpl.Execute(&b, data)
+	if err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
 }


### PR DESCRIPTION
We need a way to validate the content of acquis.yml files, externally (i.e. from cscli).

This PR is basically splitting the Configure() method in two, by extracting UnmarshalConfig() which does all static check without actually trying to set up each datasource.

I can add some tests to each UnmarshalConfig, they are now in the mm-wizard branch
