### PR TITLE
CI: add tests for metrics configuration

### DIFF
--- a/pkg/csconfig/prometheus.go
+++ b/pkg/csconfig/prometheus.go
@@ -2,7 +2,6 @@ package csconfig
 
 import "fmt"
 
-/**/
 type PrometheusCfg struct {
 	Enabled    bool   `yaml:"enabled"`
 	Level      string `yaml:"level"` //aggregated|full
@@ -16,6 +15,5 @@ func (c *Config) LoadPrometheus() error {
 			c.Cscli.PrometheusUrl = fmt.Sprintf("http://%s:%d", c.Prometheus.ListenAddr, c.Prometheus.ListenPort)
 		}
 	}
-
 	return nil
 }

--- a/pkg/csconfig/prometheus_test.go
+++ b/pkg/csconfig/prometheus_test.go
@@ -1,20 +1,19 @@
 package csconfig
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/crowdsecurity/go-cs-lib/pkg/cstest"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadPrometheus(t *testing.T) {
-
 	tests := []struct {
-		name           string
-		Input          *Config
-		expectedResult string
-		err            string
+		name        string
+		Input       *Config
+		expectedURL string
+		expectedErr string
 	}{
 		{
 			name: "basic valid configuration",
@@ -27,29 +26,17 @@ func TestLoadPrometheus(t *testing.T) {
 				},
 				Cscli: &CscliCfg{},
 			},
-			expectedResult: "http://127.0.0.1:6060",
+			expectedURL: "http://127.0.0.1:6060",
 		},
 	}
 
-	for idx, test := range tests {
-		err := test.Input.LoadPrometheus()
-		if err == nil && test.err != "" {
-			fmt.Printf("TEST '%s': NOK\n", test.name)
-			t.Fatalf("%d/%d expected error, didn't get it", idx, len(tests))
-		} else if test.err != "" {
-			if !strings.HasPrefix(fmt.Sprintf("%s", err), test.err) {
-				fmt.Printf("TEST '%s': NOK\n", test.name)
-				t.Fatalf("%d/%d expected '%s' got '%s'", idx, len(tests),
-					test.err,
-					fmt.Sprintf("%s", err))
-			}
-		}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.Input.LoadPrometheus()
+			cstest.RequireErrorContains(t, err, tc.expectedErr)
 
-		isOk := assert.Equal(t, test.expectedResult, test.Input.Cscli.PrometheusUrl)
-		if !isOk {
-			t.Fatalf("test '%s' failed\n", test.name)
-		} else {
-			fmt.Printf("TEST '%s': OK\n", test.name)
-		}
+			require.Equal(t, tc.expectedURL, tc.Input.Cscli.PrometheusUrl)
+		})
 	}
 }

--- a/test/bats/01_cscli.bats
+++ b/test/bats/01_cscli.bats
@@ -228,7 +228,6 @@ teardown() {
     assert_output --partial "Route"
     assert_output --partial '/v1/watchers/login'
     assert_output --partial "Local Api Metrics:"
-
 }
 
 @test "'cscli completion' with or without configuration file" {

--- a/test/bats/08_metrics.bats
+++ b/test/bats/08_metrics.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# vim: ft=bats:list:ts=8:sts=4:sw=4:et:ai:si:
+
+set -u
+
+setup_file() {
+    load "../lib/setup_file.sh"
+}
+
+teardown_file() {
+    load "../lib/teardown_file.sh"
+}
+
+setup() {
+    load "../lib/setup.sh"
+    ./instance-data load
+}
+
+teardown() {
+    ./instance-crowdsec stop
+}
+
+#----------
+
+@test "cscli metrics (crowdsec not running)" {
+    rune -1 cscli metrics
+    # crowdsec is down
+    assert_stderr --partial "failed to fetch prometheus metrics"
+    assert_stderr --partial "connect: connection refused"
+}
+
+@test "cscli metrics (bad configuration)" {
+    config_set '.prometheus.foo="bar"'
+    rune -1 cscli metrics
+    assert_stderr --partial "field foo not found in type csconfig.PrometheusCfg"
+}
+
+@test "cscli metrics (.prometheus.enabled=false)" {
+    config_set '.prometheus.enabled=false'
+    rune -1 cscli metrics
+    assert_stderr --partial "prometheus is not enabled, can't show metrics"
+}
+
+@test "cscli metrics (missing listen_addr)" {
+    config_set 'del(.prometheus.listen_addr)'
+    rune -1 cscli metrics
+    assert_stderr --partial "no prometheus url, please specify"
+}
+
+@test "cscli metrics (missing listen_port)" {
+    config_set 'del(.prometheus.listen_addr)'
+    rune -1 cscli metrics
+    assert_stderr --partial "no prometheus url, please specify"
+}
+
+@test "cscli metrics (missing prometheus section)" {
+    config_set 'del(.prometheus)'
+    rune -1 cscli metrics
+    assert_stderr --partial "prometheus section missing, can't show metrics"
+}


### PR DESCRIPTION
Also fix the case where the prometheus section is missing and `cscli metrics` causes a segfault.