### PR TITLE
don't pre-create log files (not required anymore)

### DIFF
--- a/pkg/types/utils.go
+++ b/pkg/types/utils.go
@@ -40,19 +40,9 @@ func SetDefaultLoggerConfig(cfgMode string, cfgFolder string, cfgLevel log.Level
 		if compress != nil {
 			_compress = *compress
 		}
-		/*cf. https://github.com/natefinch/lumberjack/issues/82
-		let's create the file beforehand w/ the right perms */
-		fname := cfgFolder + "/crowdsec.log"
-		// check if file exists
-		_, err := os.Stat(fname)
-		// create file if not exists, purposefully ignore errors
-		if os.IsNotExist(err) {
-			file, _ := os.OpenFile(fname, os.O_RDWR|os.O_CREATE, 0600)
-			file.Close()
-		}
 
 		LogOutput = &lumberjack.Logger{
-			Filename:   fname,
+			Filename:   filepath.Join(cfgFolder, "crowdsec.log"),
 			MaxSize:    _maxsize,
 			MaxBackups: _maxfiles,
 			MaxAge:     _maxage,


### PR DESCRIPTION
The lumberjack package fixed the issue in https://github.com/natefinch/lumberjack/pull/83 (tested with umask 002) and this code is now redundant since we updated the dependency to v2.2.1.