### PR TITLE
properly update the time structure within event

### DIFF
--- a/pkg/parser/enrich_date.go
+++ b/pkg/parser/enrich_date.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	expr "github.com/crowdsecurity/crowdsec/pkg/exprhelpers"
+	"github.com/crowdsecurity/crowdsec/pkg/leakybucket"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -72,13 +73,22 @@ func ParseDate(in string, p *types.Event, x interface{}, plog *log.Entry) (map[s
 		strDate, parsedDate = GenDateParse(in)
 		if !parsedDate.IsZero() {
 			ret["MarshaledTime"] = strDate
+			//In time machine, we take the time parsed from the event. In live mode, we keep the timestamp collected at acquisition
+			if p.ExpectMode == leakybucket.TIMEMACHINE {
+				p.Time = parsedDate
+			}
 			return ret, nil
 		}
-		strDate = expr.ParseUnix(in)
-		if strDate != "" {
-			ret["MarshaledTime"] = strDate
+		timeobj, err := expr.ParseUnixTime(in)
+		if err == nil {
+			ret["MarshaledTime"] = timeobj.Format(time.RFC3339)
+			//In time machine, we take the time parsed from the event. In live mode, we keep the timestamp collected at acquisition
+			if p.ExpectMode == leakybucket.TIMEMACHINE {
+				p.Time = timeobj
+			}
 			return ret, nil
 		}
+
 	}
 	plog.Debugf("no suitable date format found for '%s', falling back to now", in)
 	now := time.Now().UTC()


### PR DESCRIPTION
This change is to ensure it works in time-machine, allowing users to do scenarios like:

```yaml
# ssh bruteforce
type: trigger
name: crowdsecurity/ssh-bf
description: "Detect ssh bruteforce outside of office hours"
filter: "evt.Meta.log_type == 'ssh_failed-auth' && (evt.Time.Hour() >= 20 || evt.Time.Hour() < 6) || (evt.Time.Weekday().String() == 'Saturday' || evt.Time.Weekday().String() == 'Sunday')"
groupby: evt.Meta.source_ip
blackhole: 1m
reprocess: true
```