### PR TITLE
Force agent reauth on 403

### DIFF
--- a/pkg/apiclient/auth.go
+++ b/pkg/apiclient/auth.go
@@ -194,7 +194,7 @@ func (t *JWTTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		dump, _ := httputil.DumpResponse(resp, true)
 		log.Tracef("resp-jwt: %s (err:%v)", string(dump), err)
 	}
-	if err != nil || resp.StatusCode == 401 {
+	if err != nil || resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
 		/*we had an error (network error for example, or 401 because token is refused), reset the token ?*/
 		t.token = ""
 		return resp, errors.Wrapf(err, "performing jwt auth")


### PR DESCRIPTION
When LAPI starts, by default, a random key is generated to sign the JWT token used by the agent.

This means that in a multi-server setup, if LAPI restarts, all agents will fail to authenticate with their current JWT token until it expires (1h at the maximum) or they are restarted.

The previous code was only checking for a 401 error, check for 403 as well (as this is what is returned by LAPI when the token signature is invalid).