### PR TITLE
simplify feature flags

### DIFF
--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -67,7 +67,7 @@ func initConfig() {
 	}
 
 	featurePath := filepath.Join(csConfig.ConfigPaths.ConfigDir, "feature.yaml")
-	if err = fflag.CrowdsecFeatures.SetFromYamlFile(featurePath, log.StandardLogger()); err != nil {
+	if err = fflag.Crowdsec.SetFromYamlFile(featurePath, log.StandardLogger()); err != nil {
 		log.Fatalf("File %s: %s", featurePath, err)
 	}
 
@@ -137,13 +137,13 @@ func main() {
 	logFormatter := &log.TextFormatter{TimestampFormat: "02-01-2006 15:04:05", FullTimestamp: true}
 	log.SetFormatter(logFormatter)
 
-	if err := fflag.InitCrowdsecFeatures(); err != nil {
-		log.Fatalf("failed to initialize features: %s", err)
+	if err := fflag.RegisterAllFeatures(); err != nil {
+		log.Fatalf("failed to register features: %s", err)
 	}
 
 	// some features can require configuration or command-line options,
 	// so we need to parse them asap. we'll load from feature.yaml later.
-	if err := fflag.CrowdsecFeatures.SetFromEnv("CROWDSEC_FEATURE_", log.StandardLogger()); err != nil {
+	if err := fflag.Crowdsec.SetFromEnv(log.StandardLogger()); err != nil {
 		log.Fatalf("failed to set features from environment: %s", err)
 	}
 

--- a/cmd/crowdsec-cli/support.go
+++ b/cmd/crowdsec-cli/support.go
@@ -93,7 +93,7 @@ func collectVersion() []byte {
 
 func collectFeatures() []byte {
 	log.Info("Collecting feature flags")
-	enabledFeatures := fflag.CrowdsecFeatures.GetEnabledFeatures()
+	enabledFeatures := fflag.Crowdsec.GetEnabledFeatures()
 
 	w := bytes.NewBuffer(nil)
 	for _, k := range enabledFeatures {

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -314,15 +314,11 @@ func LoadConfig(cConfig *csconfig.Config) error {
 func LoadFeatureFlags(cConfig *csconfig.Config, logger *log.Logger) error {
 	featurePath := filepath.Join(cConfig.ConfigPaths.ConfigDir, "feature.yaml")
 
-	if err := fflag.InitCrowdsecFeatures(); err != nil {
-		log.Fatalf("failed to initialize features: %s", err)
-	}
-
-	if err := fflag.CrowdsecFeatures.SetFromYamlFile(featurePath, logger); err != nil {
+	if err := fflag.Crowdsec.SetFromYamlFile(featurePath, logger); err != nil {
 		return fmt.Errorf("file %s: %s", featurePath, err)
 	}
 
-	enabledFeatures := fflag.CrowdsecFeatures.GetEnabledFeatures()
+	enabledFeatures := fflag.Crowdsec.GetEnabledFeatures()
 
 	msg := "<none>"
 	if len(enabledFeatures) > 0 {
@@ -358,9 +354,13 @@ func exitWithCode(exitCode int, err error) {
 var crowdsecT0 time.Time
 
 func main() {
+	if err := fflag.RegisterAllFeatures(); err != nil {
+		log.Fatalf("failed to register features: %s", err)
+	}
+
 	// some features can require configuration or command-line options,
 	// so wwe need to parse them asap. we'll load from feature.yaml later.
-	if err := fflag.CrowdsecFeatures.SetFromEnv("CROWDSEC_FEATURE_", log.StandardLogger()); err != nil {
+	if err := fflag.Crowdsec.SetFromEnv(log.StandardLogger()); err != nil {
 		log.Fatalf("failed set features from environment: %s", err)
 	}
 

--- a/pkg/fflag/crowdsec.go
+++ b/pkg/fflag/crowdsec.go
@@ -1,9 +1,14 @@
 package fflag
 
-var CrowdsecFeatures FeatureMap
+var Crowdsec = FeatureRegister{EnvPrefix: "CROWDSEC_FEATURE_"}
 
-func InitCrowdsecFeatures() error {
-	var err error
-	CrowdsecFeatures, err = NewFeatureMap(map[string]FeatureFlag{"cscli_setup": {}})
-	return err
+var CscliSetup = &Feature{Name: "cscli_setup"}
+
+func RegisterAllFeatures() error {
+	err := Crowdsec.RegisterFeature(CscliSetup)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
Now checking for a feature flag is a one liner,
with no need to control errors.

if fflag.Crowdsec.CscliSetup.IsEnabled() {
   ...
}