### PR TITLE
improve support for persistent configurations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV CONFIG_FILE=/etc/crowdsec/config.yaml
 # because the configuration might be persistent / have manual edits.
 ENV LOCAL_API_URL=
 ENV CUSTOM_HOSTNAME=localhost
-ENV PLUGIN_DIR=/usr/local/lib/crowdsec/plugins/
+ENV PLUGIN_DIR=
 ENV DISABLE_AGENT=false
 ENV DISABLE_LOCAL_API=false
 ENV DISABLE_ONLINE_API=false
@@ -67,12 +67,12 @@ ENV AGENT_PASSWORD=
 
 ENV USE_TLS=false
 ENV CACERT_FILE=
-ENV CERT_FILE=/etc/ssl/cert.pem
-ENV KEY_FILE=/etc/ssl/key.pem
+ENV CERT_FILE=
+ENV KEY_FILE=
 # comma-separated list of allowed OU values for TLS bouncer certificates
-ENV BOUNCERS_ALLOWED_OU=bouncer-ou
+ENV BOUNCERS_ALLOWED_OU=
 # comma-separated list of allowed OU values for TLS agent certificates
-ENV AGENTS_ALLOWED_OU=agent-ou
+ENV AGENTS_ALLOWED_OU=
 
 # Install the following hub items --------------#
 
@@ -88,7 +88,7 @@ ENV DISABLE_PARSERS=
 ENV DISABLE_SCENARIOS=
 ENV DISABLE_POSTOVERFLOWS=
 
-ENV METRICS_PORT=6060
+ENV METRICS_PORT=
 
 ENTRYPOINT /bin/bash docker_start.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ COPY --from=build /usr/local/bin/cscli /usr/local/bin/cscli
 COPY --from=build /go/src/crowdsec/docker/docker_start.sh /
 COPY --from=build /go/src/crowdsec/docker/config.yaml /staging/etc/crowdsec/config.yaml
 
+# NOTE: setting default values here will overwrite the ones set in config.yaml
+#       every time the container is started. We set the default in docker/config.yaml
+#       and document them in docker/README.md, but keep the variables empty here.
+
 ENV CONFIG_FILE=/etc/crowdsec/config.yaml
 ENV LOCAL_API_URL=
 ENV CUSTOM_HOSTNAME=localhost
@@ -42,7 +46,7 @@ ENV DISABLE_ONLINE_API=false
 ENV DSN=
 ENV TYPE=
 ENV TEST_MODE=false
-ENV USE_WAL=false
+ENV USE_WAL=
 
 # register to app.crowdsec.net
 
@@ -52,9 +56,9 @@ ENV ENROLL_TAGS=
 
 # log verbosity
 
-ENV LEVEL_TRACE=false
-ENV LEVEL_DEBUG=false
-ENV LEVEL_INFO=true
+ENV LEVEL_TRACE=
+ENV LEVEL_DEBUG=
+ENV LEVEL_INFO=
 
 # TLS setup ----------------------------------- #
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# vim: set ft=dockerfile:
 ARG BUILD_ENV=full
 ARG GOVERSION=1.19
 
@@ -32,9 +33,6 @@ COPY --from=build /go/src/crowdsec/docker/docker_start.sh /
 COPY --from=build /go/src/crowdsec/docker/config.yaml /staging/etc/crowdsec/config.yaml
 
 ENV CONFIG_FILE=/etc/crowdsec/config.yaml
-# if LOCAL_API_URL is defined, even with a default, it replaces the value
-# in the config file every time the container starts. we don't want that
-# because the configuration might be persistent / have manual edits.
 ENV LOCAL_API_URL=
 ENV CUSTOM_HOSTNAME=localhost
 ENV PLUGIN_DIR=

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -10,7 +10,9 @@ COPY . .
 
 # wizard.sh requires GNU coreutils
 RUN apt-get update && \
-    apt-get install -y git gcc libc-dev make bash gettext binutils-gold coreutils tzdata && \
+    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    apt-get install -y -q apt-utils 2>/dev/null && \
+    apt-get install -y -q git gcc libc-dev make bash gettext binutils-gold coreutils tzdata && \
     SYSTEM="docker" make release && \
     cd crowdsec-v* && \
     ./wizard.sh --docker-mode && \
@@ -18,11 +20,12 @@ RUN apt-get update && \
     cscli hub update && \
     cscli collections install crowdsecurity/linux && \
     cscli parsers install crowdsecurity/whitelists && \
-    go install github.com/mikefarah/yq/v4@latest
+    go install github.com/mikefarah/yq/v4@v4.30.5
 
 FROM debian:bullseye-slim as build-slim
 
 RUN apt-get update && \
+    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get install -y -q --install-recommends --no-install-suggests \
     procps \
     systemd \
@@ -32,7 +35,8 @@ RUN apt-get update && \
     tzdata && \
     mkdir -p /staging/etc/crowdsec && \
     mkdir -p /staging/var/lib/crowdsec && \
-    mkdir -p /var/lib/crowdsec/data
+    mkdir -p /var/lib/crowdsec/data \
+    yq -n '.url="http://0.0.0.0:8080"' | install -m 0600 /dev/stdin /staging/etc/crowdsec/local_api_credentials.yaml
 
 COPY --from=build /go/bin/yq /usr/local/bin/yq
 COPY --from=build /etc/crowdsec /staging/etc/crowdsec
@@ -43,7 +47,10 @@ COPY --from=build /go/src/crowdsec/docker/config.yaml /staging/etc/crowdsec/conf
 RUN yq eval -i ".plugin_config.group = \"nogroup\"" /staging/etc/crowdsec/config.yaml
 
 ENV CONFIG_FILE=/etc/crowdsec/config.yaml
-ENV LOCAL_API_URL=http://0.0.0.0:8080/
+# if LOCAL_API_URL is defined, even with a default, it replaces the value
+# in the config file every time the container starts. we don't want that
+# because the configuration might be persistent / have manual edits.
+ENV LOCAL_API_URL=
 ENV CUSTOM_HOSTNAME=localhost
 ENV PLUGIN_DIR=/usr/local/lib/crowdsec/plugins/
 ENV DISABLE_AGENT=false
@@ -74,7 +81,7 @@ ENV AGENT_PASSWORD=
 # TLS setup ----------------------------------- #
 
 ENV USE_TLS=false
-ENV CA_CERT_PATH=
+ENV CACERT_FILE=
 ENV CERT_FILE=/etc/ssl/cert.pem
 ENV KEY_FILE=/etc/ssl/key.pem
 # comma-separated list of allowed OU values for TLS bouncer certificates

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -47,12 +47,9 @@ COPY --from=build /go/src/crowdsec/docker/config.yaml /staging/etc/crowdsec/conf
 RUN yq eval -i ".plugin_config.group = \"nogroup\"" /staging/etc/crowdsec/config.yaml
 
 ENV CONFIG_FILE=/etc/crowdsec/config.yaml
-# if LOCAL_API_URL is defined, even with a default, it replaces the value
-# in the config file every time the container starts. we don't want that
-# because the configuration might be persistent / have manual edits.
 ENV LOCAL_API_URL=
 ENV CUSTOM_HOSTNAME=localhost
-ENV PLUGIN_DIR=/usr/local/lib/crowdsec/plugins/
+ENV PLUGIN_DIR=
 ENV DISABLE_AGENT=false
 ENV DISABLE_LOCAL_API=false
 ENV DISABLE_ONLINE_API=false
@@ -82,12 +79,12 @@ ENV AGENT_PASSWORD=
 
 ENV USE_TLS=false
 ENV CACERT_FILE=
-ENV CERT_FILE=/etc/ssl/cert.pem
-ENV KEY_FILE=/etc/ssl/key.pem
+ENV CERT_FILE=
+ENV KEY_FILE=
 # comma-separated list of allowed OU values for TLS bouncer certificates
-ENV BOUNCERS_ALLOWED_OU=bouncer-ou
+ENV BOUNCERS_ALLOWED_OU=
 # comma-separated list of allowed OU values for TLS agent certificates
-ENV AGENTS_ALLOWED_OU=agent-ou
+ENV AGENTS_ALLOWED_OU=
 
 # Install the following hub items --------------#
 
@@ -103,7 +100,7 @@ ENV DISABLE_PARSERS=
 ENV DISABLE_SCENARIOS=
 ENV DISABLE_POSTOVERFLOWS=
 
-ENV METRICS_PORT=6060
+ENV METRICS_PORT=
 
 ENTRYPOINT /bin/bash docker_start.sh
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -46,6 +46,10 @@ COPY --from=build /go/src/crowdsec/docker/docker_start.sh /
 COPY --from=build /go/src/crowdsec/docker/config.yaml /staging/etc/crowdsec/config.yaml
 RUN yq eval -i ".plugin_config.group = \"nogroup\"" /staging/etc/crowdsec/config.yaml
 
+# NOTE: setting default values here will overwrite the ones set in config.yaml
+#       every time the container is started. We set the default in docker/config.yaml
+#       and document them in docker/README.md, but keep the variables empty here.
+
 ENV CONFIG_FILE=/etc/crowdsec/config.yaml
 ENV LOCAL_API_URL=
 ENV CUSTOM_HOSTNAME=localhost
@@ -56,7 +60,7 @@ ENV DISABLE_ONLINE_API=false
 ENV DSN=
 ENV TYPE=
 ENV TEST_MODE=false
-ENV USE_WAL=false
+ENV USE_WAL=
 
 # register to app.crowdsec.net
 
@@ -66,9 +70,9 @@ ENV ENROLL_TAGS=
 
 # log verbosity
 
-ENV LEVEL_TRACE=false
-ENV LEVEL_DEBUG=false
-ENV LEVEL_INFO=true
+ENV LEVEL_TRACE=
+ENV LEVEL_DEBUG=
+ENV LEVEL_INFO=
 
 # TLS setup ----------------------------------- #
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -8,10 +8,11 @@ WORKDIR /go/src/crowdsec
 
 COPY . .
 
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_NOWARNINGS="yes"
+
 # wizard.sh requires GNU coreutils
 RUN apt-get update && \
-    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get install -y -q apt-utils 2>/dev/null && \
     apt-get install -y -q git gcc libc-dev make bash gettext binutils-gold coreutils tzdata && \
     SYSTEM="docker" make release && \
     cd crowdsec-v* && \
@@ -25,7 +26,6 @@ RUN apt-get update && \
 FROM debian:bullseye-slim as build-slim
 
 RUN apt-get update && \
-    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get install -y -q --install-recommends --no-install-suggests \
     procps \
     systemd \

--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -24,14 +24,10 @@ db_config:
   log_level: info
   type: sqlite
   db_path: /var/lib/crowdsec/data/crowdsec.db
-  #user: 
-  #password:
-  #db_name:
-  #host:
-  #port:
   flush:
     max_items: 5000
     max_age: 7d
+  use_wal: false
 api:
   client:
     insecure_skip_verify: false
@@ -45,9 +41,13 @@ api:
       - ::1
     online_client: # Central API credentials (to push signals and receive bad IPs)
       #credentials_path: /etc/crowdsec/online_api_credentials.yaml
-#    tls:
-#      cert_file: /etc/crowdsec/ssl/cert.pem
-#      key_file: /etc/crowdsec/ssl/key.pem
+    tls:
+      cert_file: /etc/ssl/cert.pem
+      key_file: /etc/ssl/key.pem
+      agents_allowed_ou:
+        - agent-ou
+      bouncers_allowed_ou:
+        - bouncer-ou
 prometheus:
   enabled: true
   level: full

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -109,7 +109,6 @@ if isfalse "$DISABLE_AGENT"; then
     if isfalse "$DISABLE_LOCAL_API"; then
         echo "Regenerate local agent credentials"
         cscli machines delete "$CUSTOM_HOSTNAME" 2>/dev/null || true
-        # shellcheck disable=SC2086
         cscli machines add "$CUSTOM_HOSTNAME" --auto --url "$LOCAL_API_URL"
     fi
 
@@ -123,11 +122,18 @@ if isfalse "$DISABLE_AGENT"; then
         with(select(strenv(AGENT_PASSWORD)!=""); .password = strenv(AGENT_PASSWORD))
         ' "$lapi_credentials_path"
     fi
+
     if istrue "$USE_TLS"; then
         conf_set '
             with(select(strenv(CACERT_FILE)!=""); .ca_cert_path = strenv(CACERT_FILE)) |
             with(select(strenv(KEY_FILE)!=""); .key_path = strenv(KEY_FILE)) |
             with(select(strenv(CERT_FILE)!=""); .cert_path = strenv(CERT_FILE)) |
+        ' "$lapi_credentials_path"
+    else
+        conf_set '
+            del(.ca_cert_path) |
+            del(.key_path) |
+            del(.cert_path) |
         ' "$lapi_credentials_path"
     fi
 

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -197,7 +197,7 @@ else
     conf_set 'del(.api.server.tls)'
 fi
 
-conf_set "with(select(strenv(PLUGIN_DIR)!=""); .config_paths.plugin_dir = strenv(PLUGIN_DIR))"
+conf_set 'with(select(strenv(PLUGIN_DIR)!=""); .config_paths.plugin_dir = strenv(PLUGIN_DIR))'
 
 ## Install collections, parsers, scenarios & postoverflows
 cscli hub update

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -8,6 +8,7 @@ shopt -s inherit_errexit
 
 #- HELPER FUNCTIONS ----------------#
 
+# match true, TRUE, True, tRuE, etc.
 istrue() {
   case "$(echo "$1" | tr '[:upper:]' '[:lower:]')" in
     true) return 0 ;;
@@ -23,6 +24,7 @@ isfalse() {
     fi
 }
 
+# csv2yaml <string>
 # generate a yaml list from a comma-separated string of values
 csv2yaml() {
     [ -z "$1" ] && return
@@ -34,6 +36,8 @@ cscli() {
     command cscli -c "$CONFIG_FILE" "$@"
 }
 
+# conf_get <key> [file_path]
+# retrieve a value from a file (by default $CONFIG_FILE)
 conf_get() {
     if [ $# -ge 2 ]; then
         yq e "$1" "$2"
@@ -43,13 +47,13 @@ conf_get() {
 }
 
 # conf_set <yq_expression> [file_path]
-# evaluate a yq command (by default on CONFIG_FILE),
+# evaluate a yq command (by default on $CONFIG_FILE),
 # create the file if it doesn't exist
 conf_set() {
     if [ $# -ge 2 ]; then
-        YAML_FILE=$2
+        YAML_FILE="$2"
     else
-        YAML_FILE=$CONFIG_FILE
+        YAML_FILE="$CONFIG_FILE"
     fi
     YAML_CONTENT=$(cat "$YAML_FILE" 2>/dev/null || true)
     echo "$YAML_CONTENT" | yq e "$1" | install -m 0600 /dev/stdin "$YAML_FILE"

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -165,16 +165,16 @@ if istrue "$USE_TLS"; then
     agents_allowed_yaml=$(csv2yaml "$AGENTS_ALLOWED_OU") \
     bouncers_allowed_yaml=$(csv2yaml "$BOUNCERS_ALLOWED_OU") \
     conf_set '
-        .api.server.tls.ca_cert_path = strenv(CACERT_FILE) |
-        .api.server.tls.cert_file = strenv(CERT_FILE) |
-        .api.server.tls.key_file = strenv(KEY_FILE) |
+        with(select(strenv(CACERT_FILE)!=""); .api.server.tls.ca_cert_path = strenv(CACERT_FILE)) |
+        with(select(strenv(CERT_FILE)!=""); .api.server.tls.cert_file = strenv(CERT_FILE)) |
+        with(select(strenv(KEY_FILE)!=""); .api.server.tls.key_file = strenv(KEY_FILE)) |
         .api.server.tls.bouncers_allowed_ou = env(bouncers_allowed_yaml) |
         .api.server.tls.agents_allowed_ou = env(agents_allowed_yaml) |
         ... comments=""
         '
 fi
 
-conf_set ".config_paths.plugin_dir = strenv(PLUGIN_DIR)"
+conf_set "with(select(strenv(PLUGIN_DIR)!=""); .config_paths.plugin_dir = strenv(PLUGIN_DIR))"
 
 ## Install collections, parsers, scenarios & postoverflows
 cscli hub update
@@ -290,7 +290,7 @@ if istrue "$LEVEL_INFO"; then
     ARGS="$ARGS -info"
 fi
 
-conf_set '.prometheus.listen_port=env(METRICS_PORT)'
+conf_set 'with(select(strenv(METRICS_PORT)!=""); .prometheus.listen_port=env(METRICS_PORT))'
 
 # shellcheck disable=SC2086
 exec crowdsec $ARGS

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -142,7 +142,7 @@ if isfalse "$DISABLE_AGENT"; then
         conf_set '
             with(select(strenv(CACERT_FILE)!=""); .ca_cert_path = strenv(CACERT_FILE)) |
             with(select(strenv(KEY_FILE)!=""); .key_path = strenv(KEY_FILE)) |
-            with(select(strenv(CERT_FILE)!=""); .cert_path = strenv(CERT_FILE)) |
+            with(select(strenv(CERT_FILE)!=""); .cert_path = strenv(CERT_FILE))
         ' "$lapi_credentials_path"
     else
         conf_set '

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -3,6 +3,9 @@
 # shellcheck disable=SC2292      # allow [ test ] syntax
 # shellcheck disable=SC2310      # allow "if function..." syntax with -e
 
+#set -x
+#export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+
 set -e
 shopt -s inherit_errexit
 
@@ -136,7 +139,6 @@ if isfalse "$DISABLE_AGENT"; then
         with(select(strenv(AGENT_USERNAME)!=""); .login = strenv(AGENT_USERNAME)) |
         with(select(strenv(AGENT_PASSWORD)!=""); .password = strenv(AGENT_PASSWORD))
         ' "$lapi_credentials_path"
-    fi
 
     if istrue "$USE_TLS"; then
         conf_set '
@@ -151,6 +153,7 @@ if isfalse "$DISABLE_AGENT"; then
             del(.cert_path)
         ' "$lapi_credentials_path"
     fi
+fi
 
 if isfalse "$DISABLE_LOCAL_API"; then
     echo "Check if lapi needs to automatically register an agent"
@@ -204,8 +207,8 @@ if istrue "$USE_TLS"; then
         with(select(strenv(CACERT_FILE)!=""); .api.server.tls.ca_cert_path = strenv(CACERT_FILE)) |
         with(select(strenv(CERT_FILE)!=""); .api.server.tls.cert_file = strenv(CERT_FILE)) |
         with(select(strenv(KEY_FILE)!=""); .api.server.tls.key_file = strenv(KEY_FILE)) |
-        .api.server.tls.bouncers_allowed_ou = env(bouncers_allowed_yaml) |
-        .api.server.tls.agents_allowed_ou = env(agents_allowed_yaml) |
+        with(select(strenv(BOUNCERS_ALLOWED_OU)!=""); .api.server.tls.bouncers_allowed_ou = env(bouncers_allowed_yaml)) |
+        with(select(strenv(AGENTS_ALLOWED_OU)!=""); .api.server.tls.agents_allowed_ou = env(agents_allowed_yaml)) |
         ... comments=""
         '
 else


### PR DESCRIPTION
Some people like to configure completely from environment variables, others prefer persistent configuration in bind mount or persistent volumes. Since we have data as well in etc (the hub) and don't support all the possible options in envvars, persistent configurations are sometimes necessary.

 - fix a bug with parsing the BOUNCER_KEY variables
 - set all defaults in config.yaml and leave environment variables empty. This way when they are set we know that we must override the values in config.yaml.
 - ignore tainted objects when calling install/upgrade/remove
 - less verbose docker build
 - pinned yq
 - use_wal is false by default (what's the threshold to observe performance issues?)
 