### PR TITLE
Update KV ignore whitespace before and after `=`

### DIFF
--- a/pkg/exprhelpers/exprlib_test.go
+++ b/pkg/exprhelpers/exprlib_test.go
@@ -1399,6 +1399,18 @@ func TestParseKv(t *testing.T) {
 			expected: map[string]string{"foo": "bar=toto"},
 			expr:     `ParseKV(value, out, "a")`,
 		},
+		{
+			name:     "ParseKV() test: ignore empty unquoted string",
+			value:    `foo= bar=toto`,
+			expected: map[string]string{"bar": "toto"},
+			expr:     `ParseKV(value, out, "a")`,
+		},
+		{
+			name:     "ParseKV() test: empty quoted string ",
+			value:    `foo="" bar=toto`,
+			expected: map[string]string{"bar": "toto", "foo": ""},
+			expr:     `ParseKV(value, out, "a")`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/exprhelpers/exprlib_test.go
+++ b/pkg/exprhelpers/exprlib_test.go
@@ -1400,9 +1400,9 @@ func TestParseKv(t *testing.T) {
 			expr:     `ParseKV(value, out, "a")`,
 		},
 		{
-			name:     "ParseKV() test: ignore empty unquoted string",
+			name:     "ParseKV() test: empty unquoted string",
 			value:    `foo= bar=toto`,
-			expected: map[string]string{"bar": "toto"},
+			expected: map[string]string{"bar": "toto", "foo": ""},
 			expr:     `ParseKV(value, out, "a")`,
 		},
 		{

--- a/pkg/exprhelpers/helpers.go
+++ b/pkg/exprhelpers/helpers.go
@@ -51,7 +51,7 @@ var dbClient *database.Client
 
 var exprFunctionOptions []expr.Option
 
-var keyValuePattern = regexp.MustCompile(`\s*(?P<key>[^=\s]+)\s*=\s*(?:"(?P<quoted_value>[^"\\]*(?:\\.[^"\\]*)*)"|(?P<value>[^=\s]+))`)
+var keyValuePattern = regexp.MustCompile(`\s*(?P<key>[^=\s]+)=(?:"(?P<quoted_value>[^"\\]*(?:\\.[^"\\]*)*)"|(?P<value>[^=\s]+))`)
 
 func GetExprOptions(ctx map[string]interface{}) []expr.Option {
 	ret := []expr.Option{}

--- a/pkg/exprhelpers/helpers.go
+++ b/pkg/exprhelpers/helpers.go
@@ -51,7 +51,7 @@ var dbClient *database.Client
 
 var exprFunctionOptions []expr.Option
 
-var keyValuePattern = regexp.MustCompile(`(?P<key>[^=\s]+)=(?:"(?P<quoted_value>[^"\\]*(?:\\.[^"\\]*)*)"|(?P<value>[^=\s]+))`)
+var keyValuePattern = regexp.MustCompile(`(?P<key>[^=\s]+)=(?:"(?P<quoted_value>[^"\\]*(?:\\.[^"\\]*)*)"|(?P<value>[^=\s]+)|\s*)`)
 
 func GetExprOptions(ctx map[string]interface{}) []expr.Option {
 	ret := []expr.Option{}

--- a/pkg/exprhelpers/helpers.go
+++ b/pkg/exprhelpers/helpers.go
@@ -51,7 +51,7 @@ var dbClient *database.Client
 
 var exprFunctionOptions []expr.Option
 
-var keyValuePattern = regexp.MustCompile(`\s*(?P<key>[^=\s]+)=(?:"(?P<quoted_value>[^"\\]*(?:\\.[^"\\]*)*)"|(?P<value>[^=\s]+))`)
+var keyValuePattern = regexp.MustCompile(`(?P<key>[^=\s]+)=(?:"(?P<quoted_value>[^"\\]*(?:\\.[^"\\]*)*)"|(?P<value>[^=\s]+))`)
 
 func GetExprOptions(ctx map[string]interface{}) []expr.Option {
 	ret := []expr.Option{}


### PR DESCRIPTION
User cannot have `MAC =123` OR `MAC= 123` Anymore but this should never really be the case as KV format is `MAC=123` this is to ignore `OUT= MAC=123` OUT is ignore and MAC is parsed correctly