### PR TITLE
Fix chooseHubBranch when latest() doesn't work

### DIFF
--- a/pkg/cwhub/helpers.go
+++ b/pkg/cwhub/helpers.go
@@ -16,7 +16,7 @@ import (
 func chooseHubBranch() (string, error) {
 	latest, err := cwversion.Latest()
 	if err != nil {
-		return "master", err
+		return "master", nil
 	}
 
 	csVersion := cwversion.VersionStrip()

--- a/pkg/cwhub/helpers.go
+++ b/pkg/cwhub/helpers.go
@@ -16,6 +16,7 @@ import (
 func chooseHubBranch() (string, error) {
 	latest, err := cwversion.Latest()
 	if err != nil {
+		//lint:ignore nilerr reason
 		return "master", nil // ignore
 	}
 

--- a/pkg/cwhub/helpers.go
+++ b/pkg/cwhub/helpers.go
@@ -16,7 +16,7 @@ import (
 func chooseHubBranch() (string, error) {
 	latest, err := cwversion.Latest()
 	if err != nil {
-		return "master", nil
+		return "master", nil // ignore
 	}
 
 	csVersion := cwversion.VersionStrip()


### PR DESCRIPTION
When running cscli without internet connection, if the check of the version fail, we can't list/remove parsers