### PR TITLE
CAPI error code handling tests

### DIFF
--- a/pkg/apiclient/auth_service_test.go
+++ b/pkg/apiclient/auth_service_test.go
@@ -58,7 +58,7 @@ func initBasicMuxMock(t *testing.T, mux *http.ServeMux, path string) {
 		log.Printf("MockServerReceived > %s // Login : [%s] => Mux response [%d]", newStr, payload.MachineID, responseCode)
 
 		w.WriteHeader(responseCode)
-		fmt.Fprintf(w, responseBody)
+		fmt.Fprintf(w, `%s`, responseBody)
 	})
 }
 
@@ -166,7 +166,7 @@ func TestWatcherAuth(t *testing.T) {
 		})
 
 		if err == nil {
-			defer resp.Response.Body.Close()
+			resp.Response.Body.Close()
 			bodyBytes, err := io.ReadAll(resp.Response.Body)
 			if err != nil {
 				log.Fatal(err)

--- a/pkg/apiclient/auth_service_test.go
+++ b/pkg/apiclient/auth_service_test.go
@@ -169,7 +169,7 @@ func TestWatcherAuth(t *testing.T) {
 			resp.Response.Body.Close()
 			bodyBytes, err := io.ReadAll(resp.Response.Body)
 			if err != nil {
-				log.Fatal(err)
+				t.Fatalf("error while reading body: %s", err.Error())
 			}
 
 			log.Printf(string(bodyBytes))

--- a/pkg/apiserver/apic_test.go
+++ b/pkg/apiserver/apic_test.go
@@ -287,6 +287,16 @@ func TestAPICGetMetrics(t *testing.T) {
 		expectedMetric *models.Metrics
 	}{
 		{
+			name:       "no bouncers nor machines should still have bouncers/machines keys in output",
+			machineIDs: []string{},
+			bouncers:   []string{},
+			expectedMetric: &models.Metrics{
+				ApilVersion: types.StrPtr(cwversion.VersionStr()),
+				Bouncers:    []*models.MetricsBouncerInfo{},
+				Machines:    []*models.MetricsAgentInfo{},
+			},
+		},
+		{
 			name:       "simple",
 			machineIDs: []string{"a", "b", "c"},
 			bouncers:   []string{"1", "2", "3"},


### PR DESCRIPTION
Testing Error handling on CAPI interractions
Making sure future changes in CAPI response codes do not crash the agent

**Test cases:**
- register
  - username exists 409
  - invalid password 400
  - missing machineId or password 400
- login 
  - (no machineId or pass) code 400
  - login != IP 409
- Test That getMetric always returns indexes manies and bouncers to ensure we'll never get a 409

**No test added for **
- decisionDelete code 400 (not 403 to avoid retry loop) //not yet implemented
- decisionSync code 400 (not 403 to avoid retry loop) //not yet implemented