### PR TITLE
add indexes on the FK between alerts and {decisions,metas,events}

### DIFF
--- a/pkg/database/ent/alert_query.go
+++ b/pkg/database/ent/alert_query.go
@@ -562,7 +562,6 @@ func (aq *AlertQuery) loadDecisions(ctx context.Context, query *DecisionQuery, n
 			init(nodes[i])
 		}
 	}
-	query.withFKs = true
 	query.Where(predicate.Decision(func(s *sql.Selector) {
 		s.Where(sql.InValues(alert.DecisionsColumn, fks...))
 	}))
@@ -571,13 +570,10 @@ func (aq *AlertQuery) loadDecisions(ctx context.Context, query *DecisionQuery, n
 		return err
 	}
 	for _, n := range neighbors {
-		fk := n.alert_decisions
-		if fk == nil {
-			return fmt.Errorf(`foreign-key "alert_decisions" is nil for node %v`, n.ID)
-		}
-		node, ok := nodeids[*fk]
+		fk := n.AlertDecisions
+		node, ok := nodeids[fk]
 		if !ok {
-			return fmt.Errorf(`unexpected foreign-key "alert_decisions" returned %v for node %v`, *fk, n.ID)
+			return fmt.Errorf(`unexpected foreign-key "alert_decisions" returned %v for node %v`, fk, n.ID)
 		}
 		assign(node, n)
 	}
@@ -593,7 +589,6 @@ func (aq *AlertQuery) loadEvents(ctx context.Context, query *EventQuery, nodes [
 			init(nodes[i])
 		}
 	}
-	query.withFKs = true
 	query.Where(predicate.Event(func(s *sql.Selector) {
 		s.Where(sql.InValues(alert.EventsColumn, fks...))
 	}))
@@ -602,13 +597,10 @@ func (aq *AlertQuery) loadEvents(ctx context.Context, query *EventQuery, nodes [
 		return err
 	}
 	for _, n := range neighbors {
-		fk := n.alert_events
-		if fk == nil {
-			return fmt.Errorf(`foreign-key "alert_events" is nil for node %v`, n.ID)
-		}
-		node, ok := nodeids[*fk]
+		fk := n.AlertEvents
+		node, ok := nodeids[fk]
 		if !ok {
-			return fmt.Errorf(`unexpected foreign-key "alert_events" returned %v for node %v`, *fk, n.ID)
+			return fmt.Errorf(`unexpected foreign-key "alert_events" returned %v for node %v`, fk, n.ID)
 		}
 		assign(node, n)
 	}
@@ -624,7 +616,6 @@ func (aq *AlertQuery) loadMetas(ctx context.Context, query *MetaQuery, nodes []*
 			init(nodes[i])
 		}
 	}
-	query.withFKs = true
 	query.Where(predicate.Meta(func(s *sql.Selector) {
 		s.Where(sql.InValues(alert.MetasColumn, fks...))
 	}))
@@ -633,13 +624,10 @@ func (aq *AlertQuery) loadMetas(ctx context.Context, query *MetaQuery, nodes []*
 		return err
 	}
 	for _, n := range neighbors {
-		fk := n.alert_metas
-		if fk == nil {
-			return fmt.Errorf(`foreign-key "alert_metas" is nil for node %v`, n.ID)
-		}
-		node, ok := nodeids[*fk]
+		fk := n.AlertMetas
+		node, ok := nodeids[fk]
 		if !ok {
-			return fmt.Errorf(`unexpected foreign-key "alert_metas" returned %v for node %v`, *fk, n.ID)
+			return fmt.Errorf(`unexpected foreign-key "alert_metas" returned %v for node %v`, fk, n.ID)
 		}
 		assign(node, n)
 	}

--- a/pkg/database/ent/decision.go
+++ b/pkg/database/ent/decision.go
@@ -47,10 +47,11 @@ type Decision struct {
 	Simulated bool `json:"simulated,omitempty"`
 	// UUID holds the value of the "uuid" field.
 	UUID string `json:"uuid,omitempty"`
+	// AlertDecisions holds the value of the "alert_decisions" field.
+	AlertDecisions int `json:"alert_decisions,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the DecisionQuery when eager-loading is set.
-	Edges           DecisionEdges `json:"edges"`
-	alert_decisions *int
+	Edges DecisionEdges `json:"edges"`
 }
 
 // DecisionEdges holds the relations/edges for other nodes in the graph.
@@ -82,14 +83,12 @@ func (*Decision) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case decision.FieldSimulated:
 			values[i] = new(sql.NullBool)
-		case decision.FieldID, decision.FieldStartIP, decision.FieldEndIP, decision.FieldStartSuffix, decision.FieldEndSuffix, decision.FieldIPSize:
+		case decision.FieldID, decision.FieldStartIP, decision.FieldEndIP, decision.FieldStartSuffix, decision.FieldEndSuffix, decision.FieldIPSize, decision.FieldAlertDecisions:
 			values[i] = new(sql.NullInt64)
 		case decision.FieldScenario, decision.FieldType, decision.FieldScope, decision.FieldValue, decision.FieldOrigin, decision.FieldUUID:
 			values[i] = new(sql.NullString)
 		case decision.FieldCreatedAt, decision.FieldUpdatedAt, decision.FieldUntil:
 			values[i] = new(sql.NullTime)
-		case decision.ForeignKeys[0]: // alert_decisions
-			values[i] = new(sql.NullInt64)
 		default:
 			return nil, fmt.Errorf("unexpected column %q for type Decision", columns[i])
 		}
@@ -204,12 +203,11 @@ func (d *Decision) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				d.UUID = value.String
 			}
-		case decision.ForeignKeys[0]:
+		case decision.FieldAlertDecisions:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
-				return fmt.Errorf("unexpected type %T for edge-field alert_decisions", value)
+				return fmt.Errorf("unexpected type %T for field alert_decisions", values[i])
 			} else if value.Valid {
-				d.alert_decisions = new(int)
-				*d.alert_decisions = int(value.Int64)
+				d.AlertDecisions = int(value.Int64)
 			}
 		}
 	}
@@ -294,6 +292,9 @@ func (d *Decision) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("uuid=")
 	builder.WriteString(d.UUID)
+	builder.WriteString(", ")
+	builder.WriteString("alert_decisions=")
+	builder.WriteString(fmt.Sprintf("%v", d.AlertDecisions))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/database/ent/decision/decision.go
+++ b/pkg/database/ent/decision/decision.go
@@ -41,6 +41,8 @@ const (
 	FieldSimulated = "simulated"
 	// FieldUUID holds the string denoting the uuid field in the database.
 	FieldUUID = "uuid"
+	// FieldAlertDecisions holds the string denoting the alert_decisions field in the database.
+	FieldAlertDecisions = "alert_decisions"
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
 	EdgeOwner = "owner"
 	// Table holds the table name of the decision in the database.
@@ -72,23 +74,13 @@ var Columns = []string{
 	FieldOrigin,
 	FieldSimulated,
 	FieldUUID,
-}
-
-// ForeignKeys holds the SQL foreign-keys that are owned by the "decisions"
-// table and are not defined as standalone fields in the schema.
-var ForeignKeys = []string{
-	"alert_decisions",
+	FieldAlertDecisions,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
-			return true
-		}
-	}
-	for i := range ForeignKeys {
-		if column == ForeignKeys[i] {
 			return true
 		}
 	}

--- a/pkg/database/ent/decision/where.go
+++ b/pkg/database/ent/decision/where.go
@@ -186,6 +186,13 @@ func UUID(v string) predicate.Decision {
 	})
 }
 
+// AlertDecisions applies equality check predicate on the "alert_decisions" field. It's identical to AlertDecisionsEQ.
+func AlertDecisions(v int) predicate.Decision {
+	return predicate.Decision(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldAlertDecisions), v))
+	})
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Decision {
 	return predicate.Decision(func(s *sql.Selector) {
@@ -1429,6 +1436,56 @@ func UUIDEqualFold(v string) predicate.Decision {
 func UUIDContainsFold(v string) predicate.Decision {
 	return predicate.Decision(func(s *sql.Selector) {
 		s.Where(sql.ContainsFold(s.C(FieldUUID), v))
+	})
+}
+
+// AlertDecisionsEQ applies the EQ predicate on the "alert_decisions" field.
+func AlertDecisionsEQ(v int) predicate.Decision {
+	return predicate.Decision(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldAlertDecisions), v))
+	})
+}
+
+// AlertDecisionsNEQ applies the NEQ predicate on the "alert_decisions" field.
+func AlertDecisionsNEQ(v int) predicate.Decision {
+	return predicate.Decision(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldAlertDecisions), v))
+	})
+}
+
+// AlertDecisionsIn applies the In predicate on the "alert_decisions" field.
+func AlertDecisionsIn(vs ...int) predicate.Decision {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Decision(func(s *sql.Selector) {
+		s.Where(sql.In(s.C(FieldAlertDecisions), v...))
+	})
+}
+
+// AlertDecisionsNotIn applies the NotIn predicate on the "alert_decisions" field.
+func AlertDecisionsNotIn(vs ...int) predicate.Decision {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Decision(func(s *sql.Selector) {
+		s.Where(sql.NotIn(s.C(FieldAlertDecisions), v...))
+	})
+}
+
+// AlertDecisionsIsNil applies the IsNil predicate on the "alert_decisions" field.
+func AlertDecisionsIsNil() predicate.Decision {
+	return predicate.Decision(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldAlertDecisions)))
+	})
+}
+
+// AlertDecisionsNotNil applies the NotNil predicate on the "alert_decisions" field.
+func AlertDecisionsNotNil() predicate.Decision {
+	return predicate.Decision(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldAlertDecisions)))
 	})
 }
 

--- a/pkg/database/ent/decision_create.go
+++ b/pkg/database/ent/decision_create.go
@@ -191,6 +191,20 @@ func (dc *DecisionCreate) SetNillableUUID(s *string) *DecisionCreate {
 	return dc
 }
 
+// SetAlertDecisions sets the "alert_decisions" field.
+func (dc *DecisionCreate) SetAlertDecisions(i int) *DecisionCreate {
+	dc.mutation.SetAlertDecisions(i)
+	return dc
+}
+
+// SetNillableAlertDecisions sets the "alert_decisions" field if the given value is not nil.
+func (dc *DecisionCreate) SetNillableAlertDecisions(i *int) *DecisionCreate {
+	if i != nil {
+		dc.SetAlertDecisions(*i)
+	}
+	return dc
+}
+
 // SetOwnerID sets the "owner" edge to the Alert entity by ID.
 func (dc *DecisionCreate) SetOwnerID(id int) *DecisionCreate {
 	dc.mutation.SetOwnerID(id)
@@ -485,7 +499,7 @@ func (dc *DecisionCreate) createSpec() (*Decision, *sqlgraph.CreateSpec) {
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_node.alert_decisions = &nodes[0]
+		_node.AlertDecisions = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/pkg/database/ent/decision_update.go
+++ b/pkg/database/ent/decision_update.go
@@ -272,6 +272,26 @@ func (du *DecisionUpdate) ClearUUID() *DecisionUpdate {
 	return du
 }
 
+// SetAlertDecisions sets the "alert_decisions" field.
+func (du *DecisionUpdate) SetAlertDecisions(i int) *DecisionUpdate {
+	du.mutation.SetAlertDecisions(i)
+	return du
+}
+
+// SetNillableAlertDecisions sets the "alert_decisions" field if the given value is not nil.
+func (du *DecisionUpdate) SetNillableAlertDecisions(i *int) *DecisionUpdate {
+	if i != nil {
+		du.SetAlertDecisions(*i)
+	}
+	return du
+}
+
+// ClearAlertDecisions clears the value of the "alert_decisions" field.
+func (du *DecisionUpdate) ClearAlertDecisions() *DecisionUpdate {
+	du.mutation.ClearAlertDecisions()
+	return du
+}
+
 // SetOwnerID sets the "owner" edge to the Alert entity by ID.
 func (du *DecisionUpdate) SetOwnerID(id int) *DecisionUpdate {
 	du.mutation.SetOwnerID(id)
@@ -875,6 +895,26 @@ func (duo *DecisionUpdateOne) SetNillableUUID(s *string) *DecisionUpdateOne {
 // ClearUUID clears the value of the "uuid" field.
 func (duo *DecisionUpdateOne) ClearUUID() *DecisionUpdateOne {
 	duo.mutation.ClearUUID()
+	return duo
+}
+
+// SetAlertDecisions sets the "alert_decisions" field.
+func (duo *DecisionUpdateOne) SetAlertDecisions(i int) *DecisionUpdateOne {
+	duo.mutation.SetAlertDecisions(i)
+	return duo
+}
+
+// SetNillableAlertDecisions sets the "alert_decisions" field if the given value is not nil.
+func (duo *DecisionUpdateOne) SetNillableAlertDecisions(i *int) *DecisionUpdateOne {
+	if i != nil {
+		duo.SetAlertDecisions(*i)
+	}
+	return duo
+}
+
+// ClearAlertDecisions clears the value of the "alert_decisions" field.
+func (duo *DecisionUpdateOne) ClearAlertDecisions() *DecisionUpdateOne {
+	duo.mutation.ClearAlertDecisions()
 	return duo
 }
 

--- a/pkg/database/ent/event/event.go
+++ b/pkg/database/ent/event/event.go
@@ -19,6 +19,8 @@ const (
 	FieldTime = "time"
 	// FieldSerialized holds the string denoting the serialized field in the database.
 	FieldSerialized = "serialized"
+	// FieldAlertEvents holds the string denoting the alert_events field in the database.
+	FieldAlertEvents = "alert_events"
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
 	EdgeOwner = "owner"
 	// Table holds the table name of the event in the database.
@@ -39,23 +41,13 @@ var Columns = []string{
 	FieldUpdatedAt,
 	FieldTime,
 	FieldSerialized,
-}
-
-// ForeignKeys holds the SQL foreign-keys that are owned by the "events"
-// table and are not defined as standalone fields in the schema.
-var ForeignKeys = []string{
-	"alert_events",
+	FieldAlertEvents,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
-			return true
-		}
-	}
-	for i := range ForeignKeys {
-		if column == ForeignKeys[i] {
 			return true
 		}
 	}

--- a/pkg/database/ent/event/where.go
+++ b/pkg/database/ent/event/where.go
@@ -109,6 +109,13 @@ func Serialized(v string) predicate.Event {
 	})
 }
 
+// AlertEvents applies equality check predicate on the "alert_events" field. It's identical to AlertEventsEQ.
+func AlertEvents(v int) predicate.Event {
+	return predicate.Event(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldAlertEvents), v))
+	})
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Event {
 	return predicate.Event(func(s *sql.Selector) {
@@ -425,6 +432,56 @@ func SerializedEqualFold(v string) predicate.Event {
 func SerializedContainsFold(v string) predicate.Event {
 	return predicate.Event(func(s *sql.Selector) {
 		s.Where(sql.ContainsFold(s.C(FieldSerialized), v))
+	})
+}
+
+// AlertEventsEQ applies the EQ predicate on the "alert_events" field.
+func AlertEventsEQ(v int) predicate.Event {
+	return predicate.Event(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldAlertEvents), v))
+	})
+}
+
+// AlertEventsNEQ applies the NEQ predicate on the "alert_events" field.
+func AlertEventsNEQ(v int) predicate.Event {
+	return predicate.Event(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldAlertEvents), v))
+	})
+}
+
+// AlertEventsIn applies the In predicate on the "alert_events" field.
+func AlertEventsIn(vs ...int) predicate.Event {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Event(func(s *sql.Selector) {
+		s.Where(sql.In(s.C(FieldAlertEvents), v...))
+	})
+}
+
+// AlertEventsNotIn applies the NotIn predicate on the "alert_events" field.
+func AlertEventsNotIn(vs ...int) predicate.Event {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Event(func(s *sql.Selector) {
+		s.Where(sql.NotIn(s.C(FieldAlertEvents), v...))
+	})
+}
+
+// AlertEventsIsNil applies the IsNil predicate on the "alert_events" field.
+func AlertEventsIsNil() predicate.Event {
+	return predicate.Event(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldAlertEvents)))
+	})
+}
+
+// AlertEventsNotNil applies the NotNil predicate on the "alert_events" field.
+func AlertEventsNotNil() predicate.Event {
+	return predicate.Event(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldAlertEvents)))
 	})
 }
 

--- a/pkg/database/ent/event_create.go
+++ b/pkg/database/ent/event_create.go
@@ -61,6 +61,20 @@ func (ec *EventCreate) SetSerialized(s string) *EventCreate {
 	return ec
 }
 
+// SetAlertEvents sets the "alert_events" field.
+func (ec *EventCreate) SetAlertEvents(i int) *EventCreate {
+	ec.mutation.SetAlertEvents(i)
+	return ec
+}
+
+// SetNillableAlertEvents sets the "alert_events" field if the given value is not nil.
+func (ec *EventCreate) SetNillableAlertEvents(i *int) *EventCreate {
+	if i != nil {
+		ec.SetAlertEvents(*i)
+	}
+	return ec
+}
+
 // SetOwnerID sets the "owner" edge to the Alert entity by ID.
 func (ec *EventCreate) SetOwnerID(id int) *EventCreate {
 	ec.mutation.SetOwnerID(id)
@@ -256,7 +270,7 @@ func (ec *EventCreate) createSpec() (*Event, *sqlgraph.CreateSpec) {
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_node.alert_events = &nodes[0]
+		_node.AlertEvents = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/pkg/database/ent/event_update.go
+++ b/pkg/database/ent/event_update.go
@@ -65,6 +65,26 @@ func (eu *EventUpdate) SetSerialized(s string) *EventUpdate {
 	return eu
 }
 
+// SetAlertEvents sets the "alert_events" field.
+func (eu *EventUpdate) SetAlertEvents(i int) *EventUpdate {
+	eu.mutation.SetAlertEvents(i)
+	return eu
+}
+
+// SetNillableAlertEvents sets the "alert_events" field if the given value is not nil.
+func (eu *EventUpdate) SetNillableAlertEvents(i *int) *EventUpdate {
+	if i != nil {
+		eu.SetAlertEvents(*i)
+	}
+	return eu
+}
+
+// ClearAlertEvents clears the value of the "alert_events" field.
+func (eu *EventUpdate) ClearAlertEvents() *EventUpdate {
+	eu.mutation.ClearAlertEvents()
+	return eu
+}
+
 // SetOwnerID sets the "owner" edge to the Alert entity by ID.
 func (eu *EventUpdate) SetOwnerID(id int) *EventUpdate {
 	eu.mutation.SetOwnerID(id)
@@ -323,6 +343,26 @@ func (euo *EventUpdateOne) SetTime(t time.Time) *EventUpdateOne {
 // SetSerialized sets the "serialized" field.
 func (euo *EventUpdateOne) SetSerialized(s string) *EventUpdateOne {
 	euo.mutation.SetSerialized(s)
+	return euo
+}
+
+// SetAlertEvents sets the "alert_events" field.
+func (euo *EventUpdateOne) SetAlertEvents(i int) *EventUpdateOne {
+	euo.mutation.SetAlertEvents(i)
+	return euo
+}
+
+// SetNillableAlertEvents sets the "alert_events" field if the given value is not nil.
+func (euo *EventUpdateOne) SetNillableAlertEvents(i *int) *EventUpdateOne {
+	if i != nil {
+		euo.SetAlertEvents(*i)
+	}
+	return euo
+}
+
+// ClearAlertEvents clears the value of the "alert_events" field.
+func (euo *EventUpdateOne) ClearAlertEvents() *EventUpdateOne {
+	euo.mutation.ClearAlertEvents()
 	return euo
 }
 

--- a/pkg/database/ent/meta/meta.go
+++ b/pkg/database/ent/meta/meta.go
@@ -19,6 +19,8 @@ const (
 	FieldKey = "key"
 	// FieldValue holds the string denoting the value field in the database.
 	FieldValue = "value"
+	// FieldAlertMetas holds the string denoting the alert_metas field in the database.
+	FieldAlertMetas = "alert_metas"
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
 	EdgeOwner = "owner"
 	// Table holds the table name of the meta in the database.
@@ -39,23 +41,13 @@ var Columns = []string{
 	FieldUpdatedAt,
 	FieldKey,
 	FieldValue,
-}
-
-// ForeignKeys holds the SQL foreign-keys that are owned by the "meta"
-// table and are not defined as standalone fields in the schema.
-var ForeignKeys = []string{
-	"alert_metas",
+	FieldAlertMetas,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
-			return true
-		}
-	}
-	for i := range ForeignKeys {
-		if column == ForeignKeys[i] {
 			return true
 		}
 	}

--- a/pkg/database/ent/meta/where.go
+++ b/pkg/database/ent/meta/where.go
@@ -109,6 +109,13 @@ func Value(v string) predicate.Meta {
 	})
 }
 
+// AlertMetas applies equality check predicate on the "alert_metas" field. It's identical to AlertMetasEQ.
+func AlertMetas(v int) predicate.Meta {
+	return predicate.Meta(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldAlertMetas), v))
+	})
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Meta {
 	return predicate.Meta(func(s *sql.Selector) {
@@ -460,6 +467,56 @@ func ValueEqualFold(v string) predicate.Meta {
 func ValueContainsFold(v string) predicate.Meta {
 	return predicate.Meta(func(s *sql.Selector) {
 		s.Where(sql.ContainsFold(s.C(FieldValue), v))
+	})
+}
+
+// AlertMetasEQ applies the EQ predicate on the "alert_metas" field.
+func AlertMetasEQ(v int) predicate.Meta {
+	return predicate.Meta(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldAlertMetas), v))
+	})
+}
+
+// AlertMetasNEQ applies the NEQ predicate on the "alert_metas" field.
+func AlertMetasNEQ(v int) predicate.Meta {
+	return predicate.Meta(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldAlertMetas), v))
+	})
+}
+
+// AlertMetasIn applies the In predicate on the "alert_metas" field.
+func AlertMetasIn(vs ...int) predicate.Meta {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Meta(func(s *sql.Selector) {
+		s.Where(sql.In(s.C(FieldAlertMetas), v...))
+	})
+}
+
+// AlertMetasNotIn applies the NotIn predicate on the "alert_metas" field.
+func AlertMetasNotIn(vs ...int) predicate.Meta {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Meta(func(s *sql.Selector) {
+		s.Where(sql.NotIn(s.C(FieldAlertMetas), v...))
+	})
+}
+
+// AlertMetasIsNil applies the IsNil predicate on the "alert_metas" field.
+func AlertMetasIsNil() predicate.Meta {
+	return predicate.Meta(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldAlertMetas)))
+	})
+}
+
+// AlertMetasNotNil applies the NotNil predicate on the "alert_metas" field.
+func AlertMetasNotNil() predicate.Meta {
+	return predicate.Meta(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldAlertMetas)))
 	})
 }
 

--- a/pkg/database/ent/meta_create.go
+++ b/pkg/database/ent/meta_create.go
@@ -61,6 +61,20 @@ func (mc *MetaCreate) SetValue(s string) *MetaCreate {
 	return mc
 }
 
+// SetAlertMetas sets the "alert_metas" field.
+func (mc *MetaCreate) SetAlertMetas(i int) *MetaCreate {
+	mc.mutation.SetAlertMetas(i)
+	return mc
+}
+
+// SetNillableAlertMetas sets the "alert_metas" field if the given value is not nil.
+func (mc *MetaCreate) SetNillableAlertMetas(i *int) *MetaCreate {
+	if i != nil {
+		mc.SetAlertMetas(*i)
+	}
+	return mc
+}
+
 // SetOwnerID sets the "owner" edge to the Alert entity by ID.
 func (mc *MetaCreate) SetOwnerID(id int) *MetaCreate {
 	mc.mutation.SetOwnerID(id)
@@ -256,7 +270,7 @@ func (mc *MetaCreate) createSpec() (*Meta, *sqlgraph.CreateSpec) {
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_node.alert_metas = &nodes[0]
+		_node.AlertMetas = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/pkg/database/ent/meta_query.go
+++ b/pkg/database/ent/meta_query.go
@@ -25,7 +25,6 @@ type MetaQuery struct {
 	fields     []string
 	predicates []predicate.Meta
 	withOwner  *AlertQuery
-	withFKs    bool
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -351,18 +350,11 @@ func (mq *MetaQuery) prepareQuery(ctx context.Context) error {
 func (mq *MetaQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Meta, error) {
 	var (
 		nodes       = []*Meta{}
-		withFKs     = mq.withFKs
 		_spec       = mq.querySpec()
 		loadedTypes = [1]bool{
 			mq.withOwner != nil,
 		}
 	)
-	if mq.withOwner != nil {
-		withFKs = true
-	}
-	if withFKs {
-		_spec.Node.Columns = append(_spec.Node.Columns, meta.ForeignKeys...)
-	}
 	_spec.ScanValues = func(columns []string) ([]any, error) {
 		return (*Meta).scanValues(nil, columns)
 	}
@@ -394,10 +386,7 @@ func (mq *MetaQuery) loadOwner(ctx context.Context, query *AlertQuery, nodes []*
 	ids := make([]int, 0, len(nodes))
 	nodeids := make(map[int][]*Meta)
 	for i := range nodes {
-		if nodes[i].alert_metas == nil {
-			continue
-		}
-		fk := *nodes[i].alert_metas
+		fk := nodes[i].AlertMetas
 		if _, ok := nodeids[fk]; !ok {
 			ids = append(ids, fk)
 		}

--- a/pkg/database/ent/meta_update.go
+++ b/pkg/database/ent/meta_update.go
@@ -65,6 +65,26 @@ func (mu *MetaUpdate) SetValue(s string) *MetaUpdate {
 	return mu
 }
 
+// SetAlertMetas sets the "alert_metas" field.
+func (mu *MetaUpdate) SetAlertMetas(i int) *MetaUpdate {
+	mu.mutation.SetAlertMetas(i)
+	return mu
+}
+
+// SetNillableAlertMetas sets the "alert_metas" field if the given value is not nil.
+func (mu *MetaUpdate) SetNillableAlertMetas(i *int) *MetaUpdate {
+	if i != nil {
+		mu.SetAlertMetas(*i)
+	}
+	return mu
+}
+
+// ClearAlertMetas clears the value of the "alert_metas" field.
+func (mu *MetaUpdate) ClearAlertMetas() *MetaUpdate {
+	mu.mutation.ClearAlertMetas()
+	return mu
+}
+
 // SetOwnerID sets the "owner" edge to the Alert entity by ID.
 func (mu *MetaUpdate) SetOwnerID(id int) *MetaUpdate {
 	mu.mutation.SetOwnerID(id)
@@ -323,6 +343,26 @@ func (muo *MetaUpdateOne) SetKey(s string) *MetaUpdateOne {
 // SetValue sets the "value" field.
 func (muo *MetaUpdateOne) SetValue(s string) *MetaUpdateOne {
 	muo.mutation.SetValue(s)
+	return muo
+}
+
+// SetAlertMetas sets the "alert_metas" field.
+func (muo *MetaUpdateOne) SetAlertMetas(i int) *MetaUpdateOne {
+	muo.mutation.SetAlertMetas(i)
+	return muo
+}
+
+// SetNillableAlertMetas sets the "alert_metas" field if the given value is not nil.
+func (muo *MetaUpdateOne) SetNillableAlertMetas(i *int) *MetaUpdateOne {
+	if i != nil {
+		muo.SetAlertMetas(*i)
+	}
+	return muo
+}
+
+// ClearAlertMetas clears the value of the "alert_metas" field.
+func (muo *MetaUpdateOne) ClearAlertMetas() *MetaUpdateOne {
+	muo.mutation.ClearAlertMetas()
 	return muo
 }
 

--- a/pkg/database/ent/migrate/schema.go
+++ b/pkg/database/ent/migrate/schema.go
@@ -141,6 +141,11 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{DecisionsColumns[3]},
 			},
+			{
+				Name:    "decision_alert_decisions",
+				Unique:  false,
+				Columns: []*schema.Column{DecisionsColumns[16]},
+			},
 		},
 	}
 	// EventsColumns holds the columns for the "events" table.
@@ -163,6 +168,13 @@ var (
 				Columns:    []*schema.Column{EventsColumns[5]},
 				RefColumns: []*schema.Column{AlertsColumns[0]},
 				OnDelete:   schema.Cascade,
+			},
+		},
+		Indexes: []*schema.Index{
+			{
+				Name:    "event_alert_events",
+				Unique:  false,
+				Columns: []*schema.Column{EventsColumns[5]},
 			},
 		},
 	}
@@ -208,6 +220,13 @@ var (
 				Columns:    []*schema.Column{MetaColumns[5]},
 				RefColumns: []*schema.Column{AlertsColumns[0]},
 				OnDelete:   schema.Cascade,
+			},
+		},
+		Indexes: []*schema.Index{
+			{
+				Name:    "meta_alert_metas",
+				Unique:  false,
+				Columns: []*schema.Column{MetaColumns[5]},
 			},
 		},
 	}

--- a/pkg/database/ent/mutation.go
+++ b/pkg/database/ent/mutation.go
@@ -4773,6 +4773,55 @@ func (m *DecisionMutation) ResetUUID() {
 	delete(m.clearedFields, decision.FieldUUID)
 }
 
+// SetAlertDecisions sets the "alert_decisions" field.
+func (m *DecisionMutation) SetAlertDecisions(i int) {
+	m.owner = &i
+}
+
+// AlertDecisions returns the value of the "alert_decisions" field in the mutation.
+func (m *DecisionMutation) AlertDecisions() (r int, exists bool) {
+	v := m.owner
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAlertDecisions returns the old "alert_decisions" field's value of the Decision entity.
+// If the Decision object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *DecisionMutation) OldAlertDecisions(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAlertDecisions is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAlertDecisions requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAlertDecisions: %w", err)
+	}
+	return oldValue.AlertDecisions, nil
+}
+
+// ClearAlertDecisions clears the value of the "alert_decisions" field.
+func (m *DecisionMutation) ClearAlertDecisions() {
+	m.owner = nil
+	m.clearedFields[decision.FieldAlertDecisions] = struct{}{}
+}
+
+// AlertDecisionsCleared returns if the "alert_decisions" field was cleared in this mutation.
+func (m *DecisionMutation) AlertDecisionsCleared() bool {
+	_, ok := m.clearedFields[decision.FieldAlertDecisions]
+	return ok
+}
+
+// ResetAlertDecisions resets all changes to the "alert_decisions" field.
+func (m *DecisionMutation) ResetAlertDecisions() {
+	m.owner = nil
+	delete(m.clearedFields, decision.FieldAlertDecisions)
+}
+
 // SetOwnerID sets the "owner" edge to the Alert entity by id.
 func (m *DecisionMutation) SetOwnerID(id int) {
 	m.owner = &id
@@ -4785,7 +4834,7 @@ func (m *DecisionMutation) ClearOwner() {
 
 // OwnerCleared reports if the "owner" edge to the Alert entity was cleared.
 func (m *DecisionMutation) OwnerCleared() bool {
-	return m.clearedowner
+	return m.AlertDecisionsCleared() || m.clearedowner
 }
 
 // OwnerID returns the "owner" edge ID in the mutation.
@@ -4831,7 +4880,7 @@ func (m *DecisionMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *DecisionMutation) Fields() []string {
-	fields := make([]string, 0, 15)
+	fields := make([]string, 0, 16)
 	if m.created_at != nil {
 		fields = append(fields, decision.FieldCreatedAt)
 	}
@@ -4877,6 +4926,9 @@ func (m *DecisionMutation) Fields() []string {
 	if m.uuid != nil {
 		fields = append(fields, decision.FieldUUID)
 	}
+	if m.owner != nil {
+		fields = append(fields, decision.FieldAlertDecisions)
+	}
 	return fields
 }
 
@@ -4915,6 +4967,8 @@ func (m *DecisionMutation) Field(name string) (ent.Value, bool) {
 		return m.Simulated()
 	case decision.FieldUUID:
 		return m.UUID()
+	case decision.FieldAlertDecisions:
+		return m.AlertDecisions()
 	}
 	return nil, false
 }
@@ -4954,6 +5008,8 @@ func (m *DecisionMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldSimulated(ctx)
 	case decision.FieldUUID:
 		return m.OldUUID(ctx)
+	case decision.FieldAlertDecisions:
+		return m.OldAlertDecisions(ctx)
 	}
 	return nil, fmt.Errorf("unknown Decision field %s", name)
 }
@@ -5067,6 +5123,13 @@ func (m *DecisionMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetUUID(v)
+		return nil
+	case decision.FieldAlertDecisions:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAlertDecisions(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Decision field %s", name)
@@ -5188,6 +5251,9 @@ func (m *DecisionMutation) ClearedFields() []string {
 	if m.FieldCleared(decision.FieldUUID) {
 		fields = append(fields, decision.FieldUUID)
 	}
+	if m.FieldCleared(decision.FieldAlertDecisions) {
+		fields = append(fields, decision.FieldAlertDecisions)
+	}
 	return fields
 }
 
@@ -5228,6 +5294,9 @@ func (m *DecisionMutation) ClearField(name string) error {
 		return nil
 	case decision.FieldUUID:
 		m.ClearUUID()
+		return nil
+	case decision.FieldAlertDecisions:
+		m.ClearAlertDecisions()
 		return nil
 	}
 	return fmt.Errorf("unknown Decision nullable field %s", name)
@@ -5281,6 +5350,9 @@ func (m *DecisionMutation) ResetField(name string) error {
 		return nil
 	case decision.FieldUUID:
 		m.ResetUUID()
+		return nil
+	case decision.FieldAlertDecisions:
+		m.ResetAlertDecisions()
 		return nil
 	}
 	return fmt.Errorf("unknown Decision field %s", name)
@@ -5646,6 +5718,55 @@ func (m *EventMutation) ResetSerialized() {
 	m.serialized = nil
 }
 
+// SetAlertEvents sets the "alert_events" field.
+func (m *EventMutation) SetAlertEvents(i int) {
+	m.owner = &i
+}
+
+// AlertEvents returns the value of the "alert_events" field in the mutation.
+func (m *EventMutation) AlertEvents() (r int, exists bool) {
+	v := m.owner
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAlertEvents returns the old "alert_events" field's value of the Event entity.
+// If the Event object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *EventMutation) OldAlertEvents(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAlertEvents is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAlertEvents requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAlertEvents: %w", err)
+	}
+	return oldValue.AlertEvents, nil
+}
+
+// ClearAlertEvents clears the value of the "alert_events" field.
+func (m *EventMutation) ClearAlertEvents() {
+	m.owner = nil
+	m.clearedFields[event.FieldAlertEvents] = struct{}{}
+}
+
+// AlertEventsCleared returns if the "alert_events" field was cleared in this mutation.
+func (m *EventMutation) AlertEventsCleared() bool {
+	_, ok := m.clearedFields[event.FieldAlertEvents]
+	return ok
+}
+
+// ResetAlertEvents resets all changes to the "alert_events" field.
+func (m *EventMutation) ResetAlertEvents() {
+	m.owner = nil
+	delete(m.clearedFields, event.FieldAlertEvents)
+}
+
 // SetOwnerID sets the "owner" edge to the Alert entity by id.
 func (m *EventMutation) SetOwnerID(id int) {
 	m.owner = &id
@@ -5658,7 +5779,7 @@ func (m *EventMutation) ClearOwner() {
 
 // OwnerCleared reports if the "owner" edge to the Alert entity was cleared.
 func (m *EventMutation) OwnerCleared() bool {
-	return m.clearedowner
+	return m.AlertEventsCleared() || m.clearedowner
 }
 
 // OwnerID returns the "owner" edge ID in the mutation.
@@ -5704,7 +5825,7 @@ func (m *EventMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *EventMutation) Fields() []string {
-	fields := make([]string, 0, 4)
+	fields := make([]string, 0, 5)
 	if m.created_at != nil {
 		fields = append(fields, event.FieldCreatedAt)
 	}
@@ -5716,6 +5837,9 @@ func (m *EventMutation) Fields() []string {
 	}
 	if m.serialized != nil {
 		fields = append(fields, event.FieldSerialized)
+	}
+	if m.owner != nil {
+		fields = append(fields, event.FieldAlertEvents)
 	}
 	return fields
 }
@@ -5733,6 +5857,8 @@ func (m *EventMutation) Field(name string) (ent.Value, bool) {
 		return m.Time()
 	case event.FieldSerialized:
 		return m.Serialized()
+	case event.FieldAlertEvents:
+		return m.AlertEvents()
 	}
 	return nil, false
 }
@@ -5750,6 +5876,8 @@ func (m *EventMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldTime(ctx)
 	case event.FieldSerialized:
 		return m.OldSerialized(ctx)
+	case event.FieldAlertEvents:
+		return m.OldAlertEvents(ctx)
 	}
 	return nil, fmt.Errorf("unknown Event field %s", name)
 }
@@ -5787,6 +5915,13 @@ func (m *EventMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetSerialized(v)
 		return nil
+	case event.FieldAlertEvents:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAlertEvents(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Event field %s", name)
 }
@@ -5794,13 +5929,16 @@ func (m *EventMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *EventMutation) AddedFields() []string {
-	return nil
+	var fields []string
+	return fields
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *EventMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	}
 	return nil, false
 }
 
@@ -5823,6 +5961,9 @@ func (m *EventMutation) ClearedFields() []string {
 	if m.FieldCleared(event.FieldUpdatedAt) {
 		fields = append(fields, event.FieldUpdatedAt)
 	}
+	if m.FieldCleared(event.FieldAlertEvents) {
+		fields = append(fields, event.FieldAlertEvents)
+	}
 	return fields
 }
 
@@ -5843,6 +5984,9 @@ func (m *EventMutation) ClearField(name string) error {
 	case event.FieldUpdatedAt:
 		m.ClearUpdatedAt()
 		return nil
+	case event.FieldAlertEvents:
+		m.ClearAlertEvents()
+		return nil
 	}
 	return fmt.Errorf("unknown Event nullable field %s", name)
 }
@@ -5862,6 +6006,9 @@ func (m *EventMutation) ResetField(name string) error {
 		return nil
 	case event.FieldSerialized:
 		m.ResetSerialized()
+		return nil
+	case event.FieldAlertEvents:
+		m.ResetAlertEvents()
 		return nil
 	}
 	return fmt.Errorf("unknown Event field %s", name)
@@ -7361,6 +7508,55 @@ func (m *MetaMutation) ResetValue() {
 	m.value = nil
 }
 
+// SetAlertMetas sets the "alert_metas" field.
+func (m *MetaMutation) SetAlertMetas(i int) {
+	m.owner = &i
+}
+
+// AlertMetas returns the value of the "alert_metas" field in the mutation.
+func (m *MetaMutation) AlertMetas() (r int, exists bool) {
+	v := m.owner
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAlertMetas returns the old "alert_metas" field's value of the Meta entity.
+// If the Meta object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *MetaMutation) OldAlertMetas(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAlertMetas is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAlertMetas requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAlertMetas: %w", err)
+	}
+	return oldValue.AlertMetas, nil
+}
+
+// ClearAlertMetas clears the value of the "alert_metas" field.
+func (m *MetaMutation) ClearAlertMetas() {
+	m.owner = nil
+	m.clearedFields[meta.FieldAlertMetas] = struct{}{}
+}
+
+// AlertMetasCleared returns if the "alert_metas" field was cleared in this mutation.
+func (m *MetaMutation) AlertMetasCleared() bool {
+	_, ok := m.clearedFields[meta.FieldAlertMetas]
+	return ok
+}
+
+// ResetAlertMetas resets all changes to the "alert_metas" field.
+func (m *MetaMutation) ResetAlertMetas() {
+	m.owner = nil
+	delete(m.clearedFields, meta.FieldAlertMetas)
+}
+
 // SetOwnerID sets the "owner" edge to the Alert entity by id.
 func (m *MetaMutation) SetOwnerID(id int) {
 	m.owner = &id
@@ -7373,7 +7569,7 @@ func (m *MetaMutation) ClearOwner() {
 
 // OwnerCleared reports if the "owner" edge to the Alert entity was cleared.
 func (m *MetaMutation) OwnerCleared() bool {
-	return m.clearedowner
+	return m.AlertMetasCleared() || m.clearedowner
 }
 
 // OwnerID returns the "owner" edge ID in the mutation.
@@ -7419,7 +7615,7 @@ func (m *MetaMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *MetaMutation) Fields() []string {
-	fields := make([]string, 0, 4)
+	fields := make([]string, 0, 5)
 	if m.created_at != nil {
 		fields = append(fields, meta.FieldCreatedAt)
 	}
@@ -7431,6 +7627,9 @@ func (m *MetaMutation) Fields() []string {
 	}
 	if m.value != nil {
 		fields = append(fields, meta.FieldValue)
+	}
+	if m.owner != nil {
+		fields = append(fields, meta.FieldAlertMetas)
 	}
 	return fields
 }
@@ -7448,6 +7647,8 @@ func (m *MetaMutation) Field(name string) (ent.Value, bool) {
 		return m.Key()
 	case meta.FieldValue:
 		return m.Value()
+	case meta.FieldAlertMetas:
+		return m.AlertMetas()
 	}
 	return nil, false
 }
@@ -7465,6 +7666,8 @@ func (m *MetaMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldKey(ctx)
 	case meta.FieldValue:
 		return m.OldValue(ctx)
+	case meta.FieldAlertMetas:
+		return m.OldAlertMetas(ctx)
 	}
 	return nil, fmt.Errorf("unknown Meta field %s", name)
 }
@@ -7502,6 +7705,13 @@ func (m *MetaMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetValue(v)
 		return nil
+	case meta.FieldAlertMetas:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAlertMetas(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Meta field %s", name)
 }
@@ -7509,13 +7719,16 @@ func (m *MetaMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *MetaMutation) AddedFields() []string {
-	return nil
+	var fields []string
+	return fields
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *MetaMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	}
 	return nil, false
 }
 
@@ -7538,6 +7751,9 @@ func (m *MetaMutation) ClearedFields() []string {
 	if m.FieldCleared(meta.FieldUpdatedAt) {
 		fields = append(fields, meta.FieldUpdatedAt)
 	}
+	if m.FieldCleared(meta.FieldAlertMetas) {
+		fields = append(fields, meta.FieldAlertMetas)
+	}
 	return fields
 }
 
@@ -7558,6 +7774,9 @@ func (m *MetaMutation) ClearField(name string) error {
 	case meta.FieldUpdatedAt:
 		m.ClearUpdatedAt()
 		return nil
+	case meta.FieldAlertMetas:
+		m.ClearAlertMetas()
+		return nil
 	}
 	return fmt.Errorf("unknown Meta nullable field %s", name)
 }
@@ -7577,6 +7796,9 @@ func (m *MetaMutation) ResetField(name string) error {
 		return nil
 	case meta.FieldValue:
 		m.ResetValue()
+		return nil
+	case meta.FieldAlertMetas:
+		m.ResetAlertMetas()
 		return nil
 	}
 	return fmt.Errorf("unknown Meta field %s", name)

--- a/pkg/database/ent/schema/decision.go
+++ b/pkg/database/ent/schema/decision.go
@@ -38,6 +38,7 @@ func (Decision) Fields() []ent.Field {
 		field.String("origin"),
 		field.Bool("simulated").Default(false),
 		field.String("uuid").Optional(), //this uuid is mostly here to ensure that CAPI/PAPI has a unique id for each decision
+		field.Int("alert_decisions").Optional(),
 	}
 }
 
@@ -46,6 +47,7 @@ func (Decision) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("owner", Alert.Type).
 			Ref("decisions").
+			Field("alert_decisions").
 			Unique(),
 	}
 }
@@ -55,5 +57,6 @@ func (Decision) Indexes() []ent.Index {
 		index.Fields("start_ip", "end_ip"),
 		index.Fields("value"),
 		index.Fields("until"),
+		index.Fields("alert_decisions"),
 	}
 }

--- a/pkg/database/ent/schema/event.go
+++ b/pkg/database/ent/schema/event.go
@@ -4,6 +4,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
@@ -23,6 +24,7 @@ func (Event) Fields() []ent.Field {
 			UpdateDefault(types.UtcNow).Nillable().Optional(),
 		field.Time("time"),
 		field.String("serialized").MaxLen(8191),
+		field.Int("alert_events").Optional(),
 	}
 }
 
@@ -31,6 +33,13 @@ func (Event) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("owner", Alert.Type).
 			Ref("events").
+			Field("alert_events").
 			Unique(),
+	}
+}
+
+func (Event) Indexes() []ent.Index {
+	return []ent.Index{
+		index.Fields("alert_events"),
 	}
 }

--- a/pkg/database/ent/schema/meta.go
+++ b/pkg/database/ent/schema/meta.go
@@ -4,6 +4,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
@@ -23,6 +24,7 @@ func (Meta) Fields() []ent.Field {
 			UpdateDefault(types.UtcNow).Nillable().Optional(),
 		field.String("key"),
 		field.String("value").MaxLen(4095),
+		field.Int("alert_metas").Optional(),
 	}
 }
 
@@ -31,6 +33,13 @@ func (Meta) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("owner", Alert.Type).
 			Ref("metas").
+			Field("alert_metas").
 			Unique(),
+	}
+}
+
+func (Meta) Indexes() []ent.Index {
+	return []ent.Index{
+		index.Fields("alert_metas"),
 	}
 }


### PR DESCRIPTION
Add missing indexes on the foreign keys between the alerts table and the decisions/meta/events tables.

This greatly speed up flush operations (for reference, with sqlite, on a db with around 100k alerts and 12k decisions, this change reduced the time for a flush from 100 minutes to around a second).

Before this change, FK fields were automatically added by ent, but we now have to manually add them in the schema or we're not able to add indexes on them.