### PR TITLE
re-add KeyExists expr helper

### DIFF
--- a/pkg/exprhelpers/expr_lib.go
+++ b/pkg/exprhelpers/expr_lib.go
@@ -377,6 +377,13 @@ var exprFuncs = []exprCustomFunc{
 			new(func(string, string) bool),
 		},
 	},
+	{
+		name:     "KeyExists",
+		function: KeyExists,
+		signature: []interface{}{
+			new(func(string, map[string]any) bool),
+		},
+	},
 }
 
 //go 1.20 "CutPrefix":              strings.CutPrefix,


### PR DESCRIPTION
The helper was removed by mistake when switching to expr fast call functions.