### PR TITLE
Allow running func tests while running containers with crowdsec

### DIFF
--- a/test/bin/assert-crowdsec-not-running
+++ b/test/bin/assert-crowdsec-not-running
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 is_crowdsec_running() {
-    PIDS=$(pgrep -x 'crowdsec|crowdsec.test|crowdsec.cover')
+    # ignore processes in containers
+    PIDS=$(pgrep --ns $$ -x 'crowdsec|crowdsec.test|crowdsec.cover')
 }
 
 # The process can be slow, especially on CI and during test coverage.


### PR DESCRIPTION
This PR ignores containers that have nothing to do with the functional tests - otherwise the crowdsec processes inside them are detected and the tests won't run.
