### PR TITLE
match expr helper

### DIFF
--- a/pkg/exprhelpers/exprlib.go
+++ b/pkg/exprhelpers/exprlib.go
@@ -123,6 +123,7 @@ func GetExprEnv(ctx map[string]interface{}) map[string]interface{} {
 		"Get":         Get,
 		"String":      ToString,
 		"Distance":    Distance,
+		"Match":       Match,
 	}
 	for k, v := range ctx {
 		ExprLib[k] = v
@@ -492,4 +493,30 @@ func ToString(value interface{}) string {
 		return ""
 	}
 	return s
+}
+
+func Match(pattern, name string) bool {
+	var matched bool
+	if pattern == "" {
+		return name == ""
+	}
+	if name == "" {
+		if pattern == "*" || pattern == "" {
+			return true
+		}
+		return false
+	}
+	if pattern[0] == '*' {
+		for i := 0; i <= len(name); i++ {
+			matched = Match(pattern[1:], name[i:])
+			if matched {
+				return matched
+			}
+		}
+		return matched
+	}
+	if pattern[0] == '?' || pattern[0] == name[0] {
+		return Match(pattern[1:], name[1:])
+	}
+	return matched
 }

--- a/pkg/exprhelpers/exprlib.go
+++ b/pkg/exprhelpers/exprlib.go
@@ -508,8 +508,7 @@ func Match(pattern, name string) bool {
 	}
 	if pattern[0] == '*' {
 		for i := 0; i <= len(name); i++ {
-			matched = Match(pattern[1:], name[i:])
-			if matched {
+			if matched = Match(pattern[1:], name[i:]); matched {
 				return matched
 			}
 		}

--- a/pkg/exprhelpers/exprlib_test.go
+++ b/pkg/exprhelpers/exprlib_test.go
@@ -125,6 +125,38 @@ func TestVisitor(t *testing.T) {
 	}
 }
 
+func TestMatch(t *testing.T) {
+	tests := []struct {
+		glob string
+		val  string
+		ret  bool
+	}{
+		{"foo", "foo", true},
+		{"foo", "bar", false},
+		{"foo*", "foo", true},
+		{"foo*", "foobar", true},
+		{"foo*", "barfoo", false},
+		{"foo*", "bar", false},
+		{"*foo", "foo", true},
+		{"*foo", "barfoo", true},
+		{"foo*r", "foobar", true},
+		{"foo*r", "foobazr", true},
+		{"foo?ar", "foobar", true},
+		{"foo?ar", "foobazr", false},
+		{"foo?ar", "foobaz", false},
+		{"*foo?ar?", "foobar", false},
+		{"*foo?ar?", "foobare", true},
+		{"*foo?ar?", "rafoobar", false},
+		{"*foo?ar?", "rafoobare", true},
+	}
+	for _, test := range tests {
+		ret := Match(test.glob, test.val)
+		if isOk := assert.Equal(t, test.ret, ret); !isOk {
+			t.Fatalf("pattern:%s val:%s NOK %t !=  %t", test.glob, test.val, ret, test.ret)
+		}
+	}
+}
+
 func TestDistanceHelper(t *testing.T) {
 
 	//one set of coord is empty


### PR DESCRIPTION
Add a `Match` helper that supports `*` and `?`.
That is needed to make our life easier when automagically converting [sigma](https://github.com/SigmaHQ/sigma) rules.
