### PR TITLE
ugly workaround to fix the tests

### DIFF
--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -197,6 +197,9 @@ func shutdown(sig os.Signal, cConfig *csconfig.Config) error {
 
 func drainChan(c chan types.Event) {
 	time.Sleep(500 * time.Millisecond)
+	// delay to avoid draining chan before the acquisition/parser
+	// get a chance to push its event
+	// We should close the chan on the writer side rather than this
 	for {
 		select {
 		case _, ok := <-c:

--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -196,6 +196,7 @@ func shutdown(sig os.Signal, cConfig *csconfig.Config) error {
 }
 
 func drainChan(c chan types.Event) {
+	time.Sleep(500 * time.Millisecond)
 	for {
 		select {
 		case _, ok := <-c:


### PR DESCRIPTION
ugly workaround to fix the tests that were broken in the PR https://github.com/crowdsecurity/crowdsec/pull/2069.

 In fact, the PR 2069 fixed a rare hanging bug when stopping crowdsec but breaks the tests on slow machine due to timing issues.