### PR TITLE
Fix docker_start.sh not properly handling env vars

### DIFF
--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -266,43 +266,43 @@ cscli_if_clean parsers install crowdsecurity/docker-logs
 
 if [ "$COLLECTIONS" != "" ]; then
     # shellcheck disable=SC2086
-    cscli_if_clean collections install $COLLECTIONS
+    cscli_if_clean collections install "$COLLECTIONS"
 fi
 
 if [ "$PARSERS" != "" ]; then
     # shellcheck disable=SC2086
-    cscli_if_clean parsers install $PARSERS
+    cscli_if_clean parsers install "$PARSERS"
 fi
 
 if [ "$SCENARIOS" != "" ]; then
     # shellcheck disable=SC2086
-    cscli_if_clean scenarios install $SCENARIOS
+    cscli_if_clean scenarios install "$SCENARIOS"
 fi
 
 if [ "$POSTOVERFLOWS" != "" ]; then
     # shellcheck disable=SC2086
-    cscli_if_clean postoverflows install $POSTOVERFLOWS
+    cscli_if_clean postoverflows install "$POSTOVERFLOWS"
 fi
 
 ## Remove collections, parsers, scenarios & postoverflows
 if [ "$DISABLE_COLLECTIONS" != "" ]; then
     # shellcheck disable=SC2086
-    cscli_if_clean collections remove $DISABLE_COLLECTIONS
+    cscli_if_clean collections remove "$DISABLE_COLLECTIONS"
 fi
 
 if [ "$DISABLE_PARSERS" != "" ]; then
     # shellcheck disable=SC2086
-    cscli_if_clean parsers remove $DISABLE_PARSERS
+    cscli_if_clean parsers remove "$DISABLE_PARSERS"
 fi
 
 if [ "$DISABLE_SCENARIOS" != "" ]; then
     # shellcheck disable=SC2086
-    cscli_if_clean scenarios remove $DISABLE_SCENARIOS
+    cscli_if_clean scenarios remove "$DISABLE_SCENARIOS"
 fi
 
 if [ "$DISABLE_POSTOVERFLOWS" != "" ]; then
     # shellcheck disable=SC2086
-    cscli_if_clean postoverflows remove $DISABLE_POSTOVERFLOWS
+    cscli_if_clean postoverflows remove "$DISABLE_POSTOVERFLOWS"
 fi
 
 ## Register bouncers via env


### PR DESCRIPTION
For example, the COLLECTIONS environment variable is supposed to do a space separated list. But with the unquoted call to cscli_if_clean without quotes on the $COLLECTIONS environment variable, only the first entry is passed to it as $3, the rest would be $4, $5, $6 and so on.

As the function itself is expecting a space separated list for $3, it results it it only acting on the first entry in the list.

Wrapping the parameter in quotes results in the expected behavior.

Would likely affect all call sites to cscli_if_clean().

Fixes #1987 