### PR TITLE
add -error flag to crowdsec binary

### DIFF
--- a/cmd/crowdsec/api.go
+++ b/cmd/crowdsec/api.go
@@ -4,11 +4,12 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/crowdsecurity/crowdsec/pkg/apiserver"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 func initAPIServer(cConfig *csconfig.Config) (*apiserver.APIServer, error) {
@@ -23,7 +24,7 @@ func initAPIServer(cConfig *csconfig.Config) (*apiserver.APIServer, error) {
 
 	if hasPlugins(cConfig.API.Server.Profiles) {
 		log.Info("initiating plugin broker")
-		//On windows, the plugins are always run as medium-integrity processes, so we don't care about plugin_config
+		// On windows, the plugins are always run as medium-integrity processes, so we don't care about plugin_config
 		if cConfig.PluginConfig == nil && runtime.GOOS != "windows" {
 			return nil, errors.New("plugins are enabled, but the plugin_config section is missing in the configuration")
 		}

--- a/cmd/crowdsec/api.go
+++ b/cmd/crowdsec/api.go
@@ -12,6 +12,10 @@ import (
 )
 
 func initAPIServer(cConfig *csconfig.Config) (*apiserver.APIServer, error) {
+	if cConfig.API.Server.OnlineClient == nil || cConfig.API.Server.OnlineClient.Credentials == nil {
+		log.Info("push and pull to central API disabled")
+	}
+
 	apiServer, err := apiserver.NewServer(cConfig.API.Server)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to run local API")

--- a/cmd/crowdsec/api.go
+++ b/cmd/crowdsec/api.go
@@ -14,7 +14,7 @@ import (
 
 func initAPIServer(cConfig *csconfig.Config) (*apiserver.APIServer, error) {
 	if cConfig.API.Server.OnlineClient == nil || cConfig.API.Server.OnlineClient.Credentials == nil {
-		log.Info("push and pull to central API disabled")
+		log.Info("push and pull to Central API disabled")
 	}
 
 	apiServer, err := apiserver.NewServer(cConfig.API.Server)

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -288,6 +288,15 @@ func LoadConfig(cConfig *csconfig.Config) error {
 		cConfig.Common.Daemonize = false
 	}
 
+	// Configure logging
+	if err := types.SetDefaultLoggerConfig(cConfig.Common.LogMedia,
+		cConfig.Common.LogDir, *cConfig.Common.LogLevel,
+		cConfig.Common.LogMaxSize, cConfig.Common.LogMaxFiles,
+		cConfig.Common.LogMaxAge, cConfig.Common.CompressLogs,
+		cConfig.Common.ForceColorLogs); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -42,7 +42,7 @@ var (
 	/*the state of the buckets*/
 	holders         []leakybucket.BucketFactory
 	buckets         *leakybucket.Buckets
-	outputEventChan chan types.Event //the buckets init returns its own chan that is used for multiplexing
+	outputEventChan chan types.Event // the buckets init returns its own chan that is used for multiplexing
 	/*settings*/
 	lastProcessedItem time.Time /*keep track of last item timestamp in time-machine. it is used to GC buckets when we dump them.*/
 	pluginBroker      csplugin.PluginBroker
@@ -110,7 +110,6 @@ func newParsers() *parser.Parsers {
 }
 
 func LoadBuckets(cConfig *csconfig.Config) error {
-
 	var (
 		err   error
 		files []string
@@ -161,9 +160,11 @@ func LoadAcquisition(cConfig *csconfig.Config) error {
 	return nil
 }
 
-var dumpFolder string
-var dumpStates bool
-var labels = make(labelsMap)
+var (
+	dumpFolder string
+	dumpStates bool
+	labels     = make(labelsMap)
+)
 
 func (l *labelsMap) String() string {
 	return "labels"
@@ -179,7 +180,6 @@ func (l labelsMap) Set(label string) error {
 }
 
 func (f *Flags) Parse() {
-
 	flag.StringVar(&f.ConfigFile, "c", csconfig.DefaultConfigPath("config.yaml"), "configuration file")
 	flag.BoolVar(&f.TraceLevel, "trace", false, "VERY verbose")
 	flag.BoolVar(&f.DebugLevel, "debug", false, "print debug-level on stderr")
@@ -198,7 +198,6 @@ func (f *Flags) Parse() {
 	flag.StringVar(&dumpFolder, "dump-data", "", "dump parsers/buckets raw outputs")
 	flag.Parse()
 }
-
 
 func newLogLevel(curLevelPtr *log.Level, f *Flags) *log.Level {
 	// mother of all defaults
@@ -230,7 +229,6 @@ func newLogLevel(curLevelPtr *log.Level, f *Flags) *log.Level {
 	}
 	return &ret
 }
-
 
 // LoadConfig returns a configuration parsed from configuration file
 func LoadConfig(cConfig *csconfig.Config) error {

--- a/cmd/crowdsec/run_in_svc.go
+++ b/cmd/crowdsec/run_in_svc.go
@@ -9,7 +9,6 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/database"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/writer"
 )
@@ -36,11 +35,6 @@ func StartRunSvc() error {
 	}
 	if err := LoadConfig(cConfig); err != nil {
 		return err
-	}
-	// Configure logging
-	if err = types.SetDefaultLoggerConfig(cConfig.Common.LogMedia, cConfig.Common.LogDir, *cConfig.Common.LogLevel,
-		cConfig.Common.LogMaxSize, cConfig.Common.LogMaxFiles, cConfig.Common.LogMaxAge, cConfig.Common.CompressLogs, cConfig.Common.ForceColorLogs); err != nil {
-		log.Fatal(err)
 	}
 
 	log.Infof("Crowdsec %s", cwversion.VersionStr())

--- a/cmd/crowdsec/run_in_svc.go
+++ b/cmd/crowdsec/run_in_svc.go
@@ -6,11 +6,12 @@ package main
 import (
 	"os"
 
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/writer"
+
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/database"
-	log "github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/writer"
 )
 
 func StartRunSvc() error {

--- a/cmd/crowdsec/run_in_svc_windows.go
+++ b/cmd/crowdsec/run_in_svc_windows.go
@@ -66,11 +66,6 @@ func WindowsRun() error {
 		return err
 	}
 	// Configure logging
-	if err = types.SetDefaultLoggerConfig(cConfig.Common.LogMedia, cConfig.Common.LogDir, *cConfig.Common.LogLevel,
-		cConfig.Common.LogMaxSize, cConfig.Common.LogMaxFiles, cConfig.Common.LogMaxAge, cConfig.Common.CompressLogs, cConfig.Common.ForceColorLogs); err != nil {
-		return err
-	}
-
 	log.Infof("Crowdsec %s", cwversion.VersionStr())
 
 	if bincoverTesting != "" {

--- a/cmd/crowdsec/run_in_svc_windows.go
+++ b/cmd/crowdsec/run_in_svc_windows.go
@@ -10,7 +10,6 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/database"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 func StartRunSvc() error {

--- a/cmd/crowdsec/run_in_svc_windows.go
+++ b/cmd/crowdsec/run_in_svc_windows.go
@@ -3,13 +3,14 @@ package main
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows/svc"
+
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/database"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/sys/windows/svc"
 )
 
 func StartRunSvc() error {

--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -62,14 +62,6 @@ func reloadHandler(sig os.Signal) (*csconfig.Config, error) {
 	if err = LoadConfig(cConfig); err != nil {
 		return nil, err
 	}
-	// Configure logging
-	if err = types.SetDefaultLoggerConfig(cConfig.Common.LogMedia,
-		cConfig.Common.LogDir, *cConfig.Common.LogLevel,
-		cConfig.Common.LogMaxSize, cConfig.Common.LogMaxFiles,
-		cConfig.Common.LogMaxAge, cConfig.Common.CompressLogs,
-		cConfig.Common.ForceColorLogs); err != nil {
-		return nil, err
-	}
 
 	if !cConfig.DisableAPI {
 		if flags.DisableCAPI {

--- a/cmd/crowdsec/win_service.go
+++ b/cmd/crowdsec/win_service.go
@@ -107,12 +107,6 @@ func runService(name string) error {
 		return err
 	}
 
-	// Configure logging
-	if err := types.SetDefaultLoggerConfig(cConfig.Common.LogMedia, cConfig.Common.LogDir, *cConfig.Common.LogLevel,
-		cConfig.Common.LogMaxSize, cConfig.Common.LogMaxFiles, cConfig.Common.LogMaxAge, cConfig.Common.CompressLogs, cConfig.Common.ForceColorLogs); err != nil {
-		return err
-	}
-
 	log.Infof("starting %s service", name)
 	winsvc := crowdsec_winservice{config: cConfig}
 

--- a/cmd/crowdsec/win_service.go
+++ b/cmd/crowdsec/win_service.go
@@ -18,7 +18,6 @@ import (
 	"golang.org/x/sys/windows/svc/eventlog"
 
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 type crowdsec_winservice struct {

--- a/cmd/crowdsec/win_service.go
+++ b/cmd/crowdsec/win_service.go
@@ -11,13 +11,14 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/eventlog"
+
+	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 type crowdsec_winservice struct {
@@ -45,7 +46,7 @@ func (m *crowdsec_winservice) Execute(args []string, r <-chan svc.ChangeRequest,
 					err := shutdown(nil, m.config)
 					if err != nil {
 						log.Errorf("Error while shutting down: %s", err)
-						//don't return, we still want to notify windows that we are stopped ?
+						// don't return, we still want to notify windows that we are stopped ?
 					}
 					break loop
 				default:
@@ -64,8 +65,7 @@ func (m *crowdsec_winservice) Execute(args []string, r <-chan svc.ChangeRequest,
 }
 
 func runService(name string) error {
-
-	//All the calls to logging before the logger is configured are pretty much useless, but we keep them for clarity
+	// All the calls to logging before the logger is configured are pretty much useless, but we keep them for clarity
 	err := eventlog.InstallAsEventCreate("CrowdSec", eventlog.Error|eventlog.Warning|eventlog.Info)
 	if err != nil {
 		if errno, ok := err.(syscall.Errno); ok {
@@ -79,14 +79,14 @@ func runService(name string) error {
 		}
 	}
 
-	//Let's use our source even if we could not install it:
+	// Let's use our source even if we could not install it:
 	// - It could have been created earlier
 	// - No permission to create it (e.g. running as non-admin when working on crowdsec)
-	//It will still work, windows will just display some additional errors in the event log
+	// It will still work, windows will just display some additional errors in the event log
 	evtlog, err := eventlog.Open("CrowdSec")
 
 	if err == nil {
-		//Send panic and fatal to event log, as they can happen before the logger is configured.
+		// Send panic and fatal to event log, as they can happen before the logger is configured.
 		log.AddHook(&EventLogHook{
 			LogLevels: []log.Level{
 				log.PanicLevel,

--- a/pkg/csconfig/api.go
+++ b/pkg/csconfig/api.go
@@ -171,7 +171,6 @@ type TLSCfg struct {
 }
 
 func (c *Config) LoadAPIServer() error {
-
 	if c.DisableAPI {
 		log.Warning("crowdsec local API is disabled from flag")
 	}
@@ -228,7 +227,7 @@ func (c *Config) LoadAPIServer() error {
 		}
 	}
 	if c.API.Server.OnlineClient == nil || c.API.Server.OnlineClient.Credentials == nil {
-		log.Printf("push and pull to Central API disabled")
+		log.Info("push and pull to Central API disabled")
 	}
 	if err := c.LoadDBConfig(); err != nil {
 		return err

--- a/pkg/csconfig/api.go
+++ b/pkg/csconfig/api.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
-	"github.com/crowdsecurity/crowdsec/pkg/yamlpatch"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
+
+	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
+	"github.com/crowdsecurity/crowdsec/pkg/yamlpatch"
 )
 
 type APICfg struct {
@@ -33,13 +34,13 @@ type ApiCredentialsCfg struct {
 
 /*global api config (for lapi->oapi)*/
 type OnlineApiClientCfg struct {
-	CredentialsFilePath string             `yaml:"credentials_path,omitempty"` //credz will be edited by software, store in diff file
+	CredentialsFilePath string             `yaml:"credentials_path,omitempty"` // credz will be edited by software, store in diff file
 	Credentials         *ApiCredentialsCfg `yaml:"-"`
 }
 
 /*local api config (for crowdsec/cscli->lapi)*/
 type LocalApiClientCfg struct {
-	CredentialsFilePath string             `yaml:"credentials_path,omitempty"` //credz will be edited by software, store in diff file
+	CredentialsFilePath string             `yaml:"credentials_path,omitempty"` // credz will be edited by software, store in diff file
 	Credentials         *ApiCredentialsCfg `yaml:"-"`
 	InsecureSkipVerify  *bool              `yaml:"insecure_skip_verify"` // check if api certificate is bad or not
 }
@@ -138,7 +139,7 @@ func toValidCIDR(ip string) string {
 /*local api service configuration*/
 type LocalApiServerCfg struct {
 	Enable                 *bool               `yaml:"enable"`
-	ListenURI              string              `yaml:"listen_uri,omitempty"` //127.0.0.1:8080
+	ListenURI              string              `yaml:"listen_uri,omitempty"` // 127.0.0.1:8080
 	TLS                    *TLSCfg             `yaml:"tls"`
 	DbConfig               *DatabaseCfg        `yaml:"-"`
 	LogDir                 string              `yaml:"-"`

--- a/pkg/csconfig/api.go
+++ b/pkg/csconfig/api.go
@@ -226,9 +226,7 @@ func (c *Config) LoadAPIServer() error {
 			return errors.Wrap(err, "loading online client credentials")
 		}
 	}
-	if c.API.Server.OnlineClient == nil || c.API.Server.OnlineClient.Credentials == nil {
-		log.Info("push and pull to Central API disabled")
-	}
+
 	if err := c.LoadDBConfig(); err != nil {
 		return err
 	}

--- a/tests/bats/04_nocapi.bats
+++ b/tests/bats/04_nocapi.bats
@@ -31,6 +31,7 @@ teardown() {
 
 @test "without capi: crowdsec LAPI should still work" {
     config_disable_capi
+    config_set '.common.log_media="stdout"'
     run -124 --separate-stderr timeout 1s "${CROWDSEC}"
     # from `man timeout`: If  the  command  times  out,  and --preserve-status is not set, then exit with status 124.
     assert_stderr --partial "push and pull to Central API disabled"

--- a/tests/lib/config/config-global
+++ b/tests/lib/config/config-global
@@ -81,7 +81,7 @@ load_init_data() {
     ./bin/assert-crowdsec-not-running || die "Cannot load fixture data."
 
     if [[ ! -f "${LOCAL_INIT_DIR}/init-config-data.tar" ]]; then
-        die "Initial data not found; did you run '${script_name} make' ?"
+        die "Initial data not found; did you run 'make bats-fixture' ?"
     fi
 
     dump_backend="$(cat "${LOCAL_INIT_DIR}/.backend")"

--- a/tests/lib/config/config-local
+++ b/tests/lib/config/config-local
@@ -137,7 +137,7 @@ load_init_data() {
     ./bin/assert-crowdsec-not-running || die "Cannot load fixture data."
 
     if [[ ! -f "${LOCAL_INIT_DIR}/init-config-data.tar" ]]; then
-        die "Initial data not found; did you run '${script_name} make' ?"
+        die "Initial data not found; did you run 'make bats-fixture' ?"
     fi
 
     dump_backend="$(cat "${LOCAL_INIT_DIR}/.backend")"


### PR DESCRIPTION
This change makes the log initialization happen in a single place, and as soon as possible. This means any info-level messages, like "push and pull blah blah" are not shown in stderr anymore, by default. They end up in the regular logs.