### PR TITLE
docker: skip temporary installation of disabled items

### DIFF
--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -118,7 +118,7 @@ cscli_if_clean() {
     done
 }
 
-# Return the difference between two lists
+# Output the difference between two lists
 # of items separated by spaces
 difference() {
   list1="$1"


### PR DESCRIPTION
A bit of an edge case -- when a collection (or parser, scenario..) is in both COLLECTIONS and DISABLE_COLLECTIONS, do not install at all. The previous behavior was to install and remove
(related integration tests are on the test repo)