### PR TITLE
bump supported format version to < 4.0

### DIFF
--- a/pkg/cwversion/version.go
+++ b/pkg/cwversion/version.go
@@ -30,8 +30,8 @@ var (
 	Tag                 string                  // = "dev"
 	GoVersion           = runtime.Version()[2:] // = "1.13"
 	System              = runtime.GOOS          // = "linux"
-	Constraint_parser   = ">= 1.0, <= 2.0"
-	Constraint_scenario = ">= 1.0, < 3.0"
+	Constraint_parser   = ">= 1.0, < 4.0"
+	Constraint_scenario = ">= 1.0, < 4.0"
 	Constraint_api      = "v1"
 	Constraint_acquis   = ">= 1.0, < 2.0"
 )


### PR DESCRIPTION
it will allow us to merge future 1.5 collections into the hub during the preview phase