### PR TITLE
Improve warnings around lack of `evt.StrTime` field

### DIFF
--- a/pkg/hubtest/parser_assert.go
+++ b/pkg/hubtest/parser_assert.go
@@ -272,16 +272,16 @@ func LoadParserDump(filepath string) (*ParserResults, error) {
 
 	/* we know that some variables should always be set,
 	let's check if they're present in last parser output of last stage */
-	stages := make([]string, len(pdump))
-	for k, _ := range pdump {
+	stages := make([]string, 0, len(pdump))
+	for k := range pdump {
 		stages = append(stages, k)
 	}
 	sort.Strings(stages)
 	/*the very last one is set to 'success' which is just a bool indicating if the line was successfully parsed*/
 	lastStage := stages[len(stages)-2]
 
-	parsers := make([]string, len(pdump[lastStage]))
-	for k, _ := range pdump[lastStage] {
+	parsers := make([]string, 0, len(pdump[lastStage]))
+	for k := range pdump[lastStage] {
 		parsers = append(parsers, k)
 	}
 	sort.Strings(parsers)

--- a/pkg/leakybucket/timemachine.go
+++ b/pkg/leakybucket/timemachine.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/types"
-	"github.com/davecgh/go-spew/spew"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -14,7 +13,11 @@ func TimeMachinePour(l *Leaky, msg types.Event) {
 		err error
 	)
 	if msg.MarshaledTime == "" {
-		log.Warningf("Trying to time-machine event without timestamp : %s", spew.Sdump(msg))
+		log.WithFields(log.Fields{
+			"evt_type": msg.Line.Labels["type"],
+			"evt_src":  msg.Line.Src,
+			"scenario": l.Name,
+		}).Warningf("Trying to process event without evt.StrTime. Event cannot be poured to scenario")
 		return
 	}
 


### PR DESCRIPTION
 - fix #1951
 - Improve the message at runtime when trying to pour some events lacking `evt.StrTime` to buckets (in forensic mode)
 - Make `cscli hubtest run` warn you when you're generating logs **without** `evt.StrTime` field

