### PR TITLE
docker: separate CLIENT_* and LAPI_* variables for tls certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,11 @@ ENV CLIENT_CACERT_FILE=
 ENV CLIENT_CERT_FILE=
 ENV CLIENT_KEY_FILE=
 
+# deprecated in favor of LAPI_*
+ENV CACERT_FILE=
+ENV CERT_FILE=
+ENV KEY_FILE=
+
 # comma-separated list of allowed OU values for TLS bouncer certificates
 ENV BOUNCERS_ALLOWED_OU=
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY --from=build /usr/local/bin/cscli /usr/local/bin/cscli
 COPY --from=build /go/src/crowdsec/docker/docker_start.sh /
 COPY --from=build /go/src/crowdsec/docker/config.yaml /staging/etc/crowdsec/config.yaml
 
-# NOTE: setting default values here will overwrite the ones set in config.yaml
+# NOTE: setting default values here would overwrite the ones set in config.yaml
 #       every time the container is started. We set the default in docker/config.yaml
 #       and document them in docker/README.md, but keep the variables empty here.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,11 +68,18 @@ ENV AGENT_PASSWORD=
 # TLS setup ----------------------------------- #
 
 ENV USE_TLS=false
-ENV CACERT_FILE=
-ENV CERT_FILE=
-ENV KEY_FILE=
+
+ENV LAPI_CACERT_FILE=
+ENV LAPI_CERT_FILE=
+ENV LAPI_KEY_FILE=
+
+ENV CLIENT_CACERT_FILE=
+ENV CLIENT_CERT_FILE=
+ENV CLIENT_KEY_FILE=
+
 # comma-separated list of allowed OU values for TLS bouncer certificates
 ENV BOUNCERS_ALLOWED_OU=
+
 # comma-separated list of allowed OU values for TLS agent certificates
 ENV AGENTS_ALLOWED_OU=
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -82,11 +82,18 @@ ENV AGENT_PASSWORD=
 # TLS setup ----------------------------------- #
 
 ENV USE_TLS=false
-ENV CACERT_FILE=
-ENV CERT_FILE=
-ENV KEY_FILE=
+
+ENV LAPI_CACERT_FILE=
+ENV LAPI_CERT_FILE=
+ENV LAPI_KEY_FILE=
+
+ENV CLIENT_CACERT_FILE=
+ENV CLIENT_CERT_FILE=
+ENV CLIENT_KEY_FILE=
+
 # comma-separated list of allowed OU values for TLS bouncer certificates
 ENV BOUNCERS_ALLOWED_OU=
+
 # comma-separated list of allowed OU values for TLS agent certificates
 ENV AGENTS_ALLOWED_OU=
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -46,7 +46,7 @@ COPY --from=build /go/src/crowdsec/docker/docker_start.sh /
 COPY --from=build /go/src/crowdsec/docker/config.yaml /staging/etc/crowdsec/config.yaml
 RUN yq eval -i ".plugin_config.group = \"nogroup\"" /staging/etc/crowdsec/config.yaml
 
-# NOTE: setting default values here will overwrite the ones set in config.yaml
+# NOTE: setting default values here would overwrite the ones set in config.yaml
 #       every time the container is started. We set the default in docker/config.yaml
 #       and document them in docker/README.md, but keep the variables empty here.
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -91,6 +91,11 @@ ENV CLIENT_CACERT_FILE=
 ENV CLIENT_CERT_FILE=
 ENV CLIENT_KEY_FILE=
 
+# deprecated in favor of LAPI_*
+ENV CACERT_FILE=
+ENV CERT_FILE=
+ENV KEY_FILE=
+
 # comma-separated list of allowed OU values for TLS bouncer certificates
 ENV BOUNCERS_ALLOWED_OU=
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -226,16 +226,19 @@ Using binds rather than named volumes ([complete explanation here](https://docs.
 |                         | | |
 | __TLS Auth/encryption   | | |
 | `USE_TLS`               | false | Enable TLS on the LAPI |
-| `CERT_FILE`             | /etc/ssl/cert.pem | TLS Certificate path |
-| `KEY_FILE`              | /etc/ssl/key.pem | TLS Key path |
-| `CACERT_FILE`           | | CA certificate bundle |
+| `CLIENT_CERT_FILE`      | /etc/ssl/cert.pem | Client TLS Certificate path |
+| `CLIENT_KEY_FILE`       | /etc/ssl/key.pem | Client TLS Key path |
+| `CLIENT_CACERT_FILE`    | | Client CA certificate bundle |
+| `LAPI_CERT_FILE`        | /etc/ssl/cert.pem | LAPI TLS Certificate path |
+| `LAPI_KEY_FILE`         | /etc/ssl/key.pem | LAPI TLS Key path |
+| `LAPI_CACERT_FILE`      | | LAPI CA certificate bundle |
 | `AGENTS_ALLOWED_OU`     | agent-ou | OU values allowed for agents, separated by comma |
 | `BOUNCERS_ALLOWED_OU`   | bouncer-ou | OU values allowed for bouncers, separated by comma |
 |                         | | |
 | __Hub management__      | | |
 | `COLLECTIONS`           | | Collections to install, separated by space: `-e COLLECTIONS="crowdsecurity/linux crowdsecurity/apache2"` |
-| `SCENARIOS`             | | Scenarios to install, separated by space |
 | `PARSERS`               | | Parsers to install, separated by space |
+| `SCENARIOS`             | | Scenarios to install, separated by space |
 | `POSTOVERFLOWS`         | | Postoverflows to install, separated by space |
 | `DISABLE_COLLECTIONS`   | | Collections to remove, separated by space: `-e DISABLE_COLLECTIONS="crowdsecurity/linux crowdsecurity/nginx"` |
 | `DISABLE_PARSERS`       | | Parsers to remove, separated by space |

--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -42,8 +42,6 @@ api:
     online_client: # Central API credentials (to push signals and receive bad IPs)
       #credentials_path: /etc/crowdsec/online_api_credentials.yaml
     tls:
-      cert_file: /etc/ssl/cert.pem
-      key_file: /etc/ssl/key.pem
       agents_allowed_ou:
         - agent-ou
       bouncers_allowed_ou:

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -91,9 +91,14 @@ cscli_if_clean() {
 #-----------------------------------#
 
 if [ -n "$CERT_FILE" ] || [ -n "$KEY_FILE" ] || [ -n "$CACERT_FILE" ]; then
-    echo "Cannot start crowdsec container: the variables CERT_FILE, KEY_FILE and CACERT_FILE" >&2
-    echo "are not supported since 1.4.4, please replace them with the LAPI_* and CLIENT_* equivalents." >&2
-    exit 1
+    printf '%b' '\033[0;33m'
+    echo "Warning: the variables CERT_FILE, KEY_FILE and CACERT_FILE have been deprecated." >&2
+    echo "Please use LAPI_CERT_FILE, LAPI_KEY_FILE and LAPI_CACERT_FILE insted." >&2
+    echo "The old variables will be removed in a future release." >&2
+    printf '%b' '\033[0m'
+    LAPI_CERT_FILE=${LAPI_CERT_FILE:-$CERT_FILE}
+    LAPI_KEY_FILE=${LAPI_KEY_FILE:-$KEY_FILE}
+    LAPI_CACERT_FILE=${LAPI_CACERT_FILE:-$CACERT_FILE}
 fi
 
 # Check and prestage databases


### PR DESCRIPTION
Legacy configurations (using CERT_FILE, KEY_FILE and CACERT_FILE) still work as long as DISABLE_AGENT=true, otherwise the container crashes looking for the client certificate (in the default location which is now /etc/ssl/crowdsec-client/)