### PR TITLE
Wait for both api and agent chans if necessary when daemonize is false or running on windows

### DIFF
--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -370,10 +370,7 @@ func Serve(cConfig *csconfig.Config, apiReady chan bool, agentReady chan bool) e
 	}
 
 	for _, ch := range waitChans {
-		select {
-		case <-ch:
-			continue
-		}
+		<-ch
 	}
 	return nil
 }

--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -362,15 +362,22 @@ func Serve(cConfig *csconfig.Config, apiReady chan bool, agentReady chan bool) e
 
 	waitChans := make([]<-chan struct{}, 0)
 
-	if !cConfig.DisableAPI {
-		waitChans = append(waitChans, apiTomb.Dying())
-	}
 	if !cConfig.DisableAgent {
 		waitChans = append(waitChans, crowdsecTomb.Dying())
 	}
 
+	if !cConfig.DisableAPI {
+		waitChans = append(waitChans, apiTomb.Dying())
+	}
+
 	for _, ch := range waitChans {
 		<-ch
+		switch ch {
+		case apiTomb.Dying():
+			log.Infof("api shutdown")
+		case crowdsecTomb.Dying():
+			log.Infof("crowdsec shutdown")
+		}
 	}
 	return nil
 }

--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -363,19 +363,19 @@ func Serve(cConfig *csconfig.Config, apiReady chan bool, agentReady chan bool) e
 	waitChans := make([]<-chan struct{}, 0)
 
 	if !cConfig.DisableAgent {
-		waitChans = append(waitChans, crowdsecTomb.Dying())
+		waitChans = append(waitChans, crowdsecTomb.Dead())
 	}
 
 	if !cConfig.DisableAPI {
-		waitChans = append(waitChans, apiTomb.Dying())
+		waitChans = append(waitChans, apiTomb.Dead())
 	}
 
 	for _, ch := range waitChans {
 		<-ch
 		switch ch {
-		case apiTomb.Dying():
+		case apiTomb.Dead():
 			log.Infof("api shutdown")
-		case crowdsecTomb.Dying():
+		case crowdsecTomb.Dead():
 			log.Infof("crowdsec shutdown")
 		}
 	}


### PR DESCRIPTION
When running on windows (or with daemonize set to false), wait for all the relevant tombs to be dead (agent and/or lapi) to avoid exiting early (before, even without `-no-api`, when replaying a file, crowdsec would exit just after the acquisition is done, preventing the user from using cscli to interact with lapi)