### PR TITLE
CI: separate stderr in all func tests

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 0%

--- a/test/bats/02_nolapi.bats
+++ b/test/bats/02_nolapi.bats
@@ -24,35 +24,33 @@ teardown() {
 #----------
 
 @test "test without -no-api flag" {
-    run -124 --separate-stderr timeout 2s "${CROWDSEC}"
+    rune -124 timeout 2s "${CROWDSEC}"
     # from `man timeout`: If  the  command  times  out,  and --preserve-status is not set, then exit with status 124.
 }
 
 @test "crowdsec should not run without LAPI (-no-api flag)" {
     # really needs 4 secs on slow boxes
-    run -1 --separate-stderr timeout 4s "${CROWDSEC}" -no-api
+    rune -1 timeout 4s "${CROWDSEC}" -no-api
 }
 
 @test "crowdsec should not run without LAPI (no api.server in configuration file)" {
     config_disable_lapi
     config_log_stderr
     # really needs 4 secs on slow boxes
-    run -1 --separate-stderr timeout 4s "${CROWDSEC}"
-
+    rune -1 timeout 4s "${CROWDSEC}"
     assert_stderr --partial "crowdsec local API is disabled"
 }
 
 @test "capi status shouldn't be ok without api.server" {
     config_disable_lapi
-    run -1 --separate-stderr cscli capi status
-
+    rune -1 cscli capi status
     assert_stderr --partial "crowdsec local API is disabled"
     assert_stderr --partial "There is no configuration on 'api.server:'"
 }
 
 @test "cscli config show -o human" {
     config_disable_lapi
-    run -0 cscli config show -o human
+    rune -0 cscli config show -o human
     assert_output --partial "Global:"
     assert_output --partial "Crowdsec:"
     assert_output --partial "cscli:"
@@ -62,9 +60,9 @@ teardown() {
 @test "cscli config backup" {
     config_disable_lapi
     backupdir=$(TMPDIR="${BATS_TEST_TMPDIR}" mktemp -u)
-    run -0 cscli config backup "${backupdir}"
-    assert_output --partial "Starting configuration backup"
-    run -1 --separate-stderr cscli config backup "${backupdir}"
+    rune -0 cscli config backup "${backupdir}"
+    assert_stderr --partial "Starting configuration backup"
+    rune -1 cscli config backup "${backupdir}"
     rm -rf -- "${backupdir:?}"
 
     assert_stderr --partial "failed to backup config"
@@ -74,7 +72,7 @@ teardown() {
 @test "lapi status shouldn't be ok without api.server" {
     config_disable_lapi
     ./instance-crowdsec start || true
-    run -1 --separate-stderr cscli machines list
+    rune -1 cscli machines list
     assert_stderr --partial "local API is disabled, please run this command on the local API machine"
 }
 
@@ -82,7 +80,7 @@ teardown() {
     skip 'need to trigger metrics with a live parse'
     config_disable_lapi
     ./instance-crowdsec start
-    run -0 --separate-stderr cscli metrics
+    rune -0 cscli metrics
     assert_output --partial "ROUTE"
     assert_output --partial "/v1/watchers/login"
 

--- a/test/bats/03_noagent.bats
+++ b/test/bats/03_noagent.bats
@@ -23,25 +23,25 @@ teardown() {
 #----------
 
 @test "with agent: test without -no-cs flag" {
-    run -124 timeout 2s "${CROWDSEC}"
+    rune -124 timeout 2s "${CROWDSEC}"
     # from `man timeout`: If  the  command  times  out,  and --preserve-status is not set, then exit with status 124.
 }
 
 @test "no agent: crowdsec LAPI should run (-no-cs flag)" {
-    run -124 timeout 2s "${CROWDSEC}" -no-cs
+    rune -124 timeout 2s "${CROWDSEC}" -no-cs
 }
 
 @test "no agent: crowdsec LAPI should run (no crowdsec_service in configuration file)" {
     config_disable_agent
     config_log_stderr
-    run -124 --separate-stderr timeout 2s "${CROWDSEC}"
+    rune -124 timeout 2s "${CROWDSEC}"
 
     assert_stderr --partial "crowdsec agent is disabled"
 }
 
 @test "no agent: cscli config show" {
     config_disable_agent
-    run -0 --separate-stderr cscli config show -o human
+    rune -0 cscli config show -o human
     assert_output --partial "Global:"
     assert_output --partial "cscli:"
     assert_output --partial "Local API Server:"
@@ -52,9 +52,9 @@ teardown() {
 @test "no agent: cscli config backup" {
     config_disable_agent
     backupdir=$(TMPDIR="${BATS_TEST_TMPDIR}" mktemp -u)
-    run -0 cscli config backup "${backupdir}"
-    assert_output --partial "Starting configuration backup"
-    run -1 --separate-stderr cscli config backup "${backupdir}"
+    rune -0 cscli config backup "${backupdir}"
+    assert_stderr --partial "Starting configuration backup"
+    rune -1 cscli config backup "${backupdir}"
 
     assert_stderr --partial "failed to backup config"
     assert_stderr --partial "file exists"
@@ -64,13 +64,13 @@ teardown() {
 @test "no agent: lapi status should be ok" {
     config_disable_agent
     ./instance-crowdsec start
-    run -0 --separate-stderr cscli lapi status
+    rune -0 cscli lapi status
     assert_stderr --partial "You can successfully interact with Local API (LAPI)"
 }
 
 @test "cscli metrics" {
     config_disable_agent
     ./instance-crowdsec start
-    run -0 cscli lapi status
-    run -0 cscli metrics
+    rune -0 cscli lapi status
+    rune -0 cscli metrics
 }

--- a/test/bats/04_capi.bats
+++ b/test/bats/04_capi.bats
@@ -21,12 +21,12 @@ setup() {
 
 @test "cscli capi status" {
     config_enable_capi
-    run -0 cscli capi register --schmilblick githubciXXXXXXXXXXXXXXXXXXXXXXXX
-    run -0 cscli capi status
-    assert_output --partial "Loaded credentials from"
-    assert_output --partial "Trying to authenticate with username"
-    assert_output --partial " on https://api.crowdsec.net/"
-    assert_output --partial "You can successfully interact with Central API (CAPI)"
+    rune -0 cscli capi register --schmilblick githubciXXXXXXXXXXXXXXXXXXXXXXXX
+    rune -0 cscli capi status
+    assert_stderr --partial "Loaded credentials from"
+    assert_stderr --partial "Trying to authenticate with username"
+    assert_stderr --partial " on https://api.crowdsec.net/"
+    assert_stderr --partial "You can successfully interact with Central API (CAPI)"
 }
 
 @test "cscli alerts list: receive a community pull when capi is enabled" {
@@ -37,17 +37,14 @@ setup() {
         [[ $(cscli alerts list -a -o json 2>/dev/null || cscli alerts list -o json) != "null" ]] && break
     done
 
-    run --separate-stderr cscli alerts list -a -o json
-    if [[ "${status}" -ne 0 ]]; then
-        run --separate-stderr cscli alerts list -o json
-    fi
-    run -0 jq -r '. | length' <(output)
+    rune -0 cscli alerts list -a -o json
+    rune -0 jq -r '. | length' <(output)
     refute_output 0
 }
 
 @test "we have exactly one machine, localhost" {
-    run -0 --separate-stderr cscli machines list -o json
-    run -0 jq -c '[. | length, .[0].machineId[0:32], .[0].isValidated, .[0].ipAddress]' <(output)
+    rune -0 cscli machines list -o json
+    rune -0 jq -c '[. | length, .[0].machineId[0:32], .[0].isValidated, .[0].ipAddress]' <(output)
     assert_output '[1,"githubciXXXXXXXXXXXXXXXXXXXXXXXX",true,"127.0.0.1"]'
 }
 
@@ -55,13 +52,13 @@ setup() {
     ./instance-crowdsec stop
     config_disable_agent
     ./instance-crowdsec start
-    run -0 --separate-stderr cscli capi status
+    rune -0 cscli capi status
     assert_stderr --partial "You can successfully interact with Central API (CAPI)"
 }
 
 @test "cscli capi status: fails without credentials" {
     ONLINE_API_CREDENTIALS_YAML="$(config_get '.api.server.online_client.credentials_path')"
     rm "${ONLINE_API_CREDENTIALS_YAML}"
-    run -1 --separate-stderr cscli capi status
+    rune -1 cscli capi status
     assert_stderr --partial "Local API is disabled, please run this command on the local API machine: loading online client credentials: failed to read api server credentials configuration file '${ONLINE_API_CREDENTIALS_YAML}': open ${ONLINE_API_CREDENTIALS_YAML}: no such file or directory"
 }

--- a/test/bats/04_nocapi.bats
+++ b/test/bats/04_nocapi.bats
@@ -25,14 +25,14 @@ teardown() {
 @test "without capi: crowdsec LAPI should run without capi (-no-capi flag)" {
     config_set '.common.log_media="stdout"'
 
-    run -124 --separate-stderr timeout 1s "${CROWDSEC}" -no-capi
+    rune -124 timeout 1s "${CROWDSEC}" -no-capi
     assert_stderr --partial "Communication with CrowdSec Central API disabled from args"
 }
 
 @test "without capi: crowdsec LAPI should still work" {
     config_disable_capi
     config_set '.common.log_media="stdout"'
-    run -124 --separate-stderr timeout 1s "${CROWDSEC}"
+    rune -124 timeout 1s "${CROWDSEC}"
     # from `man timeout`: If  the  command  times  out,  and --preserve-status is not set, then exit with status 124.
     assert_stderr --partial "push and pull to Central API disabled"
 }
@@ -40,13 +40,13 @@ teardown() {
 @test "without capi: cscli capi status -> fail" {
     config_disable_capi
     ./instance-crowdsec start
-    run -1 --separate-stderr cscli capi status
+    rune -1 cscli capi status
     assert_stderr --partial "no configuration for Central API in "
 }
 
 @test "no capi: cscli config show" {
     config_disable_capi
-    run -0 --separate-stderr cscli config show -o human
+    rune -0 cscli config show -o human
     assert_output --partial "Global:"
     assert_output --partial "cscli:"
     assert_output --partial "Crowdsec:"
@@ -56,9 +56,9 @@ teardown() {
 @test "no agent: cscli config backup" {
     config_disable_capi
     backupdir=$(TMPDIR="${BATS_TEST_TMPDIR}" mktemp -u)
-    run -0 cscli config backup "${backupdir}"
-    assert_output --partial "Starting configuration backup"
-    run -1 --separate-stderr cscli config backup "${backupdir}"
+    rune -0 cscli config backup "${backupdir}"
+    assert_stderr --partial "Starting configuration backup"
+    rune -1 cscli config backup "${backupdir}"
     assert_stderr --partial "failed to backup config"
     assert_stderr --partial "file exists"
     rm -rf -- "${backupdir:?}"
@@ -67,15 +67,15 @@ teardown() {
 @test "without capi: cscli lapi status -> success" {
     config_disable_capi
     ./instance-crowdsec start
-    run -0 --separate-stderr cscli lapi status
+    rune -0 cscli lapi status
     assert_stderr --partial "You can successfully interact with Local API (LAPI)"
 }
 
 @test "cscli metrics" {
     config_disable_capi
     ./instance-crowdsec start
-    run -0 cscli lapi status
-    run -0 --separate-stderr cscli metrics
+    rune -0 cscli lapi status
+    rune -0 cscli metrics
     assert_output --partial "Route"
     assert_output --partial '/v1/watchers/login'
     assert_output --partial "Local Api Metrics:"

--- a/test/bats/05_config_yaml_local.bats
+++ b/test/bats/05_config_yaml_local.bats
@@ -20,7 +20,7 @@ teardown_file() {
 setup() {
     load "../lib/setup.sh"
     ./instance-data load
-    run -0 config_get '.api.client.credentials_path'
+    rune -0 config_get '.api.client.credentials_path'
     LOCAL_API_CREDENTIALS="${output}"
     export LOCAL_API_CREDENTIALS
 }
@@ -33,82 +33,82 @@ teardown() {
 
 @test "config.yaml.local - cscli (log_level)" {
     config_set '.common.log_level="warning"'
-    run -0 --separate-stderr cscli config show --key Config.Common.LogLevel
+    rune -0 cscli config show --key Config.Common.LogLevel
     assert_output "warning"
 
     echo "{'common':{'log_level':'debug'}}" >"${CONFIG_YAML}.local"
-    run -0 --separate-stderr cscli config show --key Config.Common.LogLevel
+    rune -0 cscli config show --key Config.Common.LogLevel
     assert_output "debug"
 }
 
 @test "config.yaml.local - cscli (log_level - with envvar)" {
     config_set '.common.log_level="warning"'
-    run -0 --separate-stderr cscli config show --key Config.Common.LogLevel
+    rune -0 cscli config show --key Config.Common.LogLevel
     assert_output "warning"
 
     export CROWDSEC_LOG_LEVEL=debug
     echo "{'common':{'log_level':'${CROWDSEC_LOG_LEVEL}'}}" >"${CONFIG_YAML}.local"
-    run -0 --separate-stderr cscli config show --key Config.Common.LogLevel
+    rune -0 cscli config show --key Config.Common.LogLevel
     assert_output "debug"
 }
 
 @test "config.yaml.local - crowdsec (listen_url)" {
     # disable the agent or we'll need to patch api client credentials too
-    run -0 config_disable_agent
+    rune -0 config_disable_agent
     ./instance-crowdsec start
-    run -0 ./bin/wait-for-port -q 8080
+    rune -0 ./bin/wait-for-port -q 8080
     ./instance-crowdsec stop
-    run -1 ./bin/wait-for-port -q 8080
+    rune -1 ./bin/wait-for-port -q 8080
 
     echo "{'api':{'server':{'listen_uri':127.0.0.1:8083}}}" >"${CONFIG_YAML}.local"
 
     ./instance-crowdsec start
-    run -0 ./bin/wait-for-port -q 8083
-    run -1 ./bin/wait-for-port -q 8080
+    rune -0 ./bin/wait-for-port -q 8083
+    rune -1 ./bin/wait-for-port -q 8080
     ./instance-crowdsec stop
 
     rm -f "${CONFIG_YAML}.local"
     ./instance-crowdsec start
-    run -1 ./bin/wait-for-port -q 8083
-    run -0 ./bin/wait-for-port -q 8080
+    rune -1 ./bin/wait-for-port -q 8083
+    rune -0 ./bin/wait-for-port -q 8080
 }
 
 @test "local_api_credentials.yaml.local" {
-    run -0 config_disable_agent
+    rune -0 config_disable_agent
     echo "{'api':{'server':{'listen_uri':127.0.0.1:8083}}}" >"${CONFIG_YAML}.local"
     ./instance-crowdsec start
-    run -0 ./bin/wait-for-port -q 8083
+    rune -0 ./bin/wait-for-port -q 8083
 
-    run -1 cscli decisions list
+    rune -1 cscli decisions list
     echo "{'url':'http://127.0.0.1:8083'}" >"${LOCAL_API_CREDENTIALS}.local"
 
-    run -0 cscli decisions list
+    rune -0 cscli decisions list
 }
 
 @test "simulation.yaml.local" {
-    run -0 config_get '.config_paths.simulation_path'
+    rune -0 config_get '.config_paths.simulation_path'
     refute_output null
     SIMULATION="${output}"
 
     echo "simulation: off" >"${SIMULATION}"
-    run -0 cscli simulation status -o human
-    assert_output --partial "global simulation: disabled"
+    rune -0 cscli simulation status -o human
+    assert_stderr --partial "global simulation: disabled"
 
     echo "simulation: on" >"${SIMULATION}"
-    run -0 cscli simulation status -o human
-    assert_output --partial "global simulation: enabled"
+    rune -0 cscli simulation status -o human
+    assert_stderr --partial "global simulation: enabled"
 
     echo "simulation: off" >"${SIMULATION}.local"
-    run -0 cscli simulation status -o human
-    assert_output --partial "global simulation: disabled"
+    rune -0 cscli simulation status -o human
+    assert_stderr --partial "global simulation: disabled"
 
     rm -f "${SIMULATION}.local"
-    run -0 cscli simulation status -o human
-    assert_output --partial "global simulation: enabled"
+    rune -0 cscli simulation status -o human
+    assert_stderr --partial "global simulation: enabled"
 }
 
 @test "profiles.yaml.local" {
-    run -0 --separate-stderr config_get '.api.server.profiles_path'
+    rune -0 config_get '.api.server.profiles_path'
     refute_output null
     PROFILES="${output}"
 
@@ -135,8 +135,8 @@ teardown() {
     # wait more than required
     for ((i=0;i<30;i++)); do
         sleep .5
-        run -0 --separate-stderr cscli decisions list -o json
-        run -0 jq --exit-status '.[].decisions[0] | [.value,.type] == ["1.1.1.172","captcha"]' <(output) && break
+        rune -0 cscli decisions list -o json
+        rune -0 jq --exit-status '.[].decisions[0] | [.value,.type] == ["1.1.1.172","captcha"]' <(output) && break
     done
     rm -f -- "${tmpfile}"
     [[ "${status}" -eq 0 ]] || fail "captcha not triggered"

--- a/test/bats/07_setup.bats
+++ b/test/bats/07_setup.bats
@@ -67,7 +67,7 @@ teardown() {
     assert_line --partial "--force-os-version string   override OS.RawVersion (of OS or Linux distribution)"
     assert_line --partial "--skip-service strings      ignore a service, don't recommend hub/datasources (can be repeated)"
 
-    rune -1 --separate-stderr cscli setup detect --detect-config /path/does/not/exist
+    rune -1 cscli setup detect --detect-config /path/does/not/exist
     assert_stderr --partial "detecting services: while reading file: open /path/does/not/exist: no such file or directory"
 
     # rm -f "${HUB_DIR}/detect.yaml"
@@ -91,27 +91,27 @@ teardown() {
 	  foobarbaz:
 	EOT
 
-    rune -0 --separate-stderr cscli setup detect --detect-config "$tempfile"
+    rune -0 cscli setup detect --detect-config "$tempfile"
     assert_json '{setup:[{detected_service:"foobarbaz"},{detected_service:"linux",install:{collections:["crowdsecurity/linux"]}}]}'
 
-    rune -0 --separate-stderr cscli setup detect --detect-config "$tempfile" --skip-service linux
+    rune -0 cscli setup detect --detect-config "$tempfile" --skip-service linux
     assert_json '{setup:[{detected_service:"foobarbaz"}]}'
 }
 
 @test "cscli setup detect --force-os-*" {
-    rune -0 --separate-stderr cscli setup detect --force-os-family linux --detect-config "${TESTDATA}/detect.yaml"
+    rune -0 cscli setup detect --force-os-family linux --detect-config "${TESTDATA}/detect.yaml"
     rune -0 jq -cS '.setup[] | select(.detected_service=="linux")' <(output)
     assert_json '{detected_service:"linux",install:{collections:["crowdsecurity/linux"]},datasource:{source:"file",labels:{type:"syslog"},filenames:["/var/log/syslog","/var/log/kern.log","/var/log/messages"]}}'
 
-    rune -0 --separate-stderr cscli setup detect --force-os-family freebsd --detect-config "${TESTDATA}/detect.yaml"
+    rune -0 cscli setup detect --force-os-family freebsd --detect-config "${TESTDATA}/detect.yaml"
     rune -0 jq -cS '.setup[] | select(.detected_service=="freebsd")' <(output)
     assert_json '{detected_service:"freebsd",install:{collections:["crowdsecurity/freebsd"]}}'
 
-    rune -0 --separate-stderr cscli setup detect --force-os-family windows --detect-config "${TESTDATA}/detect.yaml"
+    rune -0 cscli setup detect --force-os-family windows --detect-config "${TESTDATA}/detect.yaml"
     rune -0 jq -cS '.setup[] | select(.detected_service=="windows")' <(output)
     assert_json '{detected_service:"windows",install:{collections:["crowdsecurity/windows"]}}'
 
-    rune -0 --separate-stderr cscli setup detect --force-os-family darwin --detect-config "${TESTDATA}/detect.yaml"
+    rune -0 cscli setup detect --force-os-family darwin --detect-config "${TESTDATA}/detect.yaml"
 
     # XXX do we want do disallow unknown family?
     # assert_stderr --partial "detecting services: OS 'darwin' not supported"
@@ -129,7 +129,7 @@ teardown() {
 	  apache2:
 	EOT
 
-    rune -0 --separate-stderr cscli setup detect --list-supported-services --detect-config "$tempfile"
+    rune -0 cscli setup detect --list-supported-services --detect-config "$tempfile"
     # the service list is sorted
     assert_output - <<-EOT
 	apache2
@@ -141,7 +141,7 @@ teardown() {
 	thisisajoke
 	EOT
 
-    rune -1 --separate-stderr cscli setup detect --list-supported-services --detect-config "$tempfile"
+    rune -1 cscli setup detect --list-supported-services --detect-config "$tempfile"
     assert_stderr --partial "while parsing ${tempfile}: yaml: unmarshal errors:"
 
     rm -f "$tempfile"
@@ -201,7 +201,7 @@ update-notifier-motd.timer              enabled enabled
 20 unit files listed.'
     mock_set_status "$mock" 1 2
 
-    rune -0 --separate-stderr cscli setup detect
+    rune -0 cscli setup detect
     rune -0 jq -c '.setup' <(output)
 
     # If a call to UnitFoundwas part of the expression and it returned true,
@@ -254,7 +254,7 @@ update-notifier-motd.timer              enabled enabled
     mock_set_output "$mock" ""
     mock_set_status "$mock" 1 2
 
-    rune -0 --separate-stderr cscli setup detect --snub-systemd
+    rune -0 cscli setup detect --snub-systemd
 
     # setup must not be 'null', but an empty list
     assert_json '{setup:[]}'
@@ -291,20 +291,20 @@ update-notifier-motd.timer              enabled enabled
 	        type: apache3
 	EOT
 
-    rune -0 --separate-stderr cscli setup detect --force-unit force-apache2
+    rune -0 cscli setup detect --force-unit force-apache2
     rune -0 jq -cS '.setup' <(output)
     assert_json '[{datasource:{source:"file",filename:"dummy.log",labels:{"type":"apache2"}},detected_service:"apache2"}]'
 
-    rune -0 --separate-stderr cscli setup detect --force-unit force-apache2,force-apache3
+    rune -0 cscli setup detect --force-unit force-apache2,force-apache3
     rune -0 jq -cS '.setup' <(output)
     assert_json '[{datasource:{source:"file",filename:"dummy.log",labels:{type:"apache2"}},detected_service:"apache2"},{datasource:{source:"file",filename:"dummy.log",labels:{"type":"apache3"}},detected_service:"apache3"}]'
 
     # force-unit can be specified multiple times, the order does not matter
-    rune -0 --separate-stderr cscli setup detect --force-unit force-apache3 --force-unit force-apache2
+    rune -0 cscli setup detect --force-unit force-apache3 --force-unit force-apache2
     rune -0 jq -cS '.setup' <(output)
     assert_json '[{datasource:{source:"file",filename:"dummy.log",labels:{type:"apache2"}},detected_service:"apache2"},{datasource:{source:"file",filename:"dummy.log",labels:{type:"apache3"}},detected_service:"apache3"}]'
 
-    rune -1 --separate-stderr cscli setup detect --force-unit mock-doesnotexist
+    rune -1 cscli setup detect --force-unit mock-doesnotexist
     assert_stderr --partial "detecting services: unit(s) forced but not supported: [mock-doesnotexist]"
 }
 
@@ -324,7 +324,7 @@ update-notifier-motd.timer              enabled enabled
 	      - ProcessRunning("this-does-not-exist")
 	EOT
 
-    rune -0 --separate-stderr cscli setup detect
+    rune -0 cscli setup detect
     rune -0 jq -cS '.setup' <(output)
     assert_json '[{detected_service:"apache2"}]'
 }
@@ -341,7 +341,7 @@ update-notifier-motd.timer              enabled enabled
 	      - ProcessRunning("this-does-not-exist")
 	EOT
 
-    rune -0 --separate-stderr cscli setup detect --force-process force-apache2
+    rune -0 cscli setup detect --force-process force-apache2
     rune -0 jq -cS '.setup' <(output)
     assert_json '[{detected_service:"apache2"}]'
 }
@@ -360,11 +360,11 @@ update-notifier-motd.timer              enabled enabled
 	        type: apache2
 	EOT
 
-    rune -0 --separate-stderr cscli setup detect --force-unit force-apache2
+    rune -0 cscli setup detect --force-unit force-apache2
     rune -0 jq -cS '.setup' <(output)
     assert_json '[{datasource:{source:"file",filename:"dummy.log",labels:{type:"apache2"}},detected_service:"apache2"}]'
 
-    rune -0 --separate-stderr cscli setup detect --force-unit force-apache2 --yaml
+    rune -0 cscli setup detect --force-unit force-apache2 --yaml
     assert_output - <<-EOT
 	setup:
 	  - detected_service: apache2
@@ -417,7 +417,7 @@ update-notifier-motd.timer              enabled enabled
 	  always:
 	EOT
 
-    rune -0 --separate-stderr cscli setup detect
+    rune -0 cscli setup detect
     assert_json '{setup:[{detected_service:"always"}]}'
     setup=$output
     rune -0 cscli setup datasources /dev/stdin <<<"$setup"
@@ -448,7 +448,7 @@ update-notifier-motd.timer              enabled enabled
 	        - crowdsecurity/apache2
 	EOT
 
-    rune -0 --separate-stderr cscli setup detect --force-process force-apache2,force-foobar
+    rune -0 cscli setup detect --force-process force-apache2,force-foobar
     rune -0 jq -Sc '.setup | sort' <(output)
     assert_json '[{install:{collections:["crowdsecurity/apache2"]},detected_service:"apache2"},{install:{collections:["crowdsecurity/foobar"]},detected_service:"foobar"}]'
 }
@@ -469,7 +469,7 @@ update-notifier-motd.timer              enabled enabled
 	        - /var/log/*http*/*.log
 	EOT
 
-    rune -0 --separate-stderr cscli setup detect --force-process force-foobar
+    rune -0 cscli setup detect --force-process force-foobar
     rune -0 yq -op '.setup | sort_keys(..)' <(output)
     assert_output - <<-EOT
 	0.datasource.filenames.0 = /var/log/apache2/*.log
@@ -479,7 +479,7 @@ update-notifier-motd.timer              enabled enabled
 	0.detected_service = foobar
 	EOT
 
-    rune -1 --separate-stderr cscli setup detect --force-process mock-doesnotexist
+    rune -1 cscli setup detect --force-process mock-doesnotexist
     assert_stderr --partial "detecting services: process(es) forced but not supported: [mock-doesnotexist]"
 }
 
@@ -493,7 +493,7 @@ update-notifier-motd.timer              enabled enabled
                 type: something
 	EOT
 
-    rune -1 --separate-stderr cscli setup detect
+    rune -1 cscli setup detect
     assert_stderr --partial "detecting services: invalid datasource for foobar: source is empty"
 
     # more datasource-specific tests are in detect_test.go
@@ -501,38 +501,38 @@ update-notifier-motd.timer              enabled enabled
 
 @test "cscli setup install-hub (dry run)" {
     # it's not installed
-    rune -0 --separate-stderr cscli collections list -o json
+    rune -0 cscli collections list -o json
     rune -0 jq -r '.collections[].name' <(output)
     refute_line "crowdsecurity/apache2"
 
     # we install it
-    rune -0 --separate-stderr cscli setup install-hub /dev/stdin --dry-run <<< '{"setup":[{"install":{"collections":["crowdsecurity/apache2"]}}]}'
+    rune -0 cscli setup install-hub /dev/stdin --dry-run <<< '{"setup":[{"install":{"collections":["crowdsecurity/apache2"]}}]}'
     assert_output 'dry-run: would install collection crowdsecurity/apache2'
 
     # still not installed
-    rune -0 --separate-stderr cscli collections list -o json
+    rune -0 cscli collections list -o json
     rune -0 jq -r '.collections[].name' <(output)
     refute_line "crowdsecurity/apache2"
 }
 
 @test "cscli setup install-hub (dry run: install multiple collections)" {
     # it's not installed
-    rune -0 --separate-stderr cscli collections list -o json
+    rune -0 cscli collections list -o json
     rune -0 jq -r '.collections[].name' <(output)
     refute_line "crowdsecurity/apache2"
 
     # we install it
-    rune -0 --separate-stderr cscli setup install-hub /dev/stdin --dry-run <<< '{"setup":[{"install":{"collections":["crowdsecurity/apache2"]}}]}'
+    rune -0 cscli setup install-hub /dev/stdin --dry-run <<< '{"setup":[{"install":{"collections":["crowdsecurity/apache2"]}}]}'
     assert_output 'dry-run: would install collection crowdsecurity/apache2'
 
     # still not installed
-    rune -0 --separate-stderr cscli collections list -o json
+    rune -0 cscli collections list -o json
     rune -0 jq -r '.collections[].name' <(output)
     refute_line "crowdsecurity/apache2"
 }
 
 @test "cscli setup install-hub (dry run: install multiple collections, parsers, scenarios, postoverflows)" {
-    rune -0 --separate-stderr cscli setup install-hub /dev/stdin --dry-run <<< '{"setup":[{"install":{"collections":["crowdsecurity/foo","johndoe/bar"],"parsers":["crowdsecurity/fooparser","johndoe/barparser"],"scenarios":["crowdsecurity/fooscenario","johndoe/barscenario"],"postoverflows":["crowdsecurity/foopo","johndoe/barpo"]}}]}'
+    rune -0 cscli setup install-hub /dev/stdin --dry-run <<< '{"setup":[{"install":{"collections":["crowdsecurity/foo","johndoe/bar"],"parsers":["crowdsecurity/fooparser","johndoe/barparser"],"scenarios":["crowdsecurity/fooscenario","johndoe/barscenario"],"postoverflows":["crowdsecurity/foopo","johndoe/barpo"]}}]}'
     assert_line 'dry-run: would install collection crowdsecurity/foo'
     assert_line 'dry-run: would install collection johndoe/bar'
     assert_line 'dry-run: would install parser crowdsecurity/fooparser'
@@ -544,12 +544,12 @@ update-notifier-motd.timer              enabled enabled
 }
 
 @test "cscli setup datasources" {
-    rune -0 --separate-stderr cscli setup datasources --help
+    rune -0 cscli setup datasources --help
     assert_line --partial "--to-dir string   write the configuration to a directory, in multiple files"
 
     # single item
 
-    rune -0 --separate-stderr cscli setup datasources /dev/stdin <<-EOT
+    rune -0 cscli setup datasources /dev/stdin <<-EOT
 	setup:
 	  - datasource:
 	      source: file
@@ -575,7 +575,7 @@ update-notifier-motd.timer              enabled enabled
 
     # multiple items
 
-    rune -0 --separate-stderr cscli setup datasources /dev/stdin <<-EOT
+    rune -0 cscli setup datasources /dev/stdin <<-EOT
 	setup:
 	  - datasource:
 	      labels:
@@ -713,14 +713,14 @@ update-notifier-motd.timer              enabled enabled
 	EOT
 
     # the directory must exist
-    rune -1 --separate-stderr cscli setup datasources /dev/stdin --to-dir /path/does/not/exist <<< '{}'
+    rune -1 cscli setup datasources /dev/stdin --to-dir /path/does/not/exist <<< '{}'
     assert_stderr --partial "directory /path/does/not/exist does not exist"
 
     # of course it must be a directory
 
     touch "${acquisdir}/notadir"
 
-    rune -1 --separate-stderr cscli setup datasources /dev/stdin --to-dir "${acquisdir}/notadir" <<-EOT
+    rune -1 cscli setup datasources /dev/stdin --to-dir "${acquisdir}/notadir" <<-EOT
 	setup:
 	  - detected_service: apache2
 	    datasource:
@@ -735,11 +735,11 @@ update-notifier-motd.timer              enabled enabled
 @test "cscli setup datasources (disclaimer)" {
     disclaimer="This file was automatically generated"
 
-    rune -0 --separate-stderr cscli setup datasources /dev/stdin <<<"setup:"
+    rune -0 cscli setup datasources /dev/stdin <<<"setup:"
     rune -0 yq 'head_comment' <(output)
     assert_output --partial "$disclaimer"
 
-    rune -0 --separate-stderr cscli setup datasources /dev/stdin <<-EOT
+    rune -0 cscli setup datasources /dev/stdin <<-EOT
 	setup:
           - detected_service: something
             datasource:
@@ -768,10 +768,10 @@ update-notifier-motd.timer              enabled enabled
 	        - "SYSLOG_IDENTIFIER=TheWiz"
 	EOT
 
-    rune -0 --separate-stderr cscli setup detect --detect-config "$tempfile" --force-unit thewiz.service
+    rune -0 cscli setup detect --detect-config "$tempfile" --force-unit thewiz.service
     rune -0 jq -cS '.' <(output)
     assert_json '{setup:[{datasource:{source:"journalctl",journalctl_filter:["SYSLOG_IDENTIFIER=TheWiz"],labels:{type:"thewiz"}},detected_service:"thewiz"}]}'
-    rune -0 --separate-stderr cscli setup datasources <(output)
+    rune -0 cscli setup datasources <(output)
     rune -0 yq '. head_comment=""' <(output)
     assert_output - <<-EOT
 	journalctl_filter:
@@ -786,17 +786,17 @@ update-notifier-motd.timer              enabled enabled
 
 @test "cscli setup validate" {
     # an empty file is not enough
-    rune -1 --separate-stderr cscli setup validate /dev/null
+    rune -1 cscli setup validate /dev/null
     assert_output "EOF"
     assert_stderr --partial "invalid setup file"
 
     # this is ok; install nothing
-    rune -0 --separate-stderr cscli setup validate /dev/stdin <<-EOT
+    rune -0 cscli setup validate /dev/stdin <<-EOT
 	setup:
 	EOT
     refute_output
 
-    rune -1 --separate-stderr cscli setup validate /dev/stdin <<-EOT
+    rune -1 cscli setup validate /dev/stdin <<-EOT
 	se tup:
 	EOT
     assert_output - <<-EOT
@@ -806,7 +806,7 @@ update-notifier-motd.timer              enabled enabled
 	EOT
     assert_stderr --partial "invalid setup file"
 
-    rune -1 --separate-stderr cscli setup validate /dev/stdin <<-EOT
+    rune -1 cscli setup validate /dev/stdin <<-EOT
 	setup:
 	alsdk al; sdf
 	EOT

--- a/test/bats/10_bouncers.bats
+++ b/test/bats/10_bouncers.bats
@@ -24,37 +24,35 @@ teardown() {
 #----------
 
 @test "there are 0 bouncers" {
-    run -0 --separate-stderr cscli bouncers list -o json
+    rune -0 cscli bouncers list -o json
     assert_output "[]"
 }
 
 @test "we can add one bouncer, and delete it" {
-    run -0 cscli bouncers add ciTestBouncer
+    rune -0 cscli bouncers add ciTestBouncer
     assert_output --partial "Api key for 'ciTestBouncer':"
-    run -0 cscli bouncers delete ciTestBouncer
-    run -0 --separate-stderr cscli bouncers list -o json
+    rune -0 cscli bouncers delete ciTestBouncer
+    rune -0 cscli bouncers list -o json
     assert_output '[]'
 }
 
 @test "we can't add the same bouncer twice" {
-    run -0 cscli bouncers add ciTestBouncer
-    run -1 --separate-stderr cscli bouncers add ciTestBouncer -o json
+    rune -0 cscli bouncers add ciTestBouncer
+    rune -1 cscli bouncers add ciTestBouncer -o json
 
     # XXX temporary hack to filter out unwanted log lines that may appear before
     # log configuration (= not json)
-    run -0 jq -r '.level' <(stderr | grep "^{")
-    assert_output 'fatal'
-    run -0 jq -r '.msg' <(stderr | grep "^{")
-    assert_output "unable to create bouncer: bouncer ciTestBouncer already exists"
+    rune -0 jq -c '[.level,.msg]' <(stderr | grep "^{")
+    assert_output '["fatal","unable to create bouncer: bouncer ciTestBouncer already exists"]'
 
-    run -0 --separate-stderr cscli bouncers list -o json
-    run -0 jq '. | length' <(output)
+    rune -0 cscli bouncers list -o json
+    rune -0 jq '. | length' <(output)
     assert_output 1
 }
 
 @test "delete the bouncer multiple times, even if it does not exist" {
-    run -0 cscli bouncers add ciTestBouncer
-    run -0 cscli bouncers delete ciTestBouncer
-    run -1 cscli bouncers delete ciTestBouncer
-    run -1 cscli bouncers delete foobarbaz
+    rune -0 cscli bouncers add ciTestBouncer
+    rune -0 cscli bouncers delete ciTestBouncer
+    rune -1 cscli bouncers delete ciTestBouncer
+    rune -1 cscli bouncers delete foobarbaz
 }

--- a/test/bats/11_bouncers_tls.bats
+++ b/test/bats/11_bouncers_tls.bats
@@ -61,37 +61,37 @@ teardown() {
 #----------
 
 @test "there are 0 bouncers" {
-    run -0 --separate-stderr cscli bouncers list -o json
+    rune -0 cscli bouncers list -o json
     assert_output "[]"
 }
 
 @test "simulate one bouncer request with a valid cert" {
-    run -0 curl -s --cert "${tmpdir}/bouncer.pem" --key "${tmpdir}/bouncer-key.pem" --cacert "${tmpdir}/bundle.pem" https://localhost:8080/v1/decisions\?ip=42.42.42.42
+    rune -0 curl -s --cert "${tmpdir}/bouncer.pem" --key "${tmpdir}/bouncer-key.pem" --cacert "${tmpdir}/bundle.pem" https://localhost:8080/v1/decisions\?ip=42.42.42.42
     assert_output "null"
-    run -0 --separate-stderr cscli bouncers list -o json
-    run -0 jq '. | length' <(output)
+    rune -0 cscli bouncers list -o json
+    rune -0 jq '. | length' <(output)
     assert_output '1'
-    run -0 --separate-stderr cscli bouncers list -o json
-    run -0 jq -r '.[] | .name' <(output)
+    rune -0 cscli bouncers list -o json
+    rune -0 jq -r '.[] | .name' <(output)
     assert_output "localhost@127.0.0.1"
-    run cscli bouncers delete localhost@127.0.0.1
+    rune cscli bouncers delete localhost@127.0.0.1
 }
 
 @test "simulate one bouncer request with an invalid cert" {
-    run curl -s --cert "${tmpdir}/bouncer_invalid.pem" --key "${tmpdir}/bouncer_invalid-key.pem" --cacert "${tmpdir}/ca-key.pem" https://localhost:8080/v1/decisions\?ip=42.42.42.42
-    run -0 --separate-stderr cscli bouncers list -o json
+    rune curl -s --cert "${tmpdir}/bouncer_invalid.pem" --key "${tmpdir}/bouncer_invalid-key.pem" --cacert "${tmpdir}/ca-key.pem" https://localhost:8080/v1/decisions\?ip=42.42.42.42
+    rune -0 cscli bouncers list -o json
     assert_output "[]"
 }
 
 @test "simulate one bouncer request with an invalid OU" {
-    run curl -s --cert "${tmpdir}/bouncer_bad_ou.pem" --key "${tmpdir}/bouncer_bad_ou-key.pem" --cacert "${tmpdir}/bundle.pem" https://localhost:8080/v1/decisions\?ip=42.42.42.42
-    run -0 --separate-stderr cscli bouncers list -o json
+    rune curl -s --cert "${tmpdir}/bouncer_bad_ou.pem" --key "${tmpdir}/bouncer_bad_ou-key.pem" --cacert "${tmpdir}/bundle.pem" https://localhost:8080/v1/decisions\?ip=42.42.42.42
+    rune -0 cscli bouncers list -o json
     assert_output "[]"
 }
 
 @test "simulate one bouncer request with a revoked certificate" {
-    run -0 curl -i -s --cert "${tmpdir}/bouncer_revoked.pem" --key "${tmpdir}/bouncer_revoked-key.pem" --cacert "${tmpdir}/bundle.pem" https://localhost:8080/v1/decisions\?ip=42.42.42.42
+    rune -0 curl -i -s --cert "${tmpdir}/bouncer_revoked.pem" --key "${tmpdir}/bouncer_revoked-key.pem" --cacert "${tmpdir}/bundle.pem" https://localhost:8080/v1/decisions\?ip=42.42.42.42
     assert_output --partial "access forbidden"
-    run -0 --separate-stderr cscli bouncers list -o json
+    rune -0 cscli bouncers list -o json
     assert_output "[]"
 }

--- a/test/bats/20_collections.bats
+++ b/test/bats/20_collections.bats
@@ -24,7 +24,7 @@ teardown() {
 #----------
 
 @test "we can list collections" {
-    run -0 cscli collections list
+    rune -0 cscli collections list
 }
 
 @test "there are 2 collections (linux and sshd)" {
@@ -105,7 +105,7 @@ teardown() {
     rune -0 cscli collections remove --all
     assert_stderr --partial "Removed symlink [crowdsecurity/sshd]"
     assert_stderr --partial "Removed symlink [crowdsecurity/linux]"
-    rune -0 --separate-stderr cscli hub list -o json
+    rune -0 cscli hub list -o json
     assert_json '{collections:[],parsers:[],postoverflows:[],scenarios:[]}'
     rune -0 cscli collections remove --all
     assert_stderr --partial 'Disabled 0 items'

--- a/test/bats/30_machines.bats
+++ b/test/bats/30_machines.bats
@@ -24,60 +24,60 @@ teardown() {
 #----------
 
 @test "can list machines as regular user" {
-    run -0 cscli machines list
+    rune -0 cscli machines list
 }
 
 @test "we have exactly one machine" {
-    run -0 --separate-stderr cscli machines list -o json
-    run -0 jq -c '[. | length, .[0].machineId[0:32], .[0].isValidated]' <(output)
+    rune -0 cscli machines list -o json
+    rune -0 jq -c '[. | length, .[0].machineId[0:32], .[0].isValidated]' <(output)
     assert_output '[1,"githubciXXXXXXXXXXXXXXXXXXXXXXXX",true]'
 }
 
 @test "add a new machine and delete it" {
-    run -0 cscli machines add -a -f /dev/null CiTestMachine -o human
-    assert_output --partial "Machine 'CiTestMachine' successfully added to the local API"
-    assert_output --partial "API credentials dumped to '/dev/null'"
+    rune -0 cscli machines add -a -f /dev/null CiTestMachine -o human
+    assert_stderr --partial "Machine 'CiTestMachine' successfully added to the local API"
+    assert_stderr --partial "API credentials dumped to '/dev/null'"
 
     # we now have two machines
-    run -0 --separate-stderr cscli machines list -o json
-    run -0 jq -c '[. | length, .[-1].machineId, .[0].isValidated]' <(output)
+    rune -0 cscli machines list -o json
+    rune -0 jq -c '[. | length, .[-1].machineId, .[0].isValidated]' <(output)
     assert_output '[2,"CiTestMachine",true]'
 
     # delete the test machine
-    run -0 cscli machines delete CiTestMachine -o human
-    assert_output --partial "machine 'CiTestMachine' deleted successfully"
+    rune -0 cscli machines delete CiTestMachine -o human
+    assert_stderr --partial "machine 'CiTestMachine' deleted successfully"
 
     # we now have one machine again
-    run -0 --separate-stderr cscli machines list -o json
-    run -0 jq '. | length' <(output)
+    rune -0 cscli machines list -o json
+    rune -0 jq '. | length' <(output)
     assert_output 1
 }
 
 @test "register, validate and then remove a machine" {
-    run -0 cscli lapi register --machine CiTestMachineRegister -f /dev/null -o human
-    assert_output --partial "Successfully registered to Local API (LAPI)"
-    assert_output --partial "Local API credentials dumped to '/dev/null'"
+    rune -0 cscli lapi register --machine CiTestMachineRegister -f /dev/null -o human
+    assert_stderr --partial "Successfully registered to Local API (LAPI)"
+    assert_stderr --partial "Local API credentials dumped to '/dev/null'"
 
     # the machine is not validated yet
-    run -0 --separate-stderr cscli machines list -o json
-    run -0 jq '.[-1].isValidated' <(output)
+    rune -0 cscli machines list -o json
+    rune -0 jq '.[-1].isValidated' <(output)
     assert_output 'null'
 
     # validate the machine
-    run -0 cscli machines validate CiTestMachineRegister -o human
-    assert_output --partial "machine 'CiTestMachineRegister' validated successfully"
+    rune -0 cscli machines validate CiTestMachineRegister -o human
+    assert_stderr --partial "machine 'CiTestMachineRegister' validated successfully"
 
     # the machine is now validated
-    run -0 --separate-stderr cscli machines list -o json
-    run -0 jq '.[-1].isValidated' <(output)
+    rune -0 cscli machines list -o json
+    rune -0 jq '.[-1].isValidated' <(output)
     assert_output 'true'
 
     # delete the test machine again
-    run -0 cscli machines delete CiTestMachineRegister -o human
-    assert_output --partial "machine 'CiTestMachineRegister' deleted successfully"
+    rune -0 cscli machines delete CiTestMachineRegister -o human
+    assert_stderr --partial "machine 'CiTestMachineRegister' deleted successfully"
 
     # we now have one machine, again
-    run -0 --separate-stderr cscli machines list -o json
-    run -0 jq '. | length' <(output)
+    rune -0 cscli machines list -o json
+    rune -0 jq '. | length' <(output)
     assert_output 1
 }

--- a/test/bats/30_machines_tls.bats
+++ b/test/bats/30_machines_tls.bats
@@ -47,10 +47,8 @@ setup_file() {
 
     # remove all machines
 
-    run -0 cscli machines list -o json
-    run -0 jq -r '.[].machineId' <(output)
-    for machine in $(output); do
-        run -0 cscli machines delete "${machine}"
+    for machine in $(cscli machines list -o json | jq -r '.[].machineId'); do
+        cscli machines delete "${machine}"
     done
 
     config_disable_agent
@@ -69,7 +67,6 @@ setup() {
         .api.server.tls.crl_path=strenv(tmpdir) + "/crl.pem" | 
         .api.server.tls.agents_allowed_ou=["agent-ou"]
     '
-
 }
 
 teardown() {
@@ -102,7 +99,7 @@ teardown() {
 
     config_set "${CONFIG_DIR}/local_api_credentials.yaml" 'del(.login,.password)'
     ./instance-crowdsec start
-    run -0 --separate-stderr cscli machines list -o json
+    rune -0 cscli machines list -o json
     assert_output '[]'
 }
 
@@ -116,9 +113,9 @@ teardown() {
 
     config_set "${CONFIG_DIR}/local_api_credentials.yaml" 'del(.login,.password)'
     ./instance-crowdsec start
-    run -0 cscli lapi status
-    run -0 --separate-stderr cscli machines list -o json
-    run -0 jq -c '[. | length, .[0].machineId[0:32], .[0].isValidated, .[0].ipAddress, .[0].auth_type]' <(output)
+    rune -0 cscli lapi status
+    rune -0 cscli machines list -o json
+    rune -0 jq -c '[. | length, .[0].machineId[0:32], .[0].isValidated, .[0].ipAddress, .[0].auth_type]' <(output)
 
     assert_output '[1,"localhost@127.0.0.1",true,"127.0.0.1","tls"]'
     cscli machines delete localhost@127.0.0.1
@@ -133,7 +130,7 @@ teardown() {
     '
     config_set "${CONFIG_DIR}/local_api_credentials.yaml" 'del(.login,.password)'
     ./instance-crowdsec start
-    run -0 --separate-stderr cscli machines list -o json
+    rune -0 cscli machines list -o json
     assert_output '[]'
 }
 
@@ -147,6 +144,6 @@ teardown() {
 
     config_set "${CONFIG_DIR}/local_api_credentials.yaml" 'del(.login,.password)'
     ./instance-crowdsec start
-    run -0 --separate-stderr cscli machines list -o json
+    rune -0 cscli machines list -o json
     assert_output '[]'
 }

--- a/test/bats/40_live-ban.bats
+++ b/test/bats/40_live-ban.bats
@@ -39,7 +39,7 @@ teardown() {
     fake_log >>"${tmpfile}"
     sleep 2
     rm -f -- "${tmpfile}"
-    run -0 --separate-stderr cscli decisions list -o json
-    run -0 jq -r '.[].decisions[0].value' <(output)
+    rune -0 cscli decisions list -o json
+    rune -0 jq -r '.[].decisions[0].value' <(output)
     assert_output '1.1.1.172'
 }

--- a/test/bats/50_simulation.bats
+++ b/test/bats/50_simulation.bats
@@ -27,40 +27,40 @@ setup() {
 #----------
 
 @test "we have one decision" {
-    run -0 cscli simulation disable --global
+    rune -0 cscli simulation disable --global
     fake_log | "${CROWDSEC}" -dsn file:///dev/fd/0 -type syslog -no-api
-    run -0 --separate-stderr cscli decisions list -o json
-    run -0 jq '. | length' <(output)
+    rune -0 cscli decisions list -o json
+    rune -0 jq '. | length' <(output)
     assert_output 1
 }
 
 @test "1.1.1.174 has been banned (exact)" {
-    run -0 cscli simulation disable --global
+    rune -0 cscli simulation disable --global
     fake_log | "${CROWDSEC}" -dsn file:///dev/fd/0 -type syslog -no-api
-    run -0 --separate-stderr cscli decisions list -o json
-    run -0 jq -r '.[].decisions[0].value' <(output)
+    rune -0 cscli decisions list -o json
+    rune -0 jq -r '.[].decisions[0].value' <(output)
     assert_output '1.1.1.174'
 }
 
 @test "decision has simulated == false (exact)" {
-    run -0 cscli simulation disable --global
+    rune -0 cscli simulation disable --global
     fake_log | "${CROWDSEC}" -dsn file:///dev/fd/0 -type syslog -no-api
-    run -0 --separate-stderr cscli decisions list -o json
-    run -0 jq '.[].decisions[0].simulated' <(output)
+    rune -0 cscli decisions list -o json
+    rune -0 jq '.[].decisions[0].simulated' <(output)
     assert_output 'false'
 }
 
 @test "simulated scenario, listing non-simulated: expect no decision" {
-    run -0 cscli simulation enable crowdsecurity/ssh-bf
+    rune -0 cscli simulation enable crowdsecurity/ssh-bf
     fake_log | "${CROWDSEC}" -dsn file:///dev/fd/0 -type syslog -no-api
-    run -0 --separate-stderr cscli decisions list --no-simu -o json
+    rune -0 cscli decisions list --no-simu -o json
     assert_output 'null'
 }
 
 @test "global simulation, listing non-simulated: expect no decision" {
-    run -0 cscli simulation disable crowdsecurity/ssh-bf
-    run -0 cscli simulation enable --global
+    rune -0 cscli simulation disable crowdsecurity/ssh-bf
+    rune -0 cscli simulation enable --global
     fake_log | "${CROWDSEC}" -dsn file:///dev/fd/0 -type syslog -no-api
-    run -0 --separate-stderr cscli decisions list --no-simu -o json
+    rune -0 cscli decisions list --no-simu -o json
     assert_output 'null'
 }

--- a/test/bats/70_http_plugin.bats
+++ b/test/bats/70_http_plugin.bats
@@ -54,33 +54,33 @@ setup() {
 #----------
 
 @test "add two bans" {
-    run -0 --separate-stderr cscli decisions add --ip 1.2.3.4 --duration 30s
+    rune -0 cscli decisions add --ip 1.2.3.4 --duration 30s
     assert_stderr --partial 'Decision successfully added'
 
-    run -0 --separate-stderr cscli decisions add --ip 1.2.3.5 --duration 30s
+    rune -0 cscli decisions add --ip 1.2.3.5 --duration 30s
     assert_stderr --partial 'Decision successfully added'
     sleep 5
 }
 
 @test "expected 1 log line from http server" {
-    run -0 wc -l <"${MOCK_OUT}"
+    rune -0 wc -l <"${MOCK_OUT}"
     # wc can pad with spaces on some platforms
-    run -0 tr -d ' ' < <(output)
+    rune -0 tr -d ' ' < <(output)
     assert_output 1
 }
 
 @test "expected to receive 2 alerts in the request body from plugin" {
-    run -0 jq -r '.request_body' <"${MOCK_OUT}"
-    run -0 jq -r 'length' <(output)
+    rune -0 jq -r '.request_body' <"${MOCK_OUT}"
+    rune -0 jq -r 'length' <(output)
     assert_output 2
 }
 
 @test "expected to receive IP 1.2.3.4 as value of first decision" {
-    run -0 jq -r '.request_body[0].decisions[0].value' <"${MOCK_OUT}"
+    rune -0 jq -r '.request_body[0].decisions[0].value' <"${MOCK_OUT}"
     assert_output 1.2.3.4
 }
 
 @test "expected to receive IP 1.2.3.5 as value of second decision" {
-    run -0 jq -r '.request_body[1].decisions[0].value' <"${MOCK_OUT}"
+    rune -0 jq -r '.request_body[1].decisions[0].value' <"${MOCK_OUT}"
     assert_output 1.2.3.5
 }

--- a/test/bats/71_dummy_plugin.bats
+++ b/test/bats/71_dummy_plugin.bats
@@ -58,21 +58,21 @@ setup() {
 #----------
 
 @test "add two bans" {
-    run -0 --separate-stderr cscli decisions add --ip 1.2.3.4 --duration 30s
+    rune -0 cscli decisions add --ip 1.2.3.4 --duration 30s
     assert_stderr --partial 'Decision successfully added'
 
-    run -0 --separate-stderr cscli decisions add --ip 1.2.3.5 --duration 30s
+    rune -0 cscli decisions add --ip 1.2.3.5 --duration 30s
     assert_stderr --partial 'Decision successfully added'
     sleep 2
 }
 
 @test "expected 1 notification" {
-    run -0 cat "${tempfile}"
+    rune -0 cat "${tempfile}"
     assert_output --partial 1.2.3.4
     assert_output --partial 1.2.3.5
 }
 
 @test "second notification works too" {
-    run -0 cat "${tempfile2}"
+    rune -0 cat "${tempfile2}"
     assert_output --partial secondfile
 }

--- a/test/bats/72_plugin_badconfig.bats
+++ b/test/bats/72_plugin_badconfig.bats
@@ -35,76 +35,76 @@ teardown() {
 @test "misconfigured plugin, only user is empty" {
     config_set '.plugin_config.user="" | .plugin_config.group="nogroup"'
     config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
-    run -1 --separate-stderr timeout 2s "${CROWDSEC}"
+    rune -1 timeout 2s "${CROWDSEC}"
     assert_stderr --partial "api server init: unable to run local API: while loading plugin: while getting process attributes: both plugin user and group must be set"
 }
 
 @test "misconfigured plugin, only group is empty" {
     config_set '(.plugin_config.user="nobody") | (.plugin_config.group="")'
     config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
-    run -1 --separate-stderr timeout 2s "${CROWDSEC}"
+    rune -1 timeout 2s "${CROWDSEC}"
     assert_stderr --partial "api server init: unable to run local API: while loading plugin: while getting process attributes: both plugin user and group must be set"
 }
 
 @test "misconfigured plugin, user does not exist" {
     config_set '(.plugin_config.user="userdoesnotexist") | (.plugin_config.group="groupdoesnotexist")'
     config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
-    run -1 --separate-stderr timeout 2s "${CROWDSEC}"
+    rune -1 timeout 2s "${CROWDSEC}"
     assert_stderr --partial "api server init: unable to run local API: while loading plugin: while getting process attributes: user: unknown user userdoesnotexist"
 }
 
 @test "misconfigured plugin, group does not exist" {
     config_set '(.plugin_config.user=strenv(USER)) | (.plugin_config.group="groupdoesnotexist")'
     config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
-    run -1 --separate-stderr timeout 2s "${CROWDSEC}"
+    rune -1 timeout 2s "${CROWDSEC}"
     assert_stderr --partial "api server init: unable to run local API: while loading plugin: while getting process attributes: group: unknown group groupdoesnotexist"
 }
 
 @test "bad plugin name" {
     config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
     cp "${PLUGIN_DIR}"/notification-http "${PLUGIN_DIR}"/badname
-    run -1 --separate-stderr timeout 2s "${CROWDSEC}"
+    rune -1 timeout 2s "${CROWDSEC}"
     assert_stderr --partial "api server init: unable to run local API: while loading plugin: plugin name ${PLUGIN_DIR}/badname is invalid. Name should be like {type-name}"
 }
 
 @test "bad plugin permission (group writable)" {
     config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
     chmod g+w "${PLUGIN_DIR}"/notification-http
-    run -1 --separate-stderr timeout 2s "${CROWDSEC}"
+    rune -1 timeout 2s "${CROWDSEC}"
     assert_stderr --partial "api server init: unable to run local API: while loading plugin: plugin at ${PLUGIN_DIR}/notification-http is group writable, group writable plugins are invalid"
 }
 
 @test "bad plugin permission (world writable)" {
     config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
     chmod o+w "${PLUGIN_DIR}"/notification-http
-    run -1 --separate-stderr timeout 2s "${CROWDSEC}"
+    rune -1 timeout 2s "${CROWDSEC}"
     assert_stderr --partial "api server init: unable to run local API: while loading plugin: plugin at ${PLUGIN_DIR}/notification-http is world writable, world writable plugins are invalid"
 }
 
 @test "config.yaml: missing .plugin_config section" {
     config_set 'del(.plugin_config)'
     config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
-    run -1 --separate-stderr timeout 2s "${CROWDSEC}"
+    rune -1 timeout 2s "${CROWDSEC}"
     assert_stderr --partial "api server init: plugins are enabled, but the plugin_config section is missing in the configuration"
 }
 
 @test "config.yaml: missing config_paths.notification_dir" {
     config_set 'del(.config_paths.notification_dir)'
     config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
-    run -1 --separate-stderr timeout 2s "${CROWDSEC}"
+    rune -1 timeout 2s "${CROWDSEC}"
     assert_stderr --partial "api server init: plugins are enabled, but config_paths.notification_dir is not defined"
 }
 
 @test "config.yaml: missing config_paths.plugin_dir" {
     config_set 'del(.config_paths.plugin_dir)'
     config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
-    run -1 --separate-stderr timeout 2s "${CROWDSEC}"
+    rune -1 timeout 2s "${CROWDSEC}"
     assert_stderr --partial "api server init: plugins are enabled, but config_paths.plugin_dir is not defined"
 }
 
 @test "unable to run local API: while reading plugin config" {
     config_set '.config_paths.notification_dir="/this/path/does/not/exist"'
     config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
-    run -1 --separate-stderr timeout 2s "${CROWDSEC}"
+    rune -1 timeout 2s "${CROWDSEC}"
     assert_stderr --partial "api server init: unable to run local API: while loading plugin config: open /this/path/does/not/exist: no such file or directory"
 }

--- a/test/bats/80_alerts.bats
+++ b/test/bats/80_alerts.bats
@@ -25,42 +25,42 @@ teardown() {
 
 @test "cscli alerts list, with and without --machine" {
     is_db_postgres && skip
-    run -0 cscli decisions add -i 10.20.30.40 -t ban
+    rune -0 cscli decisions add -i 10.20.30.40 -t ban
 
-    run -0 cscli alerts list
+    rune -0 cscli alerts list
     refute_output --partial 'machine'
     # machine name appears quoted in the "REASON" column
     assert_output --regexp " 'githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})?' "
     refute_output --regexp " githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})? "
 
-    run -0 cscli alerts list -m
+    rune -0 cscli alerts list -m
     assert_output --partial 'machine'
     assert_output --regexp " 'githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})?' "
     assert_output --regexp " githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})? "
 
-    run -0 cscli alerts list --machine
+    rune -0 cscli alerts list --machine
     assert_output --partial 'machine'
     assert_output --regexp " 'githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})?' "
     assert_output --regexp " githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})? "
 }
 
 @test "cscli alerts list, human/json/raw" {
-    run -0 cscli decisions add -i 10.20.30.40 -t ban
+    rune -0 cscli decisions add -i 10.20.30.40 -t ban
 
-    run -0 cscli alerts list -o human
-    run -0 plaintext < <(output)
+    rune -0 cscli alerts list -o human
+    rune -0 plaintext < <(output)
     assert_output --regexp ".* ID .* value .* reason .* country .* as .* decisions .* created_at .*"
     assert_output --regexp ".*Ip:10.20.30.40.*manual 'ban' from.*ban:1.*"
 
-    run -0 --separate-stderr cscli alerts list -o json
-    run -0 jq -c '.[].decisions[0] | [.origin, .scenario, .scope, .simulated, .type, .value]' <(output)
+    rune -0 cscli alerts list -o json
+    rune -0 jq -c '.[].decisions[0] | [.origin, .scenario, .scope, .simulated, .type, .value]' <(output)
     assert_line --regexp "\[\"cscli\",\"manual 'ban' from 'githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})?'\",\"Ip\",false,\"ban\",\"10.20.30.40\"\]"
 
-    run -0 cscli alerts list -o raw
+    rune -0 cscli alerts list -o raw
     assert_line "id,scope,value,reason,country,as,decisions,created_at"
     assert_line --regexp ".*,Ip,10.20.30.40,manual 'ban' from 'githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})?',,,ban:1,.*"
 
-    run -0 cscli alerts list -o raw --machine
+    rune -0 cscli alerts list -o raw --machine
     assert_line "id,scope,value,reason,country,as,decisions,created_at,machine"
     assert_line --regexp "^[0-9]+,Ip,10.20.30.40,manual 'ban' from 'githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})?',,,ban:1,.*,githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})?$"
 }
@@ -69,14 +69,14 @@ teardown() {
     rune -1 cscli alerts inspect
     assert_stderr --partial 'missing alert_id'
 
-    run -0 cscli decisions add -i 10.20.30.40 -t ban
-    run -0 cscli alerts list -o raw <(output)
-    run -0 grep 10.20.30.40 <(output)
-    run -0 cut -d, -f1 <(output)
+    rune -0 cscli decisions add -i 10.20.30.40 -t ban
+    rune -0 cscli alerts list -o raw <(output)
+    rune -0 grep 10.20.30.40 <(output)
+    rune -0 cut -d, -f1 <(output)
     ALERT_ID="${output}"
 
-    run -0 cscli alerts inspect "${ALERT_ID}" -o human
-    run -0 plaintext < <(output)
+    rune -0 cscli alerts inspect "${ALERT_ID}" -o human
+    rune -0 plaintext < <(output)
     assert_line --regexp '^#+$'
     assert_line --regexp "^ - ID *: ${ALERT_ID}$"
     assert_line --regexp "^ - Date *: .*$"
@@ -93,10 +93,10 @@ teardown() {
     assert_line --regexp "^.* ID .* scope:value .* action .* expiration .* created_at .*$"
     assert_line --regexp "^.* Ip:10.20.30.40 .* ban .*$"
 
-    run -0 cscli alerts inspect "${ALERT_ID}" -o human --details
+    rune -0 cscli alerts inspect "${ALERT_ID}" -o human --details
     # XXX can we have something here?
 
-    run -0 cscli alerts inspect "${ALERT_ID}" -o raw
+    rune -0 cscli alerts inspect "${ALERT_ID}" -o raw
     assert_line --regexp "^ *capacity: 0$"
     assert_line --regexp "^ *id: ${ALERT_ID}$"
     assert_line --regexp "^ *origin: cscli$"
@@ -106,91 +106,91 @@ teardown() {
     assert_line --regexp "^ *type: ban$"
     assert_line --regexp "^ *value: 10.20.30.40$"
 
-    run -0 --separate-stderr cscli alerts inspect "${ALERT_ID}" -o json
+    rune -0 cscli alerts inspect "${ALERT_ID}" -o json
     alert=${output}
-    run jq -c '.decisions[] | [.origin,.scenario,.scope,.simulated,.type,.value]' <<<"${alert}"
+    rune jq -c '.decisions[] | [.origin,.scenario,.scope,.simulated,.type,.value]' <<<"${alert}"
     assert_output --regexp "\[\"cscli\",\"manual 'ban' from 'githubciXXXXXXXXXXXXXXXXXXXXXXXX.*'\",\"Ip\",false,\"ban\",\"10.20.30.40\"\]"
-    run jq -c '.source' <<<"${alert}"
+    rune jq -c '.source' <<<"${alert}"
     assert_json '{ip:"10.20.30.40",scope:"Ip",value:"10.20.30.40"}'
 }
 
 @test "no active alerts" {
-    run -0 --separate-stderr cscli alerts list --until 200d -o human
+    rune -0 cscli alerts list --until 200d -o human
     assert_output "No active alerts"
-    run -0 --separate-stderr cscli alerts list --until 200d -o json
+    rune -0 cscli alerts list --until 200d -o json
     assert_output "null"
-    run -0 --separate-stderr cscli alerts list --until 200d -o raw
+    rune -0 cscli alerts list --until 200d -o raw
     assert_output "id,scope,value,reason,country,as,decisions,created_at"
-    run -0 --separate-stderr cscli alerts list --until 200d -o raw --machine
+    rune -0 cscli alerts list --until 200d -o raw --machine
     assert_output "id,scope,value,reason,country,as,decisions,created_at,machine"
 }
 
 @test "cscli alerts delete (by id)" {
-    run -0 --separate-stderr cscli alerts delete --help
+    rune -0 cscli alerts delete --help
     if [[ ! "$output" =~ "--id string" ]]; then
         skip "cscli alerts delete --id not supported"
     fi
 
     # make sure there is at least one alert
-    run -0 cscli decisions add -i 127.0.0.1 -d 1h -R crowdsecurity/test
+    rune -0 cscli decisions add -i 127.0.0.1 -d 1h -R crowdsecurity/test
     # when testing with global config, alert id is not guaranteed to be 1.
     # we'll just remove the first alert we find
-    run -0 --separate-stderr cscli alerts list -o json
-    run -0 jq -c '.[0].id' <(output)
+    rune -0 cscli alerts list -o json
+    rune -0 jq -c '.[0].id' <(output)
     ALERT_ID="$output"
 
-    run -0 --separate-stderr cscli alerts delete --id "$ALERT_ID"
+    rune -0 cscli alerts delete --id "$ALERT_ID"
     refute_output
     assert_stderr --partial "1 alert(s) deleted"
 
     # can't delete twice
-    run -1 --separate-stderr cscli alerts delete --id "$ALERT_ID"
+    rune -1 cscli alerts delete --id "$ALERT_ID"
     refute_output
     assert_stderr --partial "unable to delete alert"
     assert_stderr --partial "API error: ent: alert not found"
 }
 
 @test "cscli alerts delete (all)" {
-    run -0 --separate-stderr cscli alerts delete --all
+    rune -0 cscli alerts delete --all
     assert_stderr --partial '0 alert(s) deleted'
 
-    run -0 cscli decisions add -i 1.2.3.4 -d 1h -R crowdsecurity/test
-    run -0 cscli decisions add -i 1.2.3.5 -d 1h -R crowdsecurity/test
+    rune -0 cscli decisions add -i 1.2.3.4 -d 1h -R crowdsecurity/test
+    rune -0 cscli decisions add -i 1.2.3.5 -d 1h -R crowdsecurity/test
 
-    run -0 --separate-stderr cscli alerts delete --all
+    rune -0 cscli alerts delete --all
     assert_stderr --partial '2 alert(s) deleted'
 
     # XXX TODO: delete by scope, value, scenario, range..
 }
 
 @test "cscli alerts delete (with cascade to decisions)" {
-    run -0 cscli decisions add -i 1.2.3.4
-    run -0 --separate-stderr cscli decisions list -o json
-    run -0 jq '. | length' <(output)
+    rune -0 cscli decisions add -i 1.2.3.4
+    rune -0 cscli decisions list -o json
+    rune -0 jq '. | length' <(output)
     assert_output 1
 
-    run -0 --separate-stderr cscli alerts delete -i 1.2.3.4
+    rune -0 cscli alerts delete -i 1.2.3.4
     assert_stderr --partial 'alert(s) deleted'
-    run -0 --separate-stderr cscli decisions list -o json
+    rune -0 cscli decisions list -o json
     assert_output null
 }
 
 @test "cscli alerts delete (must ignore the query limit)" {
     for i in $(seq 1 200); do
-        run -0 cscli decisions add -i 1.2.3.4
+        rune -0 cscli decisions add -i 1.2.3.4
     done
-    run -0 --separate-stderr cscli alerts delete -i 1.2.3.4
+    rune -0 cscli alerts delete -i 1.2.3.4
     assert_stderr --partial '200 alert(s) deleted'
 }
 
 @test "bad duration" {
     skip 'TODO'
-    run -0 cscli decisions add -i 10.20.30.40 -t ban
-    run -9 --separate-stderr cscli decisions list --ip 10.20.30.40 -o json
-    run -9 jq -r '.[].decisions[].id' <(output)
+    rune -0 cscli decisions add -i 10.20.30.40 -t ban
+    rune -9 cscli decisions list --ip 10.20.30.40 -o json
+    rune -9 jq -r '.[].decisions[].id' <(output)
     DECISION_ID="${output}"
 
     ./instance-crowdsec stop
-    run -0 ./instance-db exec_sql "UPDATE decisions SET ... WHERE id=${DECISION_ID}"
+    rune -0 ./instance-db exec_sql "UPDATE decisions SET ... WHERE id=${DECISION_ID}"
     ./instance-crowdsec start
 }

--- a/test/bats/90_decisions.bats
+++ b/test/bats/90_decisions.bats
@@ -21,47 +21,43 @@ teardown() {
     ./instance-crowdsec stop
 }
 
-declare stderr
-
 #----------
 
 @test "'decisions add' requires parameters" {
-    run -1 --separate-stderr cscli decisions add
+    rune -1 cscli decisions add
     assert_line "Usage:"
     assert_stderr --partial "Missing arguments, a value is required (--ip, --range or --scope and --value)"
 
-    run -1 --separate-stderr cscli decisions add -o json
-    run echo "${stderr}"
-    run -0 jq -c '[ .level, .msg]' <(output | grep "^{")
+    rune -1 cscli decisions add -o json
+    rune -0 jq -c '[ .level, .msg]' <(stderr | grep "^{")
     assert_output '["fatal","Missing arguments, a value is required (--ip, --range or --scope and --value)"]'
 }
 
 @test "cscli decisions list, with and without --machine" {
     is_db_postgres && skip
-    run -0 cscli decisions add -i 10.20.30.40 -t ban
+    rune -0 cscli decisions add -i 10.20.30.40 -t ban
 
-    run -0 cscli decisions list
+    rune -0 cscli decisions list
     refute_output --partial 'Machine'
     # machine name appears quoted in the "REASON" column
     assert_output --regexp " 'githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})?' "
     refute_output --regexp " githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})? "
 
-    run -0 cscli decisions list -m
+    rune -0 cscli decisions list -m
     assert_output --partial 'Machine'
     assert_output --regexp " 'githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})?' "
     assert_output --regexp " githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})? "
 
-    run -0 cscli decisions list --machine
+    rune -0 cscli decisions list --machine
     assert_output --partial 'Machine'
     assert_output --regexp " 'githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})?' "
     assert_output --regexp " githubciXXXXXXXXXXXXXXXXXXXXXXXX([a-zA-Z0-9]{16})? "
 }
 
 @test "cscli decisions list, incorrect parameters" {
-    run -1 --separate-stderr cscli decisions list --until toto
+    rune -1 cscli decisions list --until toto
     assert_stderr --partial 'Unable to list decisions : performing request: API error: while parsing duration: time: invalid duration \"toto\"'
-    run -1 --separate-stderr cscli decisions list --until toto -o json
-    run echo "${stderr}"
-    run -0 jq -c '[.level, .msg]' <(output | grep "^{")
+    rune -1 cscli decisions list --until toto -o json
+    rune -0 jq -c '[.level, .msg]' <(stderr | grep "^{")
     assert_output '["fatal","Unable to list decisions : performing request: API error: while parsing duration: time: invalid duration \"toto\""]'
 }

--- a/test/bats/97_ipv4_single.bats
+++ b/test/bats/97_ipv4_single.bats
@@ -31,77 +31,77 @@ api() {
 
 @test "cli - first decisions list: must be empty" {
     # delete community pull
-    run -0 cscli decisions delete --all
-    run -0 --separate-stderr cscli decisions list -o json
+    rune -0 cscli decisions delete --all
+    rune -0 cscli decisions list -o json
     assert_output 'null'
 }
 
 @test "API - first decisions list: must be empty" {
-    run -0 --separate-stderr api '/v1/decisions'
+    rune -0 api '/v1/decisions'
     assert_output 'null'
 }
 
 @test "adding decision for 1.2.3.4" {
-    run -0 --separate-stderr cscli decisions add -i '1.2.3.4'
+    rune -0 cscli decisions add -i '1.2.3.4'
     assert_stderr --partial 'Decision successfully added'
 }
 
 @test "CLI - all decisions" {
-    run -0 --separate-stderr cscli decisions list -o json
-    run -0 jq -r '.[0].decisions[0].value' <(output)
+    rune -0 cscli decisions list -o json
+    rune -0 jq -r '.[0].decisions[0].value' <(output)
     assert_output '1.2.3.4'
 }
 
 @test "API - all decisions" {
-    run -0 --separate-stderr api '/v1/decisions'
-    run -0 jq -c '[ . | length, .[0].value ]' <(output)
+    rune -0 api '/v1/decisions'
+    rune -0 jq -c '[ . | length, .[0].value ]' <(output)
     assert_output '[1,"1.2.3.4"]'
 }
 
 # check ip match
 
 @test "CLI - decision for 1.2.3.4" {
-    run -0 --separate-stderr cscli decisions list -i '1.2.3.4' -o json
-    run -0 jq -r '.[0].decisions[0].value' <(output)
+    rune -0 cscli decisions list -i '1.2.3.4' -o json
+    rune -0 jq -r '.[0].decisions[0].value' <(output)
     assert_output '1.2.3.4'
 }
 
 @test "API - decision for 1.2.3.4" {
-    run -0 --separate-stderr api '/v1/decisions?ip=1.2.3.4'
-    run -0 jq -r '.[0].value' <(output)
+    rune -0 api '/v1/decisions?ip=1.2.3.4'
+    rune -0 jq -r '.[0].value' <(output)
     assert_output '1.2.3.4'
 }
 
 @test "CLI - decision for 1.2.3.5" {
-    run -0 --separate-stderr cscli decisions list -i '1.2.3.5' -o json
+    rune -0 cscli decisions list -i '1.2.3.5' -o json
     assert_output 'null'
 }
 
 @test "API - decision for 1.2.3.5" {
-    run -0 --separate-stderr api '/v1/decisions?ip=1.2.3.5'
+    rune -0 api '/v1/decisions?ip=1.2.3.5'
     assert_output 'null'
 }
 
 ## check outer range match
 
 @test "CLI - decision for 1.2.3.0/24" {
-    run -0 --separate-stderr cscli decisions list -r '1.2.3.0/24' -o json
+    rune -0 cscli decisions list -r '1.2.3.0/24' -o json
     assert_output 'null'
 }
 
 @test "API - decision for 1.2.3.0/24" {
-    run -0 --separate-stderr api '/v1/decisions?range=1.2.3.0/24'
+    rune -0 api '/v1/decisions?range=1.2.3.0/24'
     assert_output 'null'
 }
 
 @test "CLI - decisions where IP in 1.2.3.0/24" {
-    run -0 --separate-stderr cscli decisions list -r '1.2.3.0/24' --contained -o json
-    run -0 jq -r '.[0].decisions[0].value' <(output)
+    rune -0 cscli decisions list -r '1.2.3.0/24' --contained -o json
+    rune -0 jq -r '.[0].decisions[0].value' <(output)
     assert_output '1.2.3.4'
 }
 
 @test "API - decisions where IP in 1.2.3.0/24" {
-    run -0 --separate-stderr api '/v1/decisions?range=1.2.3.0/24&contains=false'
-    run -0 jq -r '.[0].value' <(output)
+    rune -0 api '/v1/decisions?range=1.2.3.0/24&contains=false'
+    rune -0 jq -r '.[0].value' <(output)
     assert_output '1.2.3.4'
 }

--- a/test/bats/97_ipv6_single.bats
+++ b/test/bats/97_ipv6_single.bats
@@ -31,125 +31,125 @@ api() {
 
 @test "cli - first decisions list: must be empty" {
     # delete community pull
-    run -0 cscli decisions delete --all
-    run -0 --separate-stderr cscli decisions list -o json
+    rune -0 cscli decisions delete --all
+    rune -0 cscli decisions list -o json
     assert_output 'null'
 }
 
 @test "adding decision for ip 1111:2222:3333:4444:5555:6666:7777:8888" {
-    run -0 --separate-stderr cscli decisions add -i '1111:2222:3333:4444:5555:6666:7777:8888'
+    rune -0 cscli decisions add -i '1111:2222:3333:4444:5555:6666:7777:8888'
     assert_stderr --partial 'Decision successfully added'
 }
 
 @test "CLI - all decisions" {
-    run -0 --separate-stderr cscli decisions list -o json
-    run -0 jq -r '.[].decisions[0].value' <(output)
+    rune -0 cscli decisions list -o json
+    rune -0 jq -r '.[].decisions[0].value' <(output)
     assert_output '1111:2222:3333:4444:5555:6666:7777:8888'
 }
 
 @test "API - all decisions" {
-    run -0 --separate-stderr api "/v1/decisions"
-    run -0 jq -r '.[].value' <(output)
+    rune -0 api "/v1/decisions"
+    rune -0 jq -r '.[].value' <(output)
     assert_output '1111:2222:3333:4444:5555:6666:7777:8888'
 }
 
 @test "CLI - decisions for ip 1111:2222:3333:4444:5555:6666:7777:8888" {
-    run -0 --separate-stderr cscli decisions list -i '1111:2222:3333:4444:5555:6666:7777:8888' -o json
-    run -0 jq -r '.[].decisions[0].value' <(output)
+    rune -0 cscli decisions list -i '1111:2222:3333:4444:5555:6666:7777:8888' -o json
+    rune -0 jq -r '.[].decisions[0].value' <(output)
     assert_output '1111:2222:3333:4444:5555:6666:7777:8888'
 }
 
 @test "API - decisions for ip 1111:2222:3333:4444:5555:6666:7777:888" {
-    run -0 --separate-stderr api '/v1/decisions?ip=1111:2222:3333:4444:5555:6666:7777:8888'
-    run -0 jq -r '.[].value' <(output)
+    rune -0 api '/v1/decisions?ip=1111:2222:3333:4444:5555:6666:7777:8888'
+    rune -0 jq -r '.[].value' <(output)
     assert_output '1111:2222:3333:4444:5555:6666:7777:8888'
 }
 
 @test "CLI - decisions for ip 1211:2222:3333:4444:5555:6666:7777:8888" {
-    run -0 --separate-stderr cscli decisions list -i '1211:2222:3333:4444:5555:6666:7777:8888' -o json
+    rune -0 cscli decisions list -i '1211:2222:3333:4444:5555:6666:7777:8888' -o json
     assert_output 'null'
 }
 
 @test "API - decisions for ip 1211:2222:3333:4444:5555:6666:7777:888" {
-    run -0 --separate-stderr api '/v1/decisions?ip=1211:2222:3333:4444:5555:6666:7777:8888'
+    rune -0 api '/v1/decisions?ip=1211:2222:3333:4444:5555:6666:7777:8888'
     assert_output 'null'
 }
 
 @test "CLI - decisions for ip 1111:2222:3333:4444:5555:6666:7777:8887" {
-    run -0 --separate-stderr cscli decisions list -i '1111:2222:3333:4444:5555:6666:7777:8887' -o json
+    rune -0 cscli decisions list -i '1111:2222:3333:4444:5555:6666:7777:8887' -o json
     assert_output 'null'
 }
 
 @test "API - decisions for ip 1111:2222:3333:4444:5555:6666:7777:8887" {
-    run -0 --separate-stderr api '/v1/decisions?ip=1111:2222:3333:4444:5555:6666:7777:8887'
+    rune -0 api '/v1/decisions?ip=1111:2222:3333:4444:5555:6666:7777:8887'
     assert_output 'null'
 }
 
 @test "CLI - decisions for range 1111:2222:3333:4444:5555:6666:7777:8888/48" {
-    run -0 --separate-stderr cscli decisions list -r '1111:2222:3333:4444:5555:6666:7777:8888/48' -o json
+    rune -0 cscli decisions list -r '1111:2222:3333:4444:5555:6666:7777:8888/48' -o json
     assert_output 'null'
 }
 
 @test "API - decisions for range 1111:2222:3333:4444:5555:6666:7777:8888/48" {
-    run -0 --separate-stderr api '/v1/decisions?range=1111:2222:3333:4444:5555:6666:7777:8888/48'
+    rune -0 api '/v1/decisions?range=1111:2222:3333:4444:5555:6666:7777:8888/48'
     assert_output 'null'
 }
 
 @test "CLI - decisions for ip/range in 1111:2222:3333:4444:5555:6666:7777:8888/48" {
-    run -0 --separate-stderr cscli decisions list -r '1111:2222:3333:4444:5555:6666:7777:8888/48' --contained -o json
-    run -0 jq -r '.[].decisions[0].value' <(output)
+    rune -0 cscli decisions list -r '1111:2222:3333:4444:5555:6666:7777:8888/48' --contained -o json
+    rune -0 jq -r '.[].decisions[0].value' <(output)
     assert_output '1111:2222:3333:4444:5555:6666:7777:8888'
 }
 
 @test "API - decisions for ip/range in 1111:2222:3333:4444:5555:6666:7777:8888/48" {
-    run -0 --separate-stderr api '/v1/decisions?range=1111:2222:3333:4444:5555:6666:7777:8888/48&&contains=false'
-    run -0 jq -r '.[].value' <(output)
+    rune -0 api '/v1/decisions?range=1111:2222:3333:4444:5555:6666:7777:8888/48&&contains=false'
+    rune -0 jq -r '.[].value' <(output)
     assert_output '1111:2222:3333:4444:5555:6666:7777:8888'
 }
 
 @test "CLI - decisions for range 1111:2222:3333:4444:5555:6666:7777:8888/64" {
-    run -0 --separate-stderr cscli decisions list -r '1111:2222:3333:4444:5555:6666:7777:8888/64' -o json
+    rune -0 cscli decisions list -r '1111:2222:3333:4444:5555:6666:7777:8888/64' -o json
     assert_output 'null'
 }
 
 @test "API - decisions for range 1111:2222:3333:4444:5555:6666:7777:8888/64" {
-    run -0 --separate-stderr api '/v1/decisions?range=1111:2222:3333:4444:5555:6666:7777:8888/64'
+    rune -0 api '/v1/decisions?range=1111:2222:3333:4444:5555:6666:7777:8888/64'
     assert_output 'null'
 }
 
 @test "CLI - decisions for ip/range in 1111:2222:3333:4444:5555:6666:7777:8888/64" {
-    run -0 --separate-stderr cscli decisions list -r '1111:2222:3333:4444:5555:6666:7777:8888/64' -o json --contained
-    run -0 jq -r '.[].decisions[0].value' <(output)
+    rune -0 cscli decisions list -r '1111:2222:3333:4444:5555:6666:7777:8888/64' -o json --contained
+    rune -0 jq -r '.[].decisions[0].value' <(output)
     assert_output '1111:2222:3333:4444:5555:6666:7777:8888'
 }
 
 @test "API - decisions for ip/range in 1111:2222:3333:4444:5555:6666:7777:8888/64" {
-    run -0 --separate-stderr api '/v1/decisions?range=1111:2222:3333:4444:5555:6666:7777:8888/64&&contains=false'
-    run -0 jq -r '.[].value' <(output)
+    rune -0 api '/v1/decisions?range=1111:2222:3333:4444:5555:6666:7777:8888/64&&contains=false'
+    rune -0 jq -r '.[].value' <(output)
     assert_output '1111:2222:3333:4444:5555:6666:7777:8888'
 }
 
 @test "adding decision for ip 1111:2222:3333:4444:5555:6666:7777:8889" {
-    run -0 --separate-stderr cscli decisions add -i '1111:2222:3333:4444:5555:6666:7777:8889'
+    rune -0 cscli decisions add -i '1111:2222:3333:4444:5555:6666:7777:8889'
     assert_stderr --partial 'Decision successfully added'
 }
 
 @test "deleting decision for ip 1111:2222:3333:4444:5555:6666:7777:8889" {
-    run -0 --separate-stderr cscli decisions delete -i '1111:2222:3333:4444:5555:6666:7777:8889'
+    rune -0 cscli decisions delete -i '1111:2222:3333:4444:5555:6666:7777:8889'
     assert_stderr --partial '1 decision(s) deleted'
 }
 
 @test "CLI - decisions for ip 1111:2222:3333:4444:5555:6666:7777:8889 after delete" {
-    run -0 --separate-stderr cscli decisions list -i '1111:2222:3333:4444:5555:6666:7777:8889' -o json
+    rune -0 cscli decisions list -i '1111:2222:3333:4444:5555:6666:7777:8889' -o json
     assert_output 'null'
 }
 
 @test "deleting decision for range 1111:2222:3333:4444:5555:6666:7777:8888/64" {
-    run -0 --separate-stderr cscli decisions delete -r '1111:2222:3333:4444:5555:6666:7777:8888/64' --contained
+    rune -0 cscli decisions delete -r '1111:2222:3333:4444:5555:6666:7777:8888/64' --contained
     assert_stderr --partial '1 decision(s) deleted'
 }
 
 @test "CLI - decisions for ip/range in 1111:2222:3333:4444:5555:6666:7777:8888/64 after delete" {
-    run -0 --separate-stderr cscli decisions list -r '1111:2222:3333:4444:5555:6666:7777:8888/64' -o json --contained
+    rune -0 cscli decisions list -r '1111:2222:3333:4444:5555:6666:7777:8888/64' -o json --contained
     assert_output 'null'
 }

--- a/test/bats/98_ipv4_range.bats
+++ b/test/bats/98_ipv4_range.bats
@@ -31,104 +31,104 @@ api() {
 
 @test "cli - first decisions list: must be empty" {
     # delete community pull
-    run -0 cscli decisions delete --all
-    run -0 --separate-stderr cscli decisions list -o json
+    rune -0 cscli decisions delete --all
+    rune -0 cscli decisions list -o json
     assert_output 'null'
 }
 
 @test "adding decision for range 4.4.4.0/24" {
-    run -0 --separate-stderr cscli decisions add -r '4.4.4.0/24'
+    rune -0 cscli decisions add -r '4.4.4.0/24'
     assert_stderr --partial 'Decision successfully added'
 }
 
 @test "CLI - all decisions" {
-    run -0 --separate-stderr cscli decisions list -o json
-    run -0 jq -r '.[0].decisions[0].value' <(output)
+    rune -0 cscli decisions list -o json
+    rune -0 jq -r '.[0].decisions[0].value' <(output)
     assert_output '4.4.4.0/24'
 }
 
 @test "API - all decisions" {
-    run -0 --separate-stderr api '/v1/decisions'
-    run -0 jq -r '.[0].value' <(output)
+    rune -0 api '/v1/decisions'
+    rune -0 jq -r '.[0].value' <(output)
     assert_output '4.4.4.0/24'
 }
 
 # check ip within/outside of range
 
 @test "CLI - decisions for ip 4.4.4." {
-    run -0 --separate-stderr cscli decisions list -i '4.4.4.3' -o json
-    run -0 jq -r '.[0].decisions[0].value' <(output)
+    rune -0 cscli decisions list -i '4.4.4.3' -o json
+    rune -0 jq -r '.[0].decisions[0].value' <(output)
     assert_output '4.4.4.0/24'
 }
 
 @test "API - decisions for ip 4.4.4." {
-    run -0 --separate-stderr api '/v1/decisions?ip=4.4.4.3'
-    run -0 jq -r '.[0].value' <(output)
+    rune -0 api '/v1/decisions?ip=4.4.4.3'
+    rune -0 jq -r '.[0].value' <(output)
     assert_output '4.4.4.0/24'
 }
 
 @test "CLI - decisions for ip contained in 4.4.4." {
-    run -0 --separate-stderr cscli decisions list -i '4.4.4.4' -o json --contained
+    rune -0 cscli decisions list -i '4.4.4.4' -o json --contained
     assert_output 'null'
 }
 
 @test "API - decisions for ip contained in 4.4.4." {
-    run -0 --separate-stderr api '/v1/decisions?ip=4.4.4.4&contains=false'
+    rune -0 api '/v1/decisions?ip=4.4.4.4&contains=false'
     assert_output 'null'
 }
 
 @test "CLI - decisions for ip 5.4.4." {
-    run -0 --separate-stderr cscli decisions list -i '5.4.4.3' -o json
+    rune -0 cscli decisions list -i '5.4.4.3' -o json
     assert_output 'null'
 }
 
 @test "API - decisions for ip 5.4.4." {
-    run -0 --separate-stderr api '/v1/decisions?ip=5.4.4.3'
+    rune -0 api '/v1/decisions?ip=5.4.4.3'
     assert_output 'null'
 }
 
 @test "CLI - decisions for range 4.4.0.0/1" {
-    run -0 --separate-stderr cscli decisions list -r '4.4.0.0/16' -o json
+    rune -0 cscli decisions list -r '4.4.0.0/16' -o json
     assert_output 'null'
 }
 
 @test "API - decisions for range 4.4.0.0/1" {
-    run -0 --separate-stderr api '/v1/decisions?range=4.4.0.0/16'
+    rune -0 api '/v1/decisions?range=4.4.0.0/16'
     assert_output 'null'
 }
 
 @test "CLI - decisions for ip/range in 4.4.0.0/1" {
-    run -0 --separate-stderr cscli decisions list -r '4.4.0.0/16' -o json --contained
-    run -0 jq -r '.[0].decisions[0].value' <(output)
+    rune -0 cscli decisions list -r '4.4.0.0/16' -o json --contained
+    rune -0 jq -r '.[0].decisions[0].value' <(output)
     assert_output '4.4.4.0/24'
 }
 
 @test "API - decisions for ip/range in 4.4.0.0/1" {
-    run -0 --separate-stderr api '/v1/decisions?range=4.4.0.0/16&contains=false'
-    run -0 jq -r '.[0].value' <(output)
+    rune -0 api '/v1/decisions?range=4.4.0.0/16&contains=false'
+    rune -0 jq -r '.[0].value' <(output)
     assert_output '4.4.4.0/24'
 }
 
 # check subrange
 
 @test "CLI - decisions for range 4.4.4.2/2" {
-    run -0 --separate-stderr cscli decisions list -r '4.4.4.2/28' -o json
-    run -0 jq -r '.[].decisions[0].value' <(output)
+    rune -0 cscli decisions list -r '4.4.4.2/28' -o json
+    rune -0 jq -r '.[].decisions[0].value' <(output)
     assert_output '4.4.4.0/24'
 }
 
 @test "API - decisions for range 4.4.4.2/2" {
-    run -0 --separate-stderr api '/v1/decisions?range=4.4.4.2/28'
-    run -0 jq -r '.[].value' <(output)
+    rune -0 api '/v1/decisions?range=4.4.4.2/28'
+    rune -0 jq -r '.[].value' <(output)
     assert_output '4.4.4.0/24'
 }
 
 @test "CLI - decisions for range 4.4.3.2/2" {
-    run -0 --separate-stderr cscli decisions list -r '4.4.3.2/28' -o json
+    rune -0 cscli decisions list -r '4.4.3.2/28' -o json
     assert_output 'null'
 }
 
 @test "API - decisions for range 4.4.3.2/2" {
-    run -0 --separate-stderr api '/v1/decisions?range=4.4.3.2/28'
+    rune -0 api '/v1/decisions?range=4.4.3.2/28'
     assert_output 'null'
 }

--- a/test/bats/98_ipv6_range.bats
+++ b/test/bats/98_ipv6_range.bats
@@ -31,187 +31,187 @@ api() {
 
 @test "cli - first decisions list: must be empty" {
     # delete community pull
-    run -0 cscli decisions delete --all
-    run -0 --separate-stderr cscli decisions list -o json
+    rune -0 cscli decisions delete --all
+    rune -0 cscli decisions list -o json
     assert_output 'null'
 }
 
 @test "adding decision for range aaaa:2222:3333:4444::/64" {
-    run -0 --separate-stderr cscli decisions add -r 'aaaa:2222:3333:4444::/64'
+    rune -0 cscli decisions add -r 'aaaa:2222:3333:4444::/64'
     assert_stderr --partial 'Decision successfully added'
 }
 
 @test "CLI - all decisions (2)" {
-    run -0 --separate-stderr cscli decisions list -o json
-    run -0 jq -r '.[].decisions[0].value' <(output)
+    rune -0 cscli decisions list -o json
+    rune -0 jq -r '.[].decisions[0].value' <(output)
     assert_output 'aaaa:2222:3333:4444::/64'
 }
 
 @test "API - all decisions (2)" {
-    run -0 --separate-stderr api '/v1/decisions'
-    run -0 jq -r '.[].value' <(output)
+    rune -0 api '/v1/decisions'
+    rune -0 jq -r '.[].value' <(output)
     assert_output 'aaaa:2222:3333:4444::/64'
 }
 
 # check ip within/out of range
 
 @test "CLI - decisions for ip aaaa:2222:3333:4444:5555:6666:7777:8888" {
-    run -0 --separate-stderr cscli decisions list -i 'aaaa:2222:3333:4444:5555:6666:7777:8888' -o json
-    run -0 jq -r '.[].decisions[0].value' <(output)
+    rune -0 cscli decisions list -i 'aaaa:2222:3333:4444:5555:6666:7777:8888' -o json
+    rune -0 jq -r '.[].decisions[0].value' <(output)
     assert_output 'aaaa:2222:3333:4444::/64'
 }
 
 @test "API - decisions for ip aaaa:2222:3333:4444:5555:6666:7777:8888" {
-    run -0 --separate-stderr api '/v1/decisions?ip=aaaa:2222:3333:4444:5555:6666:7777:8888'
-    run -0 jq -r '.[].value' <(output)
+    rune -0 api '/v1/decisions?ip=aaaa:2222:3333:4444:5555:6666:7777:8888'
+    rune -0 jq -r '.[].value' <(output)
     assert_output 'aaaa:2222:3333:4444::/64'
 }
 
 @test "CLI - decisions for ip aaaa:2222:3333:4445:5555:6666:7777:8888" {
-    run -0 --separate-stderr cscli decisions list -i 'aaaa:2222:3333:4445:5555:6666:7777:8888' -o json
+    rune -0 cscli decisions list -i 'aaaa:2222:3333:4445:5555:6666:7777:8888' -o json
     assert_output 'null'
 }
 
 @test "API - decisions for ip aaaa:2222:3333:4445:5555:6666:7777:8888" {
-    run -0 --separate-stderr api '/v1/decisions?ip=aaaa:2222:3333:4445:5555:6666:7777:8888'
+    rune -0 api '/v1/decisions?ip=aaaa:2222:3333:4445:5555:6666:7777:8888'
     assert_output 'null'
 }
 
 @test "CLI - decisions for ip aaa1:2222:3333:4444:5555:6666:7777:8887" {
-    run -0 --separate-stderr cscli decisions list -i 'aaa1:2222:3333:4444:5555:6666:7777:8887' -o json
+    rune -0 cscli decisions list -i 'aaa1:2222:3333:4444:5555:6666:7777:8887' -o json
     assert_output 'null'
 }
 
 @test "API - decisions for ip aaa1:2222:3333:4444:5555:6666:7777:8887" {
-    run -0 --separate-stderr api '/v1/decisions?ip=aaa1:2222:3333:4444:5555:6666:7777:8887'
+    rune -0 api '/v1/decisions?ip=aaa1:2222:3333:4444:5555:6666:7777:8887'
     assert_output 'null'
 }
 
 # check subrange within/out of range
 
 @test "CLI - decisions for range aaaa:2222:3333:4444:5555::/80" {
-    run -0 --separate-stderr cscli decisions list -r 'aaaa:2222:3333:4444:5555::/80' -o json
-    run -0 jq -r '.[].decisions[0].value' <(output)
+    rune -0 cscli decisions list -r 'aaaa:2222:3333:4444:5555::/80' -o json
+    rune -0 jq -r '.[].decisions[0].value' <(output)
     assert_output 'aaaa:2222:3333:4444::/64'
 }
 
 @test "API - decisions for range aaaa:2222:3333:4444:5555::/80" {
-    run -0 --separate-stderr api '/v1/decisions?range=aaaa:2222:3333:4444:5555::/80'
-    run -0 jq -r '.[].value' <(output)
+    rune -0 api '/v1/decisions?range=aaaa:2222:3333:4444:5555::/80'
+    rune -0 jq -r '.[].value' <(output)
     assert_output 'aaaa:2222:3333:4444::/64'
 }
 
 @test "CLI - decisions for range aaaa:2222:3333:4441:5555::/80" {
-    run -0 --separate-stderr cscli decisions list -r 'aaaa:2222:3333:4441:5555::/80' -o json
+    rune -0 cscli decisions list -r 'aaaa:2222:3333:4441:5555::/80' -o json
     assert_output 'null'
 
 }
 
 @test "API - decisions for range aaaa:2222:3333:4441:5555::/80" {
-    run -0 --separate-stderr api '/v1/decisions?range=aaaa:2222:3333:4441:5555::/80'
+    rune -0 api '/v1/decisions?range=aaaa:2222:3333:4441:5555::/80'
     assert_output 'null'
 }
 
 @test "CLI - decisions for range aaa1:2222:3333:4444:5555::/80" {
-    run -0 --separate-stderr cscli decisions list -r 'aaa1:2222:3333:4444:5555::/80' -o json
+    rune -0 cscli decisions list -r 'aaa1:2222:3333:4444:5555::/80' -o json
     assert_output 'null'
 }
 
 @test "API - decisions for range aaa1:2222:3333:4444:5555::/80" {
-    run -0 --separate-stderr api '/v1/decisions?range=aaa1:2222:3333:4444:5555::/80'
+    rune -0 api '/v1/decisions?range=aaa1:2222:3333:4444:5555::/80'
     assert_output 'null'
 }
 
 # check outer range
 
 @test "CLI - decisions for range aaaa:2222:3333:4444:5555:6666:7777:8888/48" {
-    run -0 --separate-stderr cscli decisions list -r 'aaaa:2222:3333:4444:5555:6666:7777:8888/48' -o json
+    rune -0 cscli decisions list -r 'aaaa:2222:3333:4444:5555:6666:7777:8888/48' -o json
     assert_output 'null'
 }
 
 @test "API - decisions for range aaaa:2222:3333:4444:5555:6666:7777:8888/48" {
-    run -0 --separate-stderr api '/v1/decisions?range=aaaa:2222:3333:4444:5555:6666:7777:8888/48'
+    rune -0 api '/v1/decisions?range=aaaa:2222:3333:4444:5555:6666:7777:8888/48'
     assert_output 'null'
 }
 
 @test "CLI - decisions for ip/range in aaaa:2222:3333:4444:5555:6666:7777:8888/48" {
-    run -0 --separate-stderr cscli decisions list -r 'aaaa:2222:3333:4444:5555:6666:7777:8888/48' -o json --contained
-    run -0 jq -r '.[].decisions[0].value' <(output)
+    rune -0 cscli decisions list -r 'aaaa:2222:3333:4444:5555:6666:7777:8888/48' -o json --contained
+    rune -0 jq -r '.[].decisions[0].value' <(output)
     assert_output 'aaaa:2222:3333:4444::/64'
 }
 
 @test "API - decisions for ip/range in aaaa:2222:3333:4444:5555:6666:7777:8888/48" {
-    run -0 --separate-stderr api '/v1/decisions?range=aaaa:2222:3333:4444:5555:6666:7777:8888/48&contains=false'
-    run -0 jq -r '.[].value' <(output)
+    rune -0 api '/v1/decisions?range=aaaa:2222:3333:4444:5555:6666:7777:8888/48&contains=false'
+    rune -0 jq -r '.[].value' <(output)
     assert_output 'aaaa:2222:3333:4444::/64'
 }
 
 @test "CLI - decisions for ip/range in aaaa:2222:3333:4445:5555:6666:7777:8888/48" {
-    run -0 --separate-stderr cscli decisions list -r 'aaaa:2222:3333:4445:5555:6666:7777:8888/48' -o json
+    rune -0 cscli decisions list -r 'aaaa:2222:3333:4445:5555:6666:7777:8888/48' -o json
     assert_output 'null'
 }
 
 @test "API - decisions for ip/range in aaaa:2222:3333:4445:5555:6666:7777:8888/48" {
-    run -0 --separate-stderr api '/v1/decisions?range=aaaa:2222:3333:4445:5555:6666:7777:8888/48'
+    rune -0 api '/v1/decisions?range=aaaa:2222:3333:4445:5555:6666:7777:8888/48'
     assert_output 'null'
 }
 
 # bbbb:db8:: -> bbbb:db8:0000:0000:0000:7fff:ffff:ffff
 
 @test "adding decision for range bbbb:db8::/81" {
-    run -0 --separate-stderr cscli decisions add -r 'bbbb:db8::/81'
+    rune -0 cscli decisions add -r 'bbbb:db8::/81'
     assert_stderr --partial 'Decision successfully added'
 }
 
 @test "CLI - decisions for ip bbbb:db8:0000:0000:0000:6fff:ffff:ffff" {
-    run -0 --separate-stderr cscli decisions list -o json -i 'bbbb:db8:0000:0000:0000:6fff:ffff:ffff'
-    run -0 jq -r '.[].decisions[0].value' <(output)
+    rune -0 cscli decisions list -o json -i 'bbbb:db8:0000:0000:0000:6fff:ffff:ffff'
+    rune -0 jq -r '.[].decisions[0].value' <(output)
     assert_output 'bbbb:db8::/81'
 }
 
 @test "API - decisions for ip in bbbb:db8:0000:0000:0000:6fff:ffff:ffff" {
-    run -0 --separate-stderr api '/v1/decisions?ip=bbbb:db8:0000:0000:0000:6fff:ffff:ffff'
-    run -0 jq -r '.[].value' <(output)
+    rune -0 api '/v1/decisions?ip=bbbb:db8:0000:0000:0000:6fff:ffff:ffff'
+    rune -0 jq -r '.[].value' <(output)
     assert_output 'bbbb:db8::/81'
 }
 
 @test "CLI - decisions for ip bbbb:db8:0000:0000:0000:8fff:ffff:ffff" {
-    run -0 --separate-stderr cscli decisions list -o json -i 'bbbb:db8:0000:0000:0000:8fff:ffff:ffff'
+    rune -0 cscli decisions list -o json -i 'bbbb:db8:0000:0000:0000:8fff:ffff:ffff'
     assert_output 'null'
 }
 
 @test "API - decisions for ip in bbbb:db8:0000:0000:0000:8fff:ffff:ffff" {
-    run -0 --separate-stderr api '/v1/decisions?ip=bbbb:db8:0000:0000:0000:8fff:ffff:ffff'
+    rune -0 api '/v1/decisions?ip=bbbb:db8:0000:0000:0000:8fff:ffff:ffff'
     assert_output 'null'
 }
 
 @test "deleting decision for range aaaa:2222:3333:4444:5555:6666:7777:8888/48" {
-    run -0 --separate-stderr cscli decisions delete -r 'aaaa:2222:3333:4444:5555:6666:7777:8888/48' --contained
+    rune -0 cscli decisions delete -r 'aaaa:2222:3333:4444:5555:6666:7777:8888/48' --contained
     assert_stderr --partial '1 decision(s) deleted'
 }
 
 @test "CLI - decisions for range aaaa:2222:3333:4444::/64 after delete" {
-    run -0 --separate-stderr cscli decisions list -o json -r 'aaaa:2222:3333:4444::/64'
+    rune -0 cscli decisions list -o json -r 'aaaa:2222:3333:4444::/64'
     assert_output 'null'
 }
 
 @test "adding decision for ip bbbb:db8:0000:0000:0000:8fff:ffff:ffff" {
-    run -0 --separate-stderr cscli decisions add -i 'bbbb:db8:0000:0000:0000:8fff:ffff:ffff'
+    rune -0 cscli decisions add -i 'bbbb:db8:0000:0000:0000:8fff:ffff:ffff'
     assert_stderr --partial 'Decision successfully added'
 }
 
 @test "adding decision for ip bbbb:db8:0000:0000:0000:6fff:ffff:ffff" {
-    run -0 --separate-stderr cscli decisions add -i 'bbbb:db8:0000:0000:0000:6fff:ffff:ffff'
+    rune -0 cscli decisions add -i 'bbbb:db8:0000:0000:0000:6fff:ffff:ffff'
     assert_stderr --partial 'Decision successfully added'
 }
 
 @test "deleting decisions for range bbbb:db8::/81" {
-    run -0 --separate-stderr cscli decisions delete -r 'bbbb:db8::/81' --contained
+    rune -0 cscli decisions delete -r 'bbbb:db8::/81' --contained
     assert_stderr --partial '2 decision(s) deleted'
 }
 
 @test "CLI - all decisions (3)" {
-    run -0 --separate-stderr cscli decisions list -o json
-    run -0 jq -r '.[].decisions[0].value' <(output)
+    rune -0 cscli decisions list -o json
+    rune -0 jq -r '.[].decisions[0].value' <(output)
     assert_output 'bbbb:db8:0000:0000:0000:8fff:ffff:ffff'
 }

--- a/test/bats/99_lapi-stream-mode-scenario.bats
+++ b/test/bats/99_lapi-stream-mode-scenario.bats
@@ -36,34 +36,34 @@ output_new_decisions() {
 
 @test "adding decisions with different duration, scenario, origin" {
     # origin: test
-    run -0 cscli decisions add -i 127.0.0.1 -d 1h -R crowdsecurity/test
+    rune -0 cscli decisions add -i 127.0.0.1 -d 1h -R crowdsecurity/test
     ./instance-crowdsec stop
-    run -0 ./instance-db exec_sql "update decisions set origin='test' where origin='cscli'"
+    rune -0 ./instance-db exec_sql "update decisions set origin='test' where origin='cscli'"
     ./instance-crowdsec start
 
-    run -0 cscli decisions add -i 127.0.0.1 -d 3h -R crowdsecurity/ssh_bf
+    rune -0 cscli decisions add -i 127.0.0.1 -d 3h -R crowdsecurity/ssh_bf
     ./instance-crowdsec stop
-    run -0 ./instance-db exec_sql "update decisions set origin='another_origin' where origin='cscli'"
+    rune -0 ./instance-db exec_sql "update decisions set origin='another_origin' where origin='cscli'"
     ./instance-crowdsec start
 
-    run -0 cscli decisions add -i 127.0.0.1 -d 5h -R crowdsecurity/longest
-    run -0 cscli decisions add -i 127.0.0.2 -d 3h -R crowdsecurity/test
-    run -0 cscli decisions add -i 127.0.0.2 -d 3h -R crowdsecurity/ssh_bf
-    run -0 cscli decisions add -i 127.0.0.2 -d 1h -R crowdsecurity/ssh_bf
+    rune -0 cscli decisions add -i 127.0.0.1 -d 5h -R crowdsecurity/longest
+    rune -0 cscli decisions add -i 127.0.0.2 -d 3h -R crowdsecurity/test
+    rune -0 cscli decisions add -i 127.0.0.2 -d 3h -R crowdsecurity/ssh_bf
+    rune -0 cscli decisions add -i 127.0.0.2 -d 1h -R crowdsecurity/ssh_bf
     ./instance-crowdsec stop
-    run -0 ./instance-db exec_sql "update decisions set origin='test' where origin='cscli'"
+    rune -0 ./instance-db exec_sql "update decisions set origin='test' where origin='cscli'"
     ./instance-crowdsec start
 
     # origin: another_origin
-    run -0 cscli decisions add -i 127.0.0.2 -d 2h -R crowdsecurity/test
+    rune -0 cscli decisions add -i 127.0.0.2 -d 2h -R crowdsecurity/test
     ./instance-crowdsec stop
-    run -0 ./instance-db exec_sql "update decisions set origin='another_origin' where origin='cscli'"
+    rune -0 ./instance-db exec_sql "update decisions set origin='another_origin' where origin='cscli'"
     ./instance-crowdsec start
 }
 
 @test "test startup" {
-    run -0 api "/v1/decisions/stream?startup=true"
-    run -0 output_new_decisions
+    rune -0 api "/v1/decisions/stream?startup=true"
+    rune -0 output_new_decisions
     assert_output - <<-EOT
 	{"duration":"2h59m","origin":"test","scenario":"crowdsecurity/test","scope":"Ip","type":"ban","value":"127.0.0.2"}
 	{"duration":"4h59m","origin":"test","scenario":"crowdsecurity/longest","scope":"Ip","type":"ban","value":"127.0.0.1"}
@@ -71,8 +71,8 @@ output_new_decisions() {
 }
 
 @test "test startup with scenarios containing" {
-    run -0 api "/v1/decisions/stream?startup=true&scenarios_containing=ssh_bf"
-    run -0 output_new_decisions
+    rune -0 api "/v1/decisions/stream?startup=true&scenarios_containing=ssh_bf"
+    rune -0 output_new_decisions
     assert_output - <<-EOT
 	{"duration":"2h59m","origin":"another_origin","scenario":"crowdsecurity/ssh_bf","scope":"Ip","type":"ban","value":"127.0.0.1"}
 	{"duration":"2h59m","origin":"test","scenario":"crowdsecurity/ssh_bf","scope":"Ip","type":"ban","value":"127.0.0.2"}
@@ -80,8 +80,8 @@ output_new_decisions() {
 }
 
 @test "test startup with multiple scenarios containing" {
-    run -0 api "/v1/decisions/stream?startup=true&scenarios_containing=ssh_bf,test"
-    run -0 output_new_decisions
+    rune -0 api "/v1/decisions/stream?startup=true&scenarios_containing=ssh_bf,test"
+    rune -0 output_new_decisions
     assert_output - <<-EOT
 	{"duration":"2h59m","origin":"another_origin","scenario":"crowdsecurity/ssh_bf","scope":"Ip","type":"ban","value":"127.0.0.1"}
 	{"duration":"2h59m","origin":"test","scenario":"crowdsecurity/test","scope":"Ip","type":"ban","value":"127.0.0.2"}
@@ -89,13 +89,13 @@ output_new_decisions() {
 }
 
 @test "test startup with unknown scenarios containing" {
-    run -0 api "/v1/decisions/stream?startup=true&scenarios_containing=unknown"
+    rune -0 api "/v1/decisions/stream?startup=true&scenarios_containing=unknown"
     assert_output '{"deleted":null,"new":null}'
 }
 
 @test "test startup with scenarios containing and not containing" {
-    run -0 api "/v1/decisions/stream?startup=true&scenarios_containing=test&scenarios_not_containing=ssh_bf"
-    run -0 output_new_decisions
+    rune -0 api "/v1/decisions/stream?startup=true&scenarios_containing=test&scenarios_not_containing=ssh_bf"
+    rune -0 output_new_decisions
     assert_output - <<-EOT
 	{"duration":"2h59m","origin":"test","scenario":"crowdsecurity/test","scope":"Ip","type":"ban","value":"127.0.0.2"}
 	{"origin":"test","scenario":"crowdsecurity/test","scope":"Ip","type":"ban","value":"127.0.0.1"}
@@ -103,16 +103,16 @@ output_new_decisions() {
 }
 
 @test "test startup with scenarios containing and not containing 2" {
-    run -0 api "/v1/decisions/stream?startup=true&scenarios_containing=longest&scenarios_not_containing=ssh_bf,test"
-    run -0 output_new_decisions
+    rune -0 api "/v1/decisions/stream?startup=true&scenarios_containing=longest&scenarios_not_containing=ssh_bf,test"
+    rune -0 output_new_decisions
     assert_output - <<-EOT
 	{"duration":"4h59m","origin":"test","scenario":"crowdsecurity/longest","scope":"Ip","type":"ban","value":"127.0.0.1"}
 	EOT
 }
 
 @test "test startup with scenarios not containing" {
-    run -0 api "/v1/decisions/stream?startup=true&scenarios_not_containing=ssh_bf"
-    run -0 output_new_decisions
+    rune -0 api "/v1/decisions/stream?startup=true&scenarios_not_containing=ssh_bf"
+    rune -0 output_new_decisions
     assert_output - <<-EOT
 	{"duration":"2h59m","origin":"test","scenario":"crowdsecurity/test","scope":"Ip","type":"ban","value":"127.0.0.2"}
 	{"duration":"4h59m","origin":"test","scenario":"crowdsecurity/longest","scope":"Ip","type":"ban","value":"127.0.0.1"}
@@ -120,16 +120,16 @@ output_new_decisions() {
 }
 
 @test "test startup with multiple scenarios not containing" {
-    run -0 api "/v1/decisions/stream?startup=true&scenarios_not_containing=ssh_bf,test"
-    run -0 output_new_decisions
+    rune -0 api "/v1/decisions/stream?startup=true&scenarios_not_containing=ssh_bf,test"
+    rune -0 output_new_decisions
     assert_output - <<-EOT
 	{"duration":"4h59m","origin":"test","scenario":"crowdsecurity/longest","scope":"Ip","type":"ban","value":"127.0.0.1"}
 	EOT
 }
 
 @test "test startup with origins parameter" {
-    run -0 api "/v1/decisions/stream?startup=true&origins=another_origin"
-    run -0 output_new_decisions
+    rune -0 api "/v1/decisions/stream?startup=true&origins=another_origin"
+    rune -0 output_new_decisions
     assert_output - <<-EOT
 	{"duration":"1h59m","origin":"another_origin","scenario":"crowdsecurity/test","scope":"Ip","type":"ban","value":"127.0.0.2"}
 	{"duration":"2h59m","origin":"another_origin","scenario":"crowdsecurity/ssh_bf","scope":"Ip","type":"ban","value":"127.0.0.1"}
@@ -137,8 +137,8 @@ output_new_decisions() {
 }
 
 @test "test startup with multiple origins parameter" {
-    run -0 api "/v1/decisions/stream?startup=true&origins=another_origin,test"
-    run -0 output_new_decisions
+    rune -0 api "/v1/decisions/stream?startup=true&origins=another_origin,test"
+    rune -0 output_new_decisions
     assert_output - <<-EOT
 	{"duration":"2h59m","origin":"test","scenario":"crowdsecurity/test","scope":"Ip","type":"ban","value":"127.0.0.2"}
 	{"duration":"4h59m","origin":"test","scenario":"crowdsecurity/longest","scope":"Ip","type":"ban","value":"127.0.0.1"}
@@ -146,7 +146,7 @@ output_new_decisions() {
 }
 
 @test "test startup with unknown origins" {
-    run -0 api "/v1/decisions/stream?startup=true&origins=unknown"
+    rune -0 api "/v1/decisions/stream?startup=true&origins=unknown"
     assert_output '{"deleted":null,"new":null}'
 }
 

--- a/test/bats/99_lapi-stream-mode-scopes.bats
+++ b/test/bats/99_lapi-stream-mode-scopes.bats
@@ -29,36 +29,36 @@ api() {
 }
 
 @test "adding decisions for multiple scopes" {
-    run -0 --separate-stderr cscli decisions add -i '1.2.3.6'
+    rune -0 cscli decisions add -i '1.2.3.6'
     assert_stderr --partial 'Decision successfully added'
-    run -0 --separate-stderr cscli decisions add --scope user --value toto
+    rune -0 cscli decisions add --scope user --value toto
     assert_stderr --partial 'Decision successfully added'
 }
 
 @test "stream start (implicit ip scope)" {
-    run -0 api "/v1/decisions/stream?startup=true"
-    run -0 jq -r '.new' <(output)
+    rune -0 api "/v1/decisions/stream?startup=true"
+    rune -0 jq -r '.new' <(output)
     assert_output --partial '1.2.3.6'
     refute_output --partial 'toto'
 }
 
 @test "stream start (explicit ip scope)" {
-    run -0 api "/v1/decisions/stream?startup=true&scopes=ip"
-    run -0 jq -r '.new' <(output)
+    rune -0 api "/v1/decisions/stream?startup=true&scopes=ip"
+    rune -0 jq -r '.new' <(output)
     assert_output --partial '1.2.3.6'
     refute_output --partial 'toto'
 }
 
 @test "stream start (user scope)" {
-    run -0 api "/v1/decisions/stream?startup=true&scopes=user"
-    run -0 jq -r '.new' <(output)
+    rune -0 api "/v1/decisions/stream?startup=true&scopes=user"
+    rune -0 jq -r '.new' <(output)
     refute_output --partial '1.2.3.6'
     assert_output --partial 'toto'
 }
 
 @test "stream start (user+ip scope)" {
-    run -0 api "/v1/decisions/stream?startup=true&scopes=user,ip"
-    run -0 jq -r '.new' <(output)
+    rune -0 api "/v1/decisions/stream?startup=true&scopes=user,ip"
+    rune -0 jq -r '.new' <(output)
     assert_output --partial '1.2.3.6'
     assert_output --partial 'toto'
 }

--- a/test/bats/99_lapi-stream-mode.bats
+++ b/test/bats/99_lapi-stream-mode.bats
@@ -29,44 +29,46 @@ api() {
 }
 
 @test "adding decisions for multiple ips" {
-    run -0 cscli decisions add -i '1111:2222:3333:4444:5555:6666:7777:8888'
-    run -0 cscli decisions add -i '1.2.3.4'
-    run -0 --separate-stderr cscli decisions add -r '1.2.4.0/24'
+    rune -0 cscli decisions add -i '1111:2222:3333:4444:5555:6666:7777:8888'
+    assert_stderr --partial 'Decision successfully added'
+    rune -0 cscli decisions add -i '1.2.3.4'
+    assert_stderr --partial 'Decision successfully added'
+    rune -0 cscli decisions add -r '1.2.4.0/24'
     assert_stderr --partial 'Decision successfully added'
 }
 
 @test "stream start" {
-    run -0 --separate-stderr api "/v1/decisions/stream?startup=true"
+    rune -0 api "/v1/decisions/stream?startup=true"
     if is_db_mysql; then sleep 3; fi
-    run -0 jq -r '.new' <(output)
+    rune -0 jq -r '.new' <(output)
     assert_output --partial '1111:2222:3333:4444:5555:6666:7777:8888'
     assert_output --partial '1.2.3.4'
     assert_output --partial '1.2.4.0/24'
 }
 
 @test "stream cont (add)" {
-    run -0 cscli decisions add -i '1.2.3.5'
+    rune -0 cscli decisions add -i '1.2.3.5'
     if is_db_mysql; then sleep 3; fi
-    run -0 --separate-stderr api "/v1/decisions/stream"
-    run -0 jq -r '.new' <(output)
+    rune -0 api "/v1/decisions/stream"
+    rune -0 jq -r '.new' <(output)
     assert_output --partial '1.2.3.5'
 }
 
 @test "stream cont (del)" {
-    run -0 cscli decisions delete -i '1.2.3.4'
+    rune -0 cscli decisions delete -i '1.2.3.4'
     if is_db_mysql; then sleep 3; fi
-    run -0 --separate-stderr api "/v1/decisions/stream"
-    run -0 jq -r '.deleted' <(output)
+    rune -0 api "/v1/decisions/stream"
+    rune -0 jq -r '.deleted' <(output)
     assert_output --partial '1.2.3.4'
 }
 
 @test "stream restart" {
-    run -0 --separate-stderr api "/v1/decisions/stream?startup=true"
+    rune -0 api "/v1/decisions/stream?startup=true"
     api_out=${output}
-    run -0 jq -r '.deleted' <(output)
+    rune -0 jq -r '.deleted' <(output)
     assert_output --partial '1.2.3.4'
     output=${api_out}
-    run -0 jq -r '.new' <(output)
+    rune -0 jq -r '.new' <(output)
     assert_output --partial '1111:2222:3333:4444:5555:6666:7777:8888'
     assert_output --partial '1.2.3.5'
     assert_output --partial '1.2.4.0/24'


### PR DESCRIPTION
Replace all calls to "run" with "run --separate-stderr" to consistently check for stdout/stderr. Using a function makes the code more compact.