### PR TITLE
make hostname available in notification template ;-)

### DIFF
--- a/debian/crowdsec.service
+++ b/debian/crowdsec.service
@@ -5,6 +5,7 @@ After=syslog.target network.target remote-fs.target nss-lookup.target
 [Service]
 Type=notify
 Environment=LC_ALL=C LANG=C
+Environment=HOSTNAME=%H
 ExecStartPre=/usr/bin/crowdsec -c /etc/crowdsec/config.yaml -t
 ExecStart=/usr/bin/crowdsec -c /etc/crowdsec/config.yaml
 #ExecStartPost=/bin/sleep 0.1


### PR DESCRIPTION
systemd define %H as the hostname. The hostname is human readable in notification message ;-)

Here is the discussion about different possible solution to make available the hostname in notification go_template:
https://discourse.crowdsec.net/t/notification-another-identifiing-machine-than-id/1284/

After different tries, this commit seems to be the simplest & efficient solution.

/area configuration
/kind enhancement
