### PR TITLE
CI: Update setup-go action to v4 (with automatic cache)

### DIFF
--- a/.github/workflows/bats-hub.yml
+++ b/.github/workflows/bats-hub.yml
@@ -27,28 +27,16 @@ jobs:
           sudo chmod +w /etc/machine-id
           echo githubciXXXXXXXXXXXXXXXXXXXXXXXX | sudo tee /etc/machine-id
 
-    - name: "Set up Go ${{ matrix.go-version }}"
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
-
     - name: "Check out CrowdSec repository"
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
         submodules: true
 
-    - name: Cache Go modules
-      uses: actions/cache@v3
+    - name: "Set up Go ${{ matrix.go-version }}"
+      uses: actions/setup-go@v4
       with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ matrix.go-version }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.go-version }}-go-
+        go-version: ${{ matrix.go-version }}
 
     - name: "Install bats dependencies"
       env:

--- a/.github/workflows/bats-hub.yml
+++ b/.github/workflows/bats-hub.yml
@@ -37,6 +37,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
+        cache-dependency-path: "**/go.sum"
 
     - name: "Install bats dependencies"
       env:

--- a/.github/workflows/bats-mysql.yml
+++ b/.github/workflows/bats-mysql.yml
@@ -34,28 +34,16 @@ jobs:
           sudo chmod +w /etc/machine-id
           echo githubciXXXXXXXXXXXXXXXXXXXXXXXX | sudo tee /etc/machine-id
 
-    - name: "Set up Go ${{ matrix.go-version }}"
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
-
     - name: "Check out CrowdSec repository"
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
         submodules: true
 
-    - name: Cache Go modules
-      uses: actions/cache@v3
+    - name: "Set up Go ${{ matrix.go-version }}"
+      uses: actions/setup-go@v4
       with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ matrix.go-version }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.go-version }}-go-
+        go-version: ${{ matrix.go-version }}
 
     - name: "Install bats dependencies"
       env:

--- a/.github/workflows/bats-mysql.yml
+++ b/.github/workflows/bats-mysql.yml
@@ -44,6 +44,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
+        cache-dependency-path: "**/go.sum"
 
     - name: "Install bats dependencies"
       env:

--- a/.github/workflows/bats-postgres.yml
+++ b/.github/workflows/bats-postgres.yml
@@ -35,28 +35,16 @@ jobs:
           sudo chmod +w /etc/machine-id
           echo githubciXXXXXXXXXXXXXXXXXXXXXXXX | sudo tee /etc/machine-id
 
-    - name: "Set up Go ${{ matrix.go-version }}"
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
-
     - name: "Check out CrowdSec repository"
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
         submodules: true
 
-    - name: Cache Go modules
-      uses: actions/cache@v3
+    - name: "Set up Go ${{ matrix.go-version }}"
+      uses: actions/setup-go@v4
       with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ matrix.go-version }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.go-version }}-go-
+        go-version: ${{ matrix.go-version }}
 
     - name: "Install bats dependencies"
       env:

--- a/.github/workflows/bats-postgres.yml
+++ b/.github/workflows/bats-postgres.yml
@@ -45,6 +45,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
+        cache-dependency-path: "**/go.sum"
 
     - name: "Install bats dependencies"
       env:

--- a/.github/workflows/bats-sqlite-coverage.yml
+++ b/.github/workflows/bats-sqlite-coverage.yml
@@ -24,28 +24,16 @@ jobs:
           sudo chmod +w /etc/machine-id
           echo githubciXXXXXXXXXXXXXXXXXXXXXXXX | sudo tee /etc/machine-id
 
-    - name: "Set up Go ${{ matrix.go-version }}"
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
-
     - name: "Check out CrowdSec repository"
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
         submodules: true
 
-    - name: Cache Go modules
-      uses: actions/cache@v3
+    - name: "Set up Go ${{ matrix.go-version }}"
+      uses: actions/setup-go@v4
       with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ matrix.go-version }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.go-version }}-go-
+        go-version: ${{ matrix.go-version }}
 
     - name: "Install bats dependencies"
       env:

--- a/.github/workflows/bats-sqlite-coverage.yml
+++ b/.github/workflows/bats-sqlite-coverage.yml
@@ -34,6 +34,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
+        cache-dependency-path: "**/go.sum"
 
     - name: "Install bats dependencies"
       env:

--- a/.github/workflows/ci-windows-build-msi.yml
+++ b/.github/workflows/ci-windows-build-msi.yml
@@ -30,28 +30,16 @@ jobs:
 
     steps:
 
-    - name: "Set up Go ${{ matrix.go-version }}"
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
         submodules: false
 
-    - name: Cache Go modules
-      uses: actions/cache@v3
+    - name: "Set up Go ${{ matrix.go-version }}"
+      uses: actions/setup-go@v4
       with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ matrix.go-version }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.go-version }}-go-
+        go-version: ${{ matrix.go-version }}
 
     - name: Build
       run: make windows_installer BUILD_RE2_WASM=1

--- a/.github/workflows/ci-windows-build-msi.yml
+++ b/.github/workflows/ci-windows-build-msi.yml
@@ -40,6 +40,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
+        cache-dependency-path: "**/go.sum"
 
     - name: Build
       run: make windows_installer BUILD_RE2_WASM=1

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -30,18 +30,6 @@ jobs:
         with:
           config: .github/buildkit.toml
 
-      # - name: "Build flavor: full"
-      #   uses: docker/build-push-action@v4
-      #   with:
-      #     context: .
-      #     file: ./Dockerfile
-      #     tags: crowdsecurity/crowdsec:test
-      #     target: full
-      #     platforms: linux/amd64
-      #     load: true
-      #     cache-from: type=gha
-      #     cache-to: type=gha,mode=min
-
       - name: "Build flavor: slim"
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/go-tests-windows.yml
+++ b/.github/workflows/go-tests-windows.yml
@@ -29,28 +29,16 @@ jobs:
 
     steps:
 
-    - name: "Set up Go ${{ matrix.go-version }}"
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
-
     - name: Check out CrowdSec repository
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
         submodules: false
 
-    - name: Cache Go modules
-      uses: actions/cache@v3
+    - name: "Set up Go ${{ matrix.go-version }}"
+      uses: actions/setup-go@v4
       with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ matrix.go-version }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.go-version }}-go-
+        go-version: ${{ matrix.go-version }}
 
     - name: Build
       run: |

--- a/.github/workflows/go-tests-windows.yml
+++ b/.github/workflows/go-tests-windows.yml
@@ -39,6 +39,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
+        cache-dependency-path: "**/go.sum"
 
     - name: Build
       run: |

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -120,6 +120,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
+        cache-dependency-path: "**/go.sum"
 
     - name: Build and run tests, static
       run: |

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -110,28 +110,16 @@ jobs:
 
     steps:
 
-    - name: "Set up Go ${{ matrix.go-version }}"
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
-
     - name: Check out CrowdSec repository
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
         submodules: false
 
-    - name: Cache Go modules
-      uses: actions/cache@v3
+    - name: "Set up Go ${{ matrix.go-version }}"
+      uses: actions/setup-go@v4
       with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ matrix.go-version }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.go-version }}-go-
+        go-version: ${{ matrix.go-version }}
 
     - name: Build and run tests, static
       run: |

--- a/.github/workflows/release_publish-package.yml
+++ b/.github/workflows/release_publish-package.yml
@@ -20,28 +20,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: "Set up Go ${{ matrix.go-version }}"
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.go-version }}
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: false
 
-      - name: Cache Go modules
-        uses: actions/cache@v3
+      - name: "Set up Go ${{ matrix.go-version }}"
+        uses: actions/setup-go@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/Library/Caches/go-build
-            %LocalAppData%\go-build
-          key: ${{ runner.os }}-${{ matrix.go-version }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.go-version }}-go-
+          go-version: ${{ matrix.go-version }}
 
       - name: Build the binaries
         run: |

--- a/.github/workflows/release_publish-package.yml
+++ b/.github/workflows/release_publish-package.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: "**/go.sum"
 
       - name: Build the binaries
         run: |


### PR DESCRIPTION
Version 4 of the setup-go action includes cache management, no need to do it by hand. Just be sure to include all go.sum files