### PR TITLE
docker build: ignore existing release directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 #.git
 
 /tests
+/crowdsec-v*


### PR DESCRIPTION
otherwise "make release" followed by "docker build" fails because the directory is included in the docker context