### PR TITLE
clean up BUILD_GOVERSION which is set at runtime with runtime lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,11 @@ BUILD_CMD = build
 
 MINIMUM_SUPPORTED_GO_MAJOR_VERSION = 1
 MINIMUM_SUPPORTED_GO_MINOR_VERSION = 18
+
+go_major_minor = $(subst ., ,$(BUILD_GOVERSION))
+GO_MAJOR_VERSION = $(word 1, $(go_major_minor))
+GO_MINOR_VERSION = $(word 2, $(go_major_minor))
+
 GO_VERSION_VALIDATION_ERR_MSG = Golang version ($(BUILD_GOVERSION)) is not supported, please use at least $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION).$(MINIMUM_SUPPORTED_GO_MINOR_VERSION)
 
 LD_OPTS_VARS= \

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,6 @@ LD_OPTS_VARS= \
 -X 'github.com/crowdsecurity/crowdsec/pkg/cwversion.BuildDate=$(BUILD_TIMESTAMP)' \
 -X 'github.com/crowdsecurity/crowdsec/pkg/cwversion.Codename=$(BUILD_CODENAME)' \
 -X 'github.com/crowdsecurity/crowdsec/pkg/cwversion.Tag=$(BUILD_TAG)' \
--X 'github.com/crowdsecurity/crowdsec/pkg/cwversion.GoVersion=$(BUILD_GOVERSION)' \
 -X 'github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultConfigDir=$(DEFAULT_CONFIGDIR)' \
 -X 'github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultDataDir=$(DEFAULT_DATADIR)'
 

--- a/platform/unix_common.mk
+++ b/platform/unix_common.mk
@@ -5,18 +5,15 @@ CPR=cp -r
 MKDIR=mkdir -p
 
 # Go should not be required to run functional tests
-GOOS ?= $(shell command -v go >/dev/null && go env GOOS)
-GOARCH ?= $(shell command -v go >/dev/null && go env GOARCH)
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
 
-GO_MAJOR_VERSION = $(shell command -v go >/dev/null && go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
-GO_MINOR_VERSION = $(shell command -v go >/dev/null && go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
-
-BUILD_GOVERSION="$(shell command -v go >/dev/null && go version | cut -d " " -f3 | sed -E 's/[go]+//g')"
+BUILD_GOVERSION=$(shell go env GOVERSION | sed s/go//)
 
 #Current versioning information from env
-BUILD_VERSION?="$(shell git describe --tags)"
+BUILD_VERSION?=$(shell git describe --tags)
 BUILD_CODENAME="alphaga"
 BUILD_TIMESTAMP=$(shell date +%F"_"%T)
-BUILD_TAG?="$(shell git rev-parse HEAD)"
+BUILD_TAG?=$(shell git rev-parse HEAD)
 DEFAULT_CONFIGDIR?=/etc/crowdsec
 DEFAULT_DATADIR?=/var/lib/crowdsec/data

--- a/platform/windows.mk
+++ b/platform/windows.mk
@@ -8,11 +8,6 @@ PREFIX=$(shell $$env:TEMP)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
-GO_MAJOR_VERSION ?= $(shell (go env GOVERSION).replace("go","").split(".")[0])
-GO_MINOR_VERSION ?= $(shell (go env GOVERSION).replace("go","").split(".")[1])
-MINIMUM_SUPPORTED_GO_MAJOR_VERSION = 1
-MINIMUM_SUPPORTED_GO_MINOR_VERSION = 17
-GO_VERSION_VALIDATION_ERR_MSG = Golang version ($(BUILD_GOVERSION)) is not supported, please use least $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION).$(MINIMUM_SUPPORTED_GO_MINOR_VERSION)
 #Current versioning information from env
 #BUILD_VERSION?=$(shell (Invoke-WebRequest -UseBasicParsing -Uri https://api.github.com/repos/crowdsecurity/crowdsec/releases/latest).Content | jq -r '.tag_name')
 #hardcode it till i find a workaround


### PR DESCRIPTION
clean up BUILD_GOVERSION which is set at runtime with runtime lib.
Hence this is not used.

fixes https://github.com/crowdsecurity/crowdsec/issues/1900