### PR TITLE
Fix docker tests (network creation)

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -54,7 +54,9 @@ jobs:
         run: |
           cd docker/test
           pipenv install --deploy
-          docker network create net-test
+
+      - name: "Create Docker network"
+        run: docker network create net-test
 
       - name: "Run tests"
         env:


### PR DESCRIPTION
network creation was skipped when the virtualenv cache was hit