### PR TITLE
feature flags

### DIFF
--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -56,7 +56,7 @@ func initConfig() {
 	logFormatter := &log.TextFormatter{TimestampFormat: "02-01-2006 15:04:05", FullTimestamp: true}
 	log.SetFormatter(logFormatter)
 
-	if err = fflag.CrowdsecFeatures.SetFromEnv("CROWDSEC_FEATURE_", log.New()); err != nil {
+	if err = fflag.CrowdsecFeatures.SetFromEnv("CROWDSEC_FEATURE_", log.StandardLogger()); err != nil {
 		log.Fatalf("failed to set features from env: %s", err)
 	}
 
@@ -74,7 +74,7 @@ func initConfig() {
 	}
 
 	featurePath := filepath.Join(csConfig.ConfigPaths.ConfigDir, "feature.yaml")
-	if err = fflag.CrowdsecFeatures.SetFromYamlFile(featurePath, log.New()); err != nil {
+	if err = fflag.CrowdsecFeatures.SetFromYamlFile(featurePath, log.StandardLogger()); err != nil {
 		log.Fatalf("File %s: %s", featurePath, err)
 	}
 
@@ -142,7 +142,7 @@ var (
 func main() {
 	// some features can require configuration or command-line options,
 	// so we need to parse them asap. we'll load from feature.yaml later.
-	fflag.CrowdsecFeatures.SetFromEnv("CROWDSEC_FEATURE_", log.New())
+	fflag.CrowdsecFeatures.SetFromEnv("CROWDSEC_FEATURE_", log.StandardLogger())
 
 	var rootCmd = &cobra.Command{
 		Use:   "cscli",

--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -53,12 +53,6 @@ func initConfig() {
 	} else if err_lvl {
 		log.SetLevel(log.ErrorLevel)
 	}
-	logFormatter := &log.TextFormatter{TimestampFormat: "02-01-2006 15:04:05", FullTimestamp: true}
-	log.SetFormatter(logFormatter)
-
-	if err = fflag.CrowdsecFeatures.SetFromEnv("CROWDSEC_FEATURE_", log.StandardLogger()); err != nil {
-		log.Fatalf("failed to set features from env: %s", err)
-	}
 
 	if !inSlice(os.Args[1], NoNeedConfig) {
 		csConfig, err = csconfig.NewConfig(ConfigFilePath, false, false)
@@ -140,6 +134,10 @@ var (
 )
 
 func main() {
+	// set the formatter asap and worry about level later
+	logFormatter := &log.TextFormatter{TimestampFormat: "02-01-2006 15:04:05", FullTimestamp: true}
+	log.SetFormatter(logFormatter)
+
 	// some features can require configuration or command-line options,
 	// so we need to parse them asap. we'll load from feature.yaml later.
 	fflag.CrowdsecFeatures.SetFromEnv("CROWDSEC_FEATURE_", log.StandardLogger())

--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/database"
+	"github.com/crowdsecurity/crowdsec/pkg/fflag"
 )
 
 var bincoverTesting = ""
@@ -130,6 +131,9 @@ var (
 )
 
 func main() {
+	// some features can require configuration or command-line options,
+	// so we need to parse them asap. we'll load from feature.yaml later.
+	fflag.CrowdsecFeatures.SetFromEnv("CROWDSEC_FEATURE_", log.New())
 
 	var rootCmd = &cobra.Command{
 		Use:   "cscli",

--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -56,6 +56,10 @@ func initConfig() {
 	logFormatter := &log.TextFormatter{TimestampFormat: "02-01-2006 15:04:05", FullTimestamp: true}
 	log.SetFormatter(logFormatter)
 
+	if err = fflag.CrowdsecFeatures.SetFromEnv("CROWDSEC_FEATURE_", log.New()); err != nil {
+		log.Fatalf("failed to set features from env: %s", err)
+	}
+
 	if !inSlice(os.Args[1], NoNeedConfig) {
 		csConfig, err = csconfig.NewConfig(ConfigFilePath, false, false)
 		if err != nil {
@@ -67,6 +71,11 @@ func initConfig() {
 		}
 	} else {
 		csConfig = csconfig.NewDefaultConfig()
+	}
+
+	featurePath := filepath.Join(csConfig.ConfigPaths.ConfigDir, "feature.yaml")
+	if err = fflag.CrowdsecFeatures.SetFromYamlFile(featurePath, log.New()); err != nil {
+		log.Fatalf("File %s: %s", featurePath, err)
 	}
 
 	if csConfig.Cscli == nil {

--- a/cmd/crowdsec-cli/support.go
+++ b/cmd/crowdsec-cli/support.go
@@ -22,6 +22,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/database"
+	"github.com/crowdsecurity/crowdsec/pkg/fflag"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
@@ -30,6 +31,7 @@ const (
 	SUPPORT_METRICS_HUMAN_PATH           = "metrics/metrics.human"
 	SUPPORT_METRICS_PROMETHEUS_PATH      = "metrics/metrics.prometheus"
 	SUPPORT_VERSION_PATH                 = "version.txt"
+	SUPPORT_FEATURES_PATH                = "features.txt"
 	SUPPORT_OS_INFO_PATH                 = "osinfo.txt"
 	SUPPORT_PARSERS_PATH                 = "hub/parsers.txt"
 	SUPPORT_SCENARIOS_PATH               = "hub/scenarios.txt"
@@ -88,6 +90,20 @@ func collectVersion() []byte {
 	log.Info("Collecting version")
 	return []byte(cwversion.ShowStr())
 }
+
+func collectFeatures() []byte {
+	log.Info("Collecting feature flags")
+	featStatus, err := fflag.GetFeatureStatus(fflag.CrowdsecFeatures)
+	if err != nil {
+		return []byte(fmt.Sprintf("failed to get feature status: %s", err))
+	}
+	w := bytes.NewBuffer(nil)
+	for k, v := range featStatus {
+		fmt.Fprintf(w, "%s: %v", k, v)
+	}
+	return w.Bytes()
+}
+
 
 func collectOSInfo() ([]byte, error) {
 	log.Info("Collecting OS info")
@@ -264,6 +280,7 @@ cscli support dump -f /tmp/crowdsec-support.zip
 			var skipHub, skipDB, skipCAPI, skipLAPI, skipAgent bool
 			infos := map[string][]byte{
 				SUPPORT_VERSION_PATH: collectVersion(),
+				SUPPORT_FEATURES_PATH: collectFeatures(),
 			}
 
 			if outFile == "" {

--- a/cmd/crowdsec-cli/support.go
+++ b/cmd/crowdsec-cli/support.go
@@ -91,17 +91,15 @@ func collectVersion() []byte {
 	return []byte(cwversion.ShowStr())
 }
 
-func collectFeatures() ([]byte, error) {
+func collectFeatures() []byte {
 	log.Info("Collecting feature flags")
-	featStatus, err := fflag.CrowdsecFeatures.GetFeatureStatus()
-	if err != nil {
-		return nil, err
-	}
+	enabledFeatures := fflag.CrowdsecFeatures.GetEnabledFeatures()
+
 	w := bytes.NewBuffer(nil)
-	for k, v := range featStatus {
-		fmt.Fprintf(w, "%s: %v", k, v)
+	for _, k := range enabledFeatures {
+		fmt.Fprintf(w, "%s\n", k)
 	}
-	return w.Bytes(), err
+	return w.Bytes()
 }
 
 
@@ -280,6 +278,7 @@ cscli support dump -f /tmp/crowdsec-support.zip
 			var skipHub, skipDB, skipCAPI, skipLAPI, skipAgent bool
 			infos := map[string][]byte{
 				SUPPORT_VERSION_PATH: collectVersion(),
+				SUPPORT_FEATURES_PATH: collectFeatures(),
 			}
 
 			if outFile == "" {
@@ -339,12 +338,6 @@ cscli support dump -f /tmp/crowdsec-support.zip
 			if err != nil {
 				log.Warnf("could not collect OS information: %s", err)
 				infos[SUPPORT_OS_INFO_PATH] = []byte(err.Error())
-			}
-
-			infos[SUPPORT_FEATURES_PATH], err = collectFeatures()
-			if err != nil {
-				log.Warnf("could not collect feature flag information: %s", err)
-				infos[SUPPORT_FEATURES_PATH] = []byte(err.Error())
 			}
 
 			infos[SUPPORT_CROWDSEC_CONFIG_PATH] = collectCrowdsecConfig()

--- a/cmd/crowdsec-cli/support.go
+++ b/cmd/crowdsec-cli/support.go
@@ -309,7 +309,7 @@ cscli support dump -f /tmp/crowdsec-support.zip
 				skipLAPI = true
 			}
 
-			if csConfig.API.Server == nil || csConfig.API.Server.OnlineClient.Credentials == nil {
+			if csConfig.API.Server == nil || csConfig.API.Server.OnlineClient == nil || csConfig.API.Server.OnlineClient.Credentials == nil {
 				log.Warn("no CAPI credentials found, skipping CAPI connectivity check")
 				skipCAPI = true
 			}

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -330,7 +330,12 @@ func LoadFeatureFlags(cConfig *csconfig.Config, logger *log.Logger) error {
 			enabledFeatures = append(enabledFeatures, feature)
 		}
 	}
-	logger.Infof("Enabled features: %s", strings.Join(enabledFeatures, ", "))
+
+	msg := "<none>"
+	if len(enabledFeatures) > 0 {
+		msg = strings.Join(enabledFeatures, ", ")
+	}
+	logger.Infof("Enabled features: %s", msg)
 
 	return nil
 }

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/csplugin"
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
+	"github.com/crowdsecurity/crowdsec/pkg/fflag"
 	"github.com/crowdsecurity/crowdsec/pkg/leakybucket"
 	"github.com/crowdsecurity/crowdsec/pkg/parser"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
@@ -231,6 +232,7 @@ func newLogLevel(curLevelPtr *log.Level, f *Flags) *log.Level {
 }
 
 // LoadConfig returns a configuration parsed from configuration file
+// XXX better name/description
 func LoadConfig(cConfig *csconfig.Config) error {
 	cConfig.Common.LogLevel = newLogLevel(cConfig.Common.LogLevel, flags)
 
@@ -322,6 +324,9 @@ func exitWithCode(exitCode int, err error) {
 var crowdsecT0 time.Time
 
 func main() {
+	// some features can require configuration or command-line options,
+	// so wwe need to parse them asap. we'll load from feature.yaml later.
+	fflag.CrowdsecFeatures.SetFromEnv("CROWDSEC_FEATURE_", log.New())
 	crowdsecT0 = time.Now()
 
 	defer types.CatchPanic("crowdsec/main")

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -318,18 +318,7 @@ func LoadFeatureFlags(cConfig *csconfig.Config, logger *log.Logger) error {
 		return fmt.Errorf("file %s: %s", featurePath, err)
 	}
 
-	enabledFeatures := []string{}
-
-	featureStatus, err := fflag.CrowdsecFeatures.GetFeatureStatus()
-	if err != nil {
-		return fmt.Errorf("unable to get feature status: %s", err)
-	}
-
-	for feature, enabled := range featureStatus {
-		if enabled {
-			enabledFeatures = append(enabledFeatures, feature)
-		}
-	}
+	enabledFeatures := fflag.CrowdsecFeatures.GetEnabledFeatures()
 
 	msg := "<none>"
 	if len(enabledFeatures) > 0 {

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/aquasecurity/table v1.8.0
 	github.com/beevik/etree v1.1.0
 	github.com/blackfireio/osinfo v1.0.3
+	github.com/goccy/go-yaml v1.9.7
 	github.com/google/winops v0.0.0-20211216095627-f0e86eb1453b
 	github.com/ivanpirog/coloredcobra v1.0.1
 	github.com/mattn/go-isatty v0.0.14
@@ -108,7 +109,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator/v10 v10.10.0 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/goccy/go-yaml v1.9.7 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/glog v0.0.0-20210429001901-424d2337a529 // indirect

--- a/go.mod
+++ b/go.mod
@@ -108,6 +108,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator/v10 v10.10.0 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/goccy/go-yaml v1.9.7 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/glog v0.0.0-20210429001901-424d2337a529 // indirect
@@ -169,6 +170,7 @@ require (
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 // indirect
 	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,7 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
@@ -372,6 +373,8 @@ github.com/gobuffalo/packd v0.1.0/go.mod h1:M2Juc+hhDXf/PnmBANFCqx4DM3wRbgDvnVWe
 github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGtJQZ0Odn4pQ=
 github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/VCm/3ptBN+0=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
+github.com/goccy/go-yaml v1.9.7 h1:D/Vx+JITklB1ugSkncB4BNR67M3X6AKs9+rqVeo3ddw=
+github.com/goccy/go-yaml v1.9.7/go.mod h1:JubOolP3gh0HpiBc4BLRD4YmjEjHAmIIB2aaXKkTfoE=
 github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
@@ -651,6 +654,7 @@ github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcncea
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
@@ -1173,6 +1177,7 @@ golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220406163625-3f8b81556e12/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1264,6 +1269,7 @@ golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/go.sum
+++ b/go.sum
@@ -668,7 +668,6 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.15 h1:vfoHhTN1af61xCRSWzFIWzx2YskyMTwHLrExkBOjvxI=

--- a/pkg/acquisition/acquisition_test.go
+++ b/pkg/acquisition/acquisition_test.go
@@ -176,7 +176,7 @@ wowo: ajsajasjas
 			yaml.Unmarshal([]byte(tc.String), &common)
 			ds, err := DataSourceConfigure(common)
 			cstest.RequireErrorContains(t, err, tc.ExpectedError)
-			if tc.ExpectedError != "" {
+			if tc.ExpectedError == "" {
 				return
 			}
 

--- a/pkg/acquisition/acquisition_test.go
+++ b/pkg/acquisition/acquisition_test.go
@@ -176,7 +176,7 @@ wowo: ajsajasjas
 			yaml.Unmarshal([]byte(tc.String), &common)
 			ds, err := DataSourceConfigure(common)
 			cstest.RequireErrorContains(t, err, tc.ExpectedError)
-			if tc.ExpectedError == "" {
+			if tc.ExpectedError != "" {
 				return
 			}
 

--- a/pkg/cstest/utils.go
+++ b/pkg/cstest/utils.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	logtest "github.com/sirupsen/logrus/hooks/test"
 )
 
 func AssertErrorContains(t *testing.T, err error, expectedErr string) {
@@ -20,6 +22,21 @@ func AssertErrorContains(t *testing.T, err error, expectedErr string) {
 	assert.NoError(t, err)
 }
 
+func AssertErrorMessage(t *testing.T, err error, expectedErr string) {
+	t.Helper()
+
+	if expectedErr != "" {
+		errmsg := ""
+		if err != nil {
+			errmsg = err.Error()
+		}
+		assert.Equal(t, expectedErr, errmsg)
+		return
+	}
+
+	require.NoError(t, err)
+}
+
 func RequireErrorContains(t *testing.T, err error, expectedErr string) {
 	t.Helper()
 
@@ -30,6 +47,42 @@ func RequireErrorContains(t *testing.T, err error, expectedErr string) {
 
 	require.NoError(t, err)
 }
+
+func RequireErrorMessage(t *testing.T, err error, expectedErr string) {
+	t.Helper()
+
+	if expectedErr != "" {
+		errmsg := ""
+		if err != nil {
+			errmsg = err.Error()
+		}
+		require.Equal(t, expectedErr, errmsg)
+		return
+	}
+
+	require.NoError(t, err)
+}
+
+func RequireLogContains(t *testing.T, hook *logtest.Hook, expected string) {
+	t.Helper()
+
+	// look for a log entry that matches the expected message
+	for _, entry := range hook.AllEntries() {
+		if strings.Contains(entry.Message, expected) {
+			return
+		}
+	}
+
+	// show all hook entries, in case the test fails we'll need them
+	for _, entry := range hook.AllEntries() {
+		t.Logf("log entry: %s", entry.Message)
+	}
+
+	require.Fail(t, "no log entry found with message", expected)
+}
+
+
+
 
 // Interpolate fills a string template with the given values, can be map or struct.
 // example: Interpolate("{{.Name}}", map[string]string{"Name": "JohnDoe"})

--- a/pkg/cstest/utils.go
+++ b/pkg/cstest/utils.go
@@ -81,9 +81,6 @@ func RequireLogContains(t *testing.T, hook *logtest.Hook, expected string) {
 	require.Fail(t, "no log entry found with message", expected)
 }
 
-
-
-
 // Interpolate fills a string template with the given values, can be map or struct.
 // example: Interpolate("{{.Name}}", map[string]string{"Name": "JohnDoe"})
 func Interpolate(s string, data interface{}) (string, error) {

--- a/pkg/fflag/crowdsec.go
+++ b/pkg/fflag/crowdsec.go
@@ -1,0 +1,5 @@
+package fflag
+
+var CrowdsecFeatures = FeatureMap{
+	"cscli_setup": {},
+}

--- a/pkg/fflag/features.go
+++ b/pkg/fflag/features.go
@@ -210,9 +210,9 @@ func (fm FeatureMap) SetFromEnv(prefix string, logger *logrus.Logger) error {
 }
 
 func (fm FeatureMap) SetFromYaml(r io.Reader, logger *logrus.Logger) error {
-	// read config file
 	var cfg map[string]bool
 
+	// parse config file
 	if err := yaml.NewDecoder(r).Decode(&cfg); err != nil {
 		if !errors.Is(err, io.EOF) {
 			return fmt.Errorf("failed to parse feature flags: %w", err)
@@ -251,12 +251,12 @@ func (fm FeatureMap) SetFromYaml(r io.Reader, logger *logrus.Logger) error {
 	return nil
 }
 
-// testme.
 func (fm FeatureMap) SetFromYamlFile(path string, logger *logrus.Logger) error {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			logger.Debugf("Feature flags config file '%s' does not exist", path)
+
 			return nil
 		}
 
@@ -269,10 +269,10 @@ func (fm FeatureMap) SetFromYamlFile(path string, logger *logrus.Logger) error {
 	return fm.SetFromYaml(f, logger)
 }
 
-// testme
-// Return the list of enabled features (for cscli support dump).
-func GetFeatureStatus(fm FeatureMap) (map[string]bool, error) {
+// GetFeatureStatus returns the runtime status of all feature flags
+func (fm FeatureMap) GetFeatureStatus() (map[string]bool, error) {
 	var err error
+
 	fstatus := make(map[string]bool)
 
 	for k := range fm {
@@ -284,4 +284,3 @@ func GetFeatureStatus(fm FeatureMap) (map[string]bool, error) {
 
 	return fstatus, nil
 }
-

--- a/pkg/fflag/features.go
+++ b/pkg/fflag/features.go
@@ -271,19 +271,17 @@ func (fm FeatureMap) SetFromYamlFile(path string, logger *logrus.Logger) error {
 
 // testme
 // Return the list of enabled features (for cscli support dump).
-func EnabledFeatureFlags(fm FeatureMap) ([]string, error) {
-	var enabled []string
+func GetFeatureStatus(fm FeatureMap) (map[string]bool, error) {
+	var err error
+	fstatus := make(map[string]bool)
 
-	for name := range fm {
-		ok, err := fm.IsFeatureEnabled(name)
+	for k := range fm {
+		fstatus[k], err = fm.IsFeatureEnabled(k)
 		if err != nil {
 			return nil, err
 		}
-
-		if ok {
-			enabled = append(enabled, name)
-		}
 	}
 
-	return enabled, nil
+	return fstatus, nil
 }
+

--- a/pkg/fflag/features.go
+++ b/pkg/fflag/features.go
@@ -1,0 +1,289 @@
+// Package fflag provides a simple feature flag system.
+//
+// Feature names are lowercase and can only contain letters, numbers, undercores
+// and dots.
+//
+// good: "foo", "foo_bar", "foo.bar"
+// bad: "Foo", "foo-bar"
+//
+// A feature flag can be enabled or disabled. It can also be deprecated or
+// retired. A deprecated feature flag is still accepted but a warning is
+// logged. A retired feature flag is ignored and an error is logged.
+//
+// Feature flags can be set from environment variables or from a config file.
+//
+// I.e. CROWDSEC_FEATURE_FOO_BAR=true
+// or in features.yaml:
+// ---
+// foo_bar: true
+//
+// If a feature flag is set from both, the first one that is parsed (usually
+// environment variables) takes precedence. If the value in the second one
+// does not match the value already set, an error is logged. This is done
+// to highlight inconsistencies in the configuration.
+package fflag
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/sirupsen/logrus"
+)
+
+type Feature struct {
+	UserEnabled    *bool  // has the user explicitly enabled/disabled this feature?
+	DefaultEnabled bool   // Default value of the feature flag.
+	Deprecated     bool   // Is the feature flag deprecated?
+	Retired        bool   // Is the feature flag retired?
+	DeprecationMsg string // Why was it deprecated? What happens next? What should the user do?
+}
+
+type FeatureMap map[string]Feature
+
+// These are returned by the constructor.
+var (
+	ErrFeatureNameEmpty   = errors.New("name is empty")
+	ErrFeatureNameCase    = errors.New("name is not lowercase")
+	ErrFeatureNameInvalid = errors.New("invalid name (allowed a-z, 0-9, _, .)")
+)
+
+var (
+	ErrFeatureUnknown      = errors.New("unknown feature flag")
+	ErrFeatureDeprecated   = errors.New("the flag is deprecated")
+	ErrFeatureInvalidValue = errors.New("invalid value (must be 'true' or 'false')")
+	ErrFeatureAlreadySet   = errors.New("feature is already set")
+)
+
+func FeatureDeprecatedError(feat Feature) error {
+	if feat.DeprecationMsg != "" {
+		return fmt.Errorf("%w: %s", ErrFeatureDeprecated, feat.DeprecationMsg)
+	}
+
+	return ErrFeatureDeprecated
+}
+
+var ErrFeatureRetired = errors.New("the flag has been retired")
+
+func FeatureRetiredError(feat Feature) error {
+	if feat.DeprecationMsg != "" {
+		return fmt.Errorf("%w: %s", ErrFeatureDeprecated, feat.DeprecationMsg)
+	}
+
+	return ErrFeatureDeprecated
+}
+
+var featureNameRexp = regexp.MustCompile(`^[a-z0-9_\.]+$`)
+
+func validateFeatureName(featureName string) error {
+	if featureName == "" {
+		return ErrFeatureNameEmpty
+	}
+
+	if featureName != strings.ToLower(featureName) {
+		return ErrFeatureNameCase
+	}
+
+	if !featureNameRexp.MatchString(featureName) {
+		return ErrFeatureNameInvalid
+	}
+
+	return nil
+}
+
+func NewFeatureMap(features map[string]Feature) (FeatureMap, error) {
+	// XXX should not actually receive a Feature (i.e. Enabled must be nil, and
+	// it cannot be retired==true && deprecated==false))
+	fm := make(FeatureMap)
+
+	for k, v := range features {
+		if err := validateFeatureName(k); err != nil {
+			return nil, fmt.Errorf("Feature flag '%s': %w", k, err)
+		}
+
+		fm[k] = v
+	}
+
+	return fm, nil
+}
+
+func (fm FeatureMap) IsFeatureEnabled(featureName string) (bool, error) {
+	feat, ok := fm[featureName]
+	if !ok {
+		return false, fmt.Errorf("Feature flag '%s': %w", featureName, ErrFeatureUnknown)
+	}
+
+	if feat.UserEnabled != nil {
+		return *feat.UserEnabled, nil
+	}
+
+	return feat.DefaultEnabled, nil
+}
+
+func (fm FeatureMap) SetFeature(featureName string, value bool) error {
+	var ret error
+
+	feat, ok := fm[featureName]
+	if !ok {
+		return fmt.Errorf("Feature flag '%s': %w", featureName, ErrFeatureUnknown)
+	}
+
+	// retired feature flags are ignored
+	if feat.Retired {
+		return fmt.Errorf("Feature flag '%s': %w", featureName, FeatureRetiredError(feat))
+	}
+
+	// deprecated feature flags are still accepted, but a warning is triggered.
+	// We return an error but set the feature anyway.
+	if feat.Deprecated {
+		ret = fmt.Errorf("Feature flag '%s': %w", featureName, FeatureDeprecatedError(feat))
+	}
+
+	// return error if the feature flag has been set with a different value
+	// (i.e. enabled by environment variable and disabled in config file, the
+	// environment variable takes precedence)
+	if feat.UserEnabled != nil && *feat.UserEnabled != value {
+		return fmt.Errorf("Feature flag '%s': %w to %t", featureName, ErrFeatureAlreadySet, *feat.UserEnabled)
+	}
+
+	feat.UserEnabled = &value
+	fm[featureName] = feat
+
+	return ret
+}
+
+func (fm FeatureMap) SetFromEnv(prefix string, logger *logrus.Logger) error {
+	for _, e := range os.Environ() {
+		// ignore non-feature variables
+		if !strings.HasPrefix(e, prefix) {
+			continue
+		}
+
+		// extract feature name and value
+		pair := strings.SplitN(e, "=", 2)
+		varName := pair[0]
+		featureName := strings.ToLower(varName[len(prefix):])
+		value := pair[1]
+
+		var enable bool
+
+		switch value {
+		case "true":
+			enable = true
+		case "false":
+			enable = false
+		default:
+			logger.Errorf("Ignored envvar %s=%s: %v", varName, value, ErrFeatureInvalidValue)
+			continue
+		}
+
+		err := fm.SetFeature(featureName, enable)
+
+		switch {
+		case errors.Is(err, ErrFeatureUnknown):
+			logger.Errorf("Ignored envvar '%s': %s", varName, err)
+			continue
+		case errors.Is(err, ErrFeatureDeprecated):
+			logger.Warningf("Envvar '%s': %s", varName, err)
+		case errors.Is(err, ErrFeatureRetired):
+			logger.Errorf("Ignored envvar '%s': %s", varName, err)
+			continue
+		case errors.Is(err, ErrFeatureAlreadySet):
+			logger.Warningf("Ignored envvar '%s': %s", varName, err)
+			continue
+		case err != nil:
+			return err
+		}
+
+		if enable {
+			logger.Infof("Enabled feature '%s' with envvar '%s'", featureName, varName)
+		} else {
+			logger.Infof("Disabled feature '%s' with envvar '%s'", featureName, varName)
+		}
+	}
+
+	return nil
+}
+
+func (fm FeatureMap) SetFromYaml(r io.Reader, logger *logrus.Logger) error {
+	// read config file
+	var cfg map[string]bool
+
+	if err := yaml.NewDecoder(r).Decode(&cfg); err != nil {
+		if !errors.Is(err, io.EOF) {
+			return fmt.Errorf("failed to parse feature flags: %w", err)
+		}
+
+		logger.Debug("No feature flags in config file")
+	}
+
+	// set features
+	for k, v := range cfg {
+		err := fm.SetFeature(k, v)
+
+		switch {
+		case errors.Is(err, ErrFeatureUnknown):
+			logger.Errorf("Ignored feature '%s': %s", k, err)
+			continue
+		case errors.Is(err, ErrFeatureDeprecated):
+			logger.Warningf("Feature '%s': %s", k, err)
+		case errors.Is(err, ErrFeatureRetired):
+			logger.Errorf("Ignored feature '%s': %s", k, err)
+			continue
+		case errors.Is(err, ErrFeatureAlreadySet):
+			logger.Warningf("Ignored feature '%s': %s", k, err)
+			continue
+		case err != nil:
+			return err
+		}
+
+		if v {
+			logger.Infof("Enabled feature '%s' with config file", k)
+		} else {
+			logger.Infof("Disabled feature '%s' with config file", k)
+		}
+	}
+
+	return nil
+}
+
+// testme.
+func (fm FeatureMap) SetFromYamlFile(path string, logger *logrus.Logger) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Debugf("Feature flags config file '%s' does not exist", path)
+			return nil
+		}
+
+		return fmt.Errorf("failed to open feature flags file: %w", err)
+	}
+	defer f.Close()
+
+	logger.Debugf("Reading feature flags from %s", path)
+
+	return fm.SetFromYaml(f, logger)
+}
+
+// testme
+// Return the list of enabled features (for cscli support dump).
+func EnabledFeatureFlags(fm FeatureMap) ([]string, error) {
+	var enabled []string
+
+	for name := range fm {
+		ok, err := fm.IsFeatureEnabled(name)
+		if err != nil {
+			return nil, err
+		}
+
+		if ok {
+			enabled = append(enabled, name)
+		}
+	}
+
+	return enabled, nil
+}

--- a/pkg/fflag/features_test.go
+++ b/pkg/fflag/features_test.go
@@ -132,7 +132,7 @@ func TestIsFeatureEnabled(t *testing.T) {
 		}, {
 			name:        "feature that does not exist",
 			feature:     "will_never_exist",
-			expectedErr: "Feature flag 'will_never_exist': unknown feature flag",
+			expectedErr: "unknown feature",
 		},
 	}
 
@@ -177,7 +177,7 @@ func TestSetFeature(t *testing.T) {
 			feature:        "experimental1",
 			value:          false,
 			expected:       true,
-			expectedSetErr: "Feature flag 'experimental1': feature is already set to true",
+			expectedSetErr: "the feature is already set to true",
 		}, {
 			name:     "disable an experimental feature, explicitly",
 			feature:  "experimental2",
@@ -193,51 +193,50 @@ func TestSetFeature(t *testing.T) {
 			feature:        "bad_idea",
 			value:          true,
 			expected:       true,
-			expectedSetErr: "Feature flag 'bad_idea': the flag is deprecated",
+			expectedSetErr: "the flag is deprecated",
 		}, {
 			name:           "enable a deprecated feature which defaults to true",
 			feature:        "gone_mainstream1",
 			value:          true,
 			expected:       true,
-			expectedSetErr: "Feature flag 'gone_mainstream1': the flag is deprecated",
+			expectedSetErr: "the flag is deprecated",
 		}, {
 			name:           "disable a deprecated feature which defaults to true",
 			feature:        "gone_mainstream2",
 			value:          false,
 			expected:       false,
-			expectedSetErr: "Feature flag 'gone_mainstream2': the flag is deprecated",
+			expectedSetErr: "the flag is deprecated",
 		}, {
 			name:           "enable a feature that will be retired in v2, default true",
 			feature:        "will_be_standard_in_v2",
 			value:          true,
 			expected:       true,
-			expectedSetErr: "Feature flag 'will_be_standard_in_v2': the flag is deprecated: in 2.0 we'll do that by default",
+			expectedSetErr: "the flag is deprecated: in 2.0 we'll do that by default",
 		}, {
 			name:           "enable a feature that will be retired in v2, default false",
 			feature:        "will_be_abandoned_in_v2",
 			value:          true,
 			expected:       true,
-			expectedSetErr: "Feature flag 'will_be_abandoned_in_v2': the flag is deprecated: in 2.0 we'll have a better way to do it",
+			expectedSetErr: "the flag is deprecated: in 2.0 we'll have a better way to do it",
 		}, {
 			name:     "enable a feature that was retired in v1.5, default true",
 			feature:  "was_adopted_in_v1.5",
 			value:    true,
 			expected: true,
-			expectedSetErr: "Feature flag 'was_adopted_in_v1.5': the flag is deprecated: " +
-				"the trinket was implemented in 1.5 with the --funnybunny command line option",
+			expectedSetErr: "the flag is deprecated: the trinket was implemented in 1.5 with the --funnybunny command line option",
 		}, {
 			name:     "enable a feature that was retired in v1.5, default false",
 			feature:  "was_abandoned_in_v1.5",
 			value:    true,
 			expected: false,
-			expectedSetErr: "Feature flag 'was_abandoned_in_v1.5': the flag is deprecated: " +
+			expectedSetErr: "the flag is deprecated: " +
 				"the magic button didn't work as expected and has been removed in 1.5",
 		}, {
 			name:           "enable a feature that does not exist",
 			feature:        "will_never_exist",
 			value:          true,
-			expectedSetErr: "Feature flag 'will_never_exist': unknown feature flag",
-			expectedGetErr: "Feature flag 'will_never_exist': unknown feature flag",
+			expectedSetErr: "unknown feature",
+			expectedGetErr: "unknown feature",
 		},
 	}
 
@@ -280,7 +279,7 @@ func TestSetFromEnv(t *testing.T) {
 			name:        "enable a feature flag",
 			envvar:      "FFLAG_TEST_EXPERIMENTAL1",
 			value:       "true",
-			expectedLog: []string{"Enabled feature 'experimental1' with envvar 'FFLAG_TEST_EXPERIMENTAL1'"},
+			expectedLog: []string{"Feature flag: experimental1=true (from envvar)"},
 		}, {
 			name:        "invalid value (not true or false)",
 			envvar:      "FFLAG_TEST_EXPERIMENTAL1",
@@ -290,23 +289,23 @@ func TestSetFromEnv(t *testing.T) {
 			name:        "feature flag that is unknown",
 			envvar:      "FFLAG_TEST_WILL_NEVER_EXIST",
 			value:       "true",
-			expectedLog: []string{"Ignored envvar 'FFLAG_TEST_WILL_NEVER_EXIST': Feature flag 'will_never_exist': unknown feature"},
+			expectedLog: []string{"Ignored envvar 'FFLAG_TEST_WILL_NEVER_EXIST': unknown feature"},
 		}, {
 			name:   "enable a deprecated feature",
 			envvar: "FFLAG_TEST_BAD_IDEA",
 			value:  "true",
 			expectedLog: []string{
-				"Envvar 'FFLAG_TEST_BAD_IDEA': Feature flag 'bad_idea': the flag is deprecated",
-				"Enabled feature 'bad_idea' with envvar 'FFLAG_TEST_BAD_IDEA'",
+				"Envvar 'FFLAG_TEST_BAD_IDEA': the flag is deprecated",
+				"Feature flag: bad_idea=true (from envvar)",
 			},
 		}, {
 			name:   "enable a feature that was retired (adopted) in v1.5",
 			envvar: "FFLAG_TEST_WAS_ADOPTED_IN_V1.5",
 			value:  "true",
 			expectedLog: []string{
-				"Envvar 'FFLAG_TEST_WAS_ADOPTED_IN_V1.5': Feature flag 'was_adopted_in_v1.5': " +
-					"the flag is deprecated: the trinket was implemented in 1.5 with the --funnybunny " +
-					"command line option",
+				"Envvar 'FFLAG_TEST_WAS_ADOPTED_IN_V1.5': the flag is deprecated: " +
+				"the trinket was implemented in 1.5 with the --funnybunny command line option",
+				"Feature flag: was_adopted_in_v1.5=true (from envvar)",
 			},
 		}, {
 			// this is unlikely to happen, because environment
@@ -315,7 +314,7 @@ func TestSetFromEnv(t *testing.T) {
 			envvar: "FFLAG_TEST_EXPERIMENTAL1",
 			value:  "false",
 			expectedLog: []string{
-				"Ignored envvar 'FFLAG_TEST_EXPERIMENTAL1': Feature flag 'experimental1': feature is already set to true",
+				"Ignored envvar 'FFLAG_TEST_EXPERIMENTAL1': the feature is already set to true",
 			},
 		},
 	}
@@ -355,7 +354,7 @@ func TestSetFromYaml(t *testing.T) {
 		}, {
 			name:        "invalid feature flag name",
 			yml:         "not_a_feature: true",
-			expectedLog: []string{"Ignored feature 'not_a_feature': Feature flag 'not_a_feature': unknown feature flag"},
+			expectedLog: []string{"Ignored feature flag 'not_a_feature': unknown feature"},
 		}, {
 			name:        "invalid value (not true or false)",
 			yml:         "experimental1: maybe",
@@ -363,26 +362,26 @@ func TestSetFromYaml(t *testing.T) {
 		}, {
 			name:        "enable a feature flag",
 			yml:         "experimental1: true",
-			expectedLog: []string{"Enabled feature 'experimental1' with config file"},
+			expectedLog: []string{"Feature flag: experimental1=true (from config file)"},
 		}, {
 			name: "enable a deprecated feature",
 			yml:  "bad_idea: true",
 			expectedLog: []string{
-				"Feature flag 'bad_idea': the flag is deprecated",
-				"Enabled feature 'bad_idea' with config file",
+				"Feature 'bad_idea': the flag is deprecated",
+				"Feature flag: bad_idea=true (from config file)",
 			},
 		}, {
 			name: "enable a feature that was retired (adopted) in v1.5",
 			yml:  "was_adopted_in_v1.5: true",
 			expectedLog: []string{
-				"Feature flag 'was_adopted_in_v1.5': the flag is deprecated: " +
+				"Feature 'was_adopted_in_v1.5': the flag is deprecated: " +
 					"the trinket was implemented in 1.5 with the --funnybunny command line option",
 			},
 		}, {
 			name: "enable a feature flag already set",
 			yml:  "experimental1: false",
 			expectedLog: []string{
-				"Feature flag 'experimental1': feature is already set to true",
+				"Ignored feature flag experimental1=false from config file: the feature is already set to true",
 			},
 		},
 	}
@@ -421,7 +420,7 @@ func TestSetFromYamlFile(t *testing.T) {
 	err = fm.SetFromYamlFile(tmpfile.Name(), logger)
 	require.NoError(t, err)
 
-	cstest.RequireLogContains(t, hook, "Enabled feature 'experimental1' with config file")
+	cstest.RequireLogContains(t, hook, "Feature flag: experimental1=true (from config file)")
 }
 
 func TestGetFeatureStatus(t *testing.T) {

--- a/pkg/fflag/features_test.go
+++ b/pkg/fflag/features_test.go
@@ -1,0 +1,403 @@
+package fflag_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/crowdsecurity/crowdsec/pkg/cstest"
+	"github.com/crowdsecurity/crowdsec/pkg/fflag"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
+)
+
+// Test the constructor, which is not required but useful for validation.
+func TestNewFeatureMap(t *testing.T) {
+	tests := []struct {
+		name        string
+		features    map[string]fflag.Feature
+		expectedErr string
+	}{
+		{
+			name:     "no feature at all",
+			features: map[string]fflag.Feature{},
+		},
+		{
+			name: "a plain feature or two",
+			features: map[string]fflag.Feature{
+				"plain":          {},
+				"plain_version2": {},
+			},
+		},
+		{
+			name: "capitalized feature name",
+			features: map[string]fflag.Feature{
+				"Plain": {},
+			},
+			expectedErr: "Feature flag 'Plain': name is not lowercase",
+		},
+		{
+			name: "empty feature name",
+			features: map[string]fflag.Feature{
+				"": {},
+			},
+			expectedErr: "Feature flag '': name is empty",
+		},
+		{
+			name: "invalid feature name",
+			features: map[string]fflag.Feature{
+				"meh!": {},
+			},
+			expectedErr: "Feature flag 'meh!': invalid name (allowed a-z, 0-9, _, .)",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run("", func(t *testing.T) {
+			_, err := fflag.NewFeatureMap(tc.features)
+			cstest.RequireErrorContains(t, err, tc.expectedErr)
+		})
+	}
+}
+
+func setUp(t *testing.T) fflag.FeatureMap {
+	t.Helper()
+
+	fm, err := fflag.NewFeatureMap(map[string]fflag.Feature{
+		"experimental1":    {},
+		"experimental2":    {},
+		"may_contain_nuts": {DefaultEnabled: true},
+		"bad_idea":         {DefaultEnabled: false, Deprecated: true},
+		"gone_mainstream1": {DefaultEnabled: true, Deprecated: true},
+		"gone_mainstream2": {DefaultEnabled: true, Deprecated: true},
+		"will_be_standard_in_v2": {
+			DefaultEnabled: false,
+			Deprecated:     true,
+			DeprecationMsg: "in 2.0 we'll do that by default",
+		},
+		"will_be_abandoned_in_v2": {
+			DefaultEnabled: false,
+			Deprecated:     true,
+			DeprecationMsg: "in 2.0 we'll have a better way to do it",
+		},
+		"was_adopted_in_v1.5": {
+			DefaultEnabled: true,
+			Deprecated:     true,
+			Retired:        true,
+			DeprecationMsg: "the trinket was implemented in 1.5 with the --funnybunny command line option",
+		},
+		"was_abandoned_in_v1.5": {
+			DefaultEnabled: false,
+			Deprecated:     true,
+			Retired:        true,
+			DeprecationMsg: "the magic button didn't work as expected and has been removed in 1.5",
+		},
+	})
+	require.NoError(t, err)
+
+	return fm
+}
+
+func TestIsFeatureEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		feature     string
+		enable      *bool
+		expected    bool
+		expectedErr string
+	}{
+		{
+			name:     "feature that is disabled by default",
+			feature:  "experimental1",
+			expected: false,
+		}, {
+			name:     "enable feature that is disabled by default",
+			feature:  "experimental1",
+			enable:   types.BoolPtr(true),
+			expected: true,
+		}, {
+			name:     "feature that is enabled by default",
+			feature:  "may_contain_nuts",
+			expected: true,
+		}, {
+			name:     "disable feature that is enabled by default",
+			feature:  "may_contain_nuts",
+			enable:   types.BoolPtr(false),
+			expected: false,
+		}, {
+			name:        "feature that does not exist",
+			feature:     "will_never_exist",
+			expectedErr: "Feature flag 'will_never_exist': unknown feature flag",
+		},
+	}
+
+	fm := setUp(t)
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.enable != nil {
+				err := fm.SetFeature(tc.feature, *tc.enable)
+				require.NoError(t, err)
+			}
+
+			enabled, err := fm.IsFeatureEnabled(tc.feature)
+			cstest.RequireErrorMessage(t, err, tc.expectedErr)
+			require.Equal(t, tc.expected, enabled)
+		})
+	}
+}
+
+func TestSetFeature(t *testing.T) {
+	tests := []struct {
+		name           string // test description
+		feature        string // feature name
+		value          bool   // value for SetFeature
+		expected       bool   // expected value from IsFeatureEnabled
+		expectedSetErr string // error expected from SetFeature
+		expectedGetErr string // error expected from IsFeatureEnabled
+	}{
+		{
+			name:     "enable a feature to try something new",
+			feature:  "experimental1",
+			value:    true,
+			expected: true,
+		}, {
+			name:     "can set the same feature twice with the same value",
+			feature:  "experimental1",
+			value:    true,
+			expected: true,
+		}, {
+			name:           "can't set the same feature again with a different value",
+			feature:        "experimental1",
+			value:          false,
+			expected:       true,
+			expectedSetErr: "Feature flag 'experimental1': feature is already set to true",
+		}, {
+			name:     "disable an experimental feature, explicitly",
+			feature:  "experimental2",
+			value:    false,
+			expected: false,
+		}, {
+			name:     "disable a mainstream feature that is causing problems",
+			feature:  "may_contain_nuts",
+			value:    false,
+			expected: false,
+		}, {
+			name:           "enable a deprecated feature which defaults to false",
+			feature:        "bad_idea",
+			value:          true,
+			expected:       true,
+			expectedSetErr: "Feature flag 'bad_idea': the flag is deprecated",
+		}, {
+			name:           "enable a deprecated feature which defaults to true",
+			feature:        "gone_mainstream1",
+			value:          true,
+			expected:       true,
+			expectedSetErr: "Feature flag 'gone_mainstream1': the flag is deprecated",
+		}, {
+			name:           "disable a deprecated feature which defaults to true",
+			feature:        "gone_mainstream2",
+			value:          false,
+			expected:       false,
+			expectedSetErr: "Feature flag 'gone_mainstream2': the flag is deprecated",
+		}, {
+			name:           "enable a feature that will be retired in v2, default true",
+			feature:        "will_be_standard_in_v2",
+			value:          true,
+			expected:       true,
+			expectedSetErr: "Feature flag 'will_be_standard_in_v2': the flag is deprecated: in 2.0 we'll do that by default",
+		}, {
+			name:           "enable a feature that will be retired in v2, default false",
+			feature:        "will_be_abandoned_in_v2",
+			value:          true,
+			expected:       true,
+			expectedSetErr: "Feature flag 'will_be_abandoned_in_v2': the flag is deprecated: in 2.0 we'll have a better way to do it",
+		}, {
+			name:     "enable a feature that was retired in v1.5, default true",
+			feature:  "was_adopted_in_v1.5",
+			value:    true,
+			expected: true,
+			expectedSetErr: "Feature flag 'was_adopted_in_v1.5': the flag is deprecated: " +
+				"the trinket was implemented in 1.5 with the --funnybunny command line option",
+		}, {
+			name:     "enable a feature that was retired in v1.5, default false",
+			feature:  "was_abandoned_in_v1.5",
+			value:    true,
+			expected: false,
+			expectedSetErr: "Feature flag 'was_abandoned_in_v1.5': the flag is deprecated: " +
+				"the magic button didn't work as expected and has been removed in 1.5",
+		}, {
+			name:           "enable a feature that does not exist",
+			feature:        "will_never_exist",
+			value:          true,
+			expectedSetErr: "Feature flag 'will_never_exist': unknown feature flag",
+			expectedGetErr: "Feature flag 'will_never_exist': unknown feature flag",
+		},
+	}
+
+	// we don't instantiate a new feature map for each test, so they are
+	// not independent, but it simplifies the test code
+	fm := setUp(t)
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := fm.SetFeature(tc.feature, tc.value)
+			t.Logf("SetFeature(%q, %v) returned %v", tc.feature, tc.value, err)
+			cstest.RequireErrorMessage(t, err, tc.expectedSetErr)
+			// check that the feature was set, or not
+			enabled, err := fm.IsFeatureEnabled(tc.feature)
+			cstest.RequireErrorMessage(t, err, tc.expectedGetErr)
+			if tc.expectedGetErr != "" {
+				return
+			}
+			require.Equal(t, tc.expected, enabled)
+		})
+	}
+}
+
+func TestSetFromEnv(t *testing.T) {
+	tests := []struct {
+		name   string
+		envvar string
+		value  string
+		// expected bool
+		expectedLog []string
+		expectedErr string
+	}{
+		{
+			name:   "variable that does not start with FFLAG_TEST_",
+			envvar: "PATH",
+			value:  "/bin:/usr/bin/:/usr/local/bin",
+			// silently ignored
+		}, {
+			name:        "enable a feature flag",
+			envvar:      "FFLAG_TEST_EXPERIMENTAL1",
+			value:       "true",
+			expectedLog: []string{"Enabled feature 'experimental1' with envvar 'FFLAG_TEST_EXPERIMENTAL1'"},
+		}, {
+			name:        "invalid value (not true or false)",
+			envvar:      "FFLAG_TEST_EXPERIMENTAL1",
+			value:       "maybe",
+			expectedLog: []string{"Ignored envvar FFLAG_TEST_EXPERIMENTAL1=maybe: invalid value (must be 'true' or 'false')"},
+		}, {
+			name:        "feature flag that is unknown",
+			envvar:      "FFLAG_TEST_WILL_NEVER_EXIST",
+			value:       "true",
+			expectedLog: []string{"Ignored envvar 'FFLAG_TEST_WILL_NEVER_EXIST': Feature flag 'will_never_exist': unknown feature"},
+		}, {
+			name:   "enable a deprecated feature",
+			envvar: "FFLAG_TEST_BAD_IDEA",
+			value:  "true",
+			expectedLog: []string{
+				"Envvar 'FFLAG_TEST_BAD_IDEA': Feature flag 'bad_idea': the flag is deprecated",
+				"Enabled feature 'bad_idea' with envvar 'FFLAG_TEST_BAD_IDEA'",
+			},
+		}, {
+			name:   "enable a feature that was retired (adopted) in v1.5",
+			envvar: "FFLAG_TEST_WAS_ADOPTED_IN_V1.5",
+			value:  "true",
+			expectedLog: []string{
+				"Envvar 'FFLAG_TEST_WAS_ADOPTED_IN_V1.5': Feature flag 'was_adopted_in_v1.5': " +
+					"the flag is deprecated: the trinket was implemented in 1.5 with the --funnybunny " +
+					"command line option",
+			},
+		}, {
+			// this is unlikely to happen, because environment
+			// variables are prioritized over the config file
+			name:   "enable a feature flag already set",
+			envvar: "FFLAG_TEST_EXPERIMENTAL1",
+			value:  "false",
+			expectedLog: []string{
+				"Ignored envvar 'FFLAG_TEST_EXPERIMENTAL1': Feature flag 'experimental1': feature is already set to true",
+			},
+		},
+	}
+
+	fm := setUp(t)
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			logger, hook := logtest.NewNullLogger()
+			logger.SetLevel(logrus.InfoLevel)
+			t.Setenv(tc.envvar, tc.value)
+			err := fm.SetFromEnv("FFLAG_TEST_", logger)
+			cstest.RequireErrorMessage(t, err, tc.expectedErr)
+			for _, expectedMessage := range tc.expectedLog {
+				cstest.RequireLogContains(t, hook, expectedMessage)
+			}
+		})
+	}
+}
+
+func TestSetFromYaml(t *testing.T) {
+	tests := []struct {
+		name        string
+		yml         string
+		expectedLog []string
+		expectedErr string
+	}{
+		{
+			name: "empty file",
+			yml:  "",
+			// nothing happens
+		}, {
+			name:        "invalid yaml",
+			yml:         "bad! content, bad!",
+			expectedErr: "failed to parse feature flags: [1:1] string was used where mapping is expected\n    >  1 | bad! content, bad!\n           ^",
+		}, {
+			name:        "invalid feature flag name",
+			yml:         "not_a_feature: true",
+			expectedLog: []string{"Ignored feature 'not_a_feature': Feature flag 'not_a_feature': unknown feature flag"},
+		}, {
+			name:        "invalid value (not true or false)",
+			yml:         "experimental1: maybe",
+			expectedErr: "failed to parse feature flags: [1:16] cannot unmarshal string into Go value of type bool\n    >  1 | experimental1: maybe\n                          ^",
+		}, {
+			name:        "enable a feature flag",
+			yml:         "experimental1: true",
+			expectedLog: []string{"Enabled feature 'experimental1' with config file"},
+		}, {
+			name: "enable a deprecated feature",
+			yml:  "bad_idea: true",
+			expectedLog: []string{
+				"Feature flag 'bad_idea': the flag is deprecated",
+				"Enabled feature 'bad_idea' with config file",
+			},
+		}, {
+			name: "enable a feature that was retired (adopted) in v1.5",
+			yml:  "was_adopted_in_v1.5: true",
+			expectedLog: []string{
+				"Feature flag 'was_adopted_in_v1.5': the flag is deprecated: " +
+					"the trinket was implemented in 1.5 with the --funnybunny command line option",
+			},
+		}, {
+			name: "enable a feature flag already set",
+			yml:  "experimental1: false",
+			expectedLog: []string{
+				"Feature flag 'experimental1': feature is already set to true",
+			},
+		},
+	}
+
+	fm := setUp(t)
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			logger, hook := logtest.NewNullLogger()
+			logger.SetLevel(logrus.InfoLevel)
+			err := fm.SetFromYaml(strings.NewReader(tc.yml), logger)
+			cstest.RequireErrorMessage(t, err, tc.expectedErr)
+			for _, expectedMessage := range tc.expectedLog {
+				cstest.RequireLogContains(t, hook, expectedMessage)
+			}
+		})
+	}
+}

--- a/tests/bats/01_base.bats
+++ b/tests/bats/01_base.bats
@@ -269,3 +269,8 @@ declare stderr
     assert_line 'crowdsecurity/ssh-bf'
     assert_line 'crowdsecurity/ssh-slow-bf'
 }
+
+@test "cscli support dump (smoke test)" {
+    run -0 cscli support dump -f "$BATS_TEST_TMPDIR"/dump.zip
+    assert_file_exist "$BATS_TEST_TMPDIR"/dump.zip
+}


### PR DESCRIPTION
Package fflag provides a simple feature flag system.

 Feature names are lowercase and can only contain letters, numbers, undercores
 and dots.

 good: "foo", "foo_bar", "foo.bar"
 bad: "Foo", "foo-bar"

 A feature flag can be enabled by the user with an environment variable
 or by adding it to {ConfigDir}/feature.yaml

 I.e. CROWDSEC_FEATURE_FOO_BAR=true
 or in feature.yaml:
```
 ---
 - foo_bar
```

 If the variable is set to false, the feature can still be enabled
 in feature.yaml. Features cannot be disabled in the file.

 A feature flag can be deprecated or retired. A deprecated feature flag is
 still accepted but a warning is logged. A retired feature flag is ignored
 and an error is logged.

 A specific deprecation message is used to inform the user of the behavior
 that has been decided when the flag is/was finally retired.