### PR TITLE
set BUILD_VERSION to the correct tag

### DIFF
--- a/platform/unix_common.mk
+++ b/platform/unix_common.mk
@@ -14,7 +14,7 @@ GO_MINOR_VERSION = $(shell command -v go >/dev/null && go version | cut -c 14- |
 BUILD_GOVERSION="$(shell command -v go >/dev/null && go version | cut -d " " -f3 | sed -E 's/[go]+//g')"
 
 #Current versioning information from env
-BUILD_VERSION?="$(shell git describe --tags $$(git rev-list --tags --max-count=1))"
+BUILD_VERSION?="$(shell git describe --tags)"
 BUILD_CODENAME="alphaga"
 BUILD_TIMESTAMP=$(shell date +%F"_"%T)
 BUILD_TAG?="$(shell git rev-parse HEAD)"


### PR DESCRIPTION
This fixes a regression introduced in 0449ec18 (Windows Support #1159) where the build system uses the last local tag that has been created (chonologically) instead of the most recent tag in the current branch. This problem is not detected while working with stable versions because they are built on a clean checkout.