### PR TITLE
Remove a check for config files to Fix enduser bind mounting config.yml

### DIFF
--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -166,16 +166,14 @@ for geodb in GeoLite2-ASN.mmdb GeoLite2-City.mmdb; do
 done
 
 # Check and prestage /etc/crowdsec
-if [ ! -e "/etc/crowdsec/local_api_credentials.yaml" ] && [ ! -e "/etc/crowdsec/config.yaml" ]; then
-    echo "Populating configuration directory..."
-    # don't overwrite existing configuration files, which may come
-    # from bind-mount or even be read-only (configmaps)
-    if [ -e /staging/etc/crowdsec ]; then
-        mkdir -p /etc/crowdsec/
-        # if you change this, check that it still works
-        # under alpine and k8s, with and without tls
-        cp -an /staging/etc/crowdsec/* /etc/crowdsec/
-    fi
+echo "Populating configuration directory..."
+# don't overwrite existing configuration files, which may come
+# from bind-mount or even be read-only (configmaps)
+if [ -e /staging/etc/crowdsec ]; then
+    mkdir -p /etc/crowdsec/
+    # if you change this, check that it still works
+    # under alpine and k8s, with and without tls
+    cp -an /staging/etc/crowdsec/* /etc/crowdsec/
 fi
 
 # do this as soon as we have a config.yaml, to avoid useless warnings


### PR DESCRIPTION
Removed the check for config files before coying them from staging directory this enable users to bind mount their own config.yml files or any files they want to change

I was mounting my config because I don't like to have 1 file with every acquisition settings, it does not look clean and you have the option to use the acquisition_dir to define a folder where you can store all config in a separate file.

I tested this by bind mounting the docker_start.sh via those docker compose files:

``` yaml
---
version: '3.8'

networks:
  proxy:
    external: true

services:
  crowdsec:
    image: crowdsecurity/crowdsec:v1.4.5-slim

    environment:
      TZ: Europe/Paris
      GID: "${GID-1000}"
      LEVEL_INFO: "true"
      COLLECTIONS: "crowdsecurity/linux crowdsecurity/traefik LePresidente/authelia Dominic-Wagner/vaultwarden"
    volumes:
      - /var/log:/var/log/dockerhost:ro
      - crowdsec-db:/var/lib/crowdsec/data/
      - crowdsec-config:/etc/crowdsec/
      #- ${PWD}/data/etc/crowdsec/acquis.yml:/etc/crowdsec/acquis.yml
      - ${PWD}/data/etc/crowdsec/acquisitions:/etc/crowdsec/acquisitions
      - ${PWD}/data/etc/crowdsec/config.yaml:/etc/crowdsec/config.yaml

volumes:
  crowdsec-db:
  crowdsec-config:
```
  
And
  
``` yaml
---
version: '3.8'

networks:
  proxy:
    external: true

services:
  crowdsec:
    image: crowdsecurity/crowdsec:v1.4.5-slim

    environment:
      TZ: Europe/Paris
      GID: "${GID-1000}"
      LEVEL_INFO: "true"
      COLLECTIONS: "crowdsecurity/linux crowdsecurity/traefik LePresidente/authelia Dominic-Wagner/vaultwarden"
    volumes:
      - /var/log:/var/log/dockerhost:ro
      - crowdsec-db:/var/lib/crowdsec/data/
      - crowdsec-config:/etc/crowdsec/
      - ${PWD}/data/etc/crowdsec/acquis.yml:/etc/crowdsec/acquis.yml
      #- ${PWD}/data/etc/crowdsec/acquisitions:/etc/crowdsec/acquisitions
      #- ${PWD}/data/etc/crowdsec/config.yaml:/etc/crowdsec/config.yaml

volumes:
  crowdsec-db:
  crowdsec-config:
```
  
Having just one thing in my acquis.yml or in ${PWD}/data/etc/crowdsec/acquisitions/ssh.yml

``` yaml
---
# SSH context
filenames:
  - /var/log/dockerhost/auth.log
labels:
  type: syslog
```

But their is another thing we could do and it will reduce the size of the image too we can gain 840.0K and a few more lines in the docker_start.sh but that's for another PR ;)

Tell me if you need anything more