### PR TITLE
Move grok_pattern.go away from pkg/types to reduce bouncer dependencies

### DIFF
--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -24,7 +24,6 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/exprhelpers"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/crowdsecurity/crowdsec/pkg/parser"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 var LAPIURLPrefix string = "v1"
@@ -440,7 +439,7 @@ cscli lapi context delete --value evt.Line.Src
 	return cmdContext
 }
 
-func detectStaticField(GrokStatics []types.ExtraField) []string {
+func detectStaticField(GrokStatics []parser.ExtraField) []string {
 	ret := make([]string, 0)
 	for _, static := range GrokStatics {
 		if static.Parsed != "" {

--- a/pkg/hubtest/hubtest_item.go
+++ b/pkg/hubtest/hubtest_item.go
@@ -10,7 +10,6 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	"github.com/crowdsecurity/crowdsec/pkg/parser"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
@@ -23,7 +22,7 @@ type HubTestItemConfig struct {
 	LogType         string             `yaml:"log_type"`
 	Labels          map[string]string  `yaml:"labels"`
 	IgnoreParsers   bool               `yaml:"ignore_parsers"`   // if we test a scenario, we don't want to assert on Parser
-	OverrideStatics []types.ExtraField `yaml:"override_statics"` //Allow to override statics. Executed before s00
+	OverrideStatics []parser.ExtraField `yaml:"override_statics"` //Allow to override statics. Executed before s00
 }
 
 type HubIndex struct {

--- a/pkg/parser/grok_pattern.go
+++ b/pkg/parser/grok_pattern.go
@@ -1,4 +1,4 @@
-package types
+package parser
 
 import (
 	"time"

--- a/pkg/parser/node.go
+++ b/pkg/parser/node.go
@@ -56,11 +56,11 @@ type Node struct {
 	SubGroks yaml.MapSlice `yaml:"pattern_syntax,omitempty"`
 
 	//Holds a grok pattern
-	Grok types.GrokPattern `yaml:"grok,omitempty"`
+	Grok GrokPattern `yaml:"grok,omitempty"`
 	//Statics can be present in any type of node and is executed last
-	Statics []types.ExtraField `yaml:"statics,omitempty"`
+	Statics []ExtraField `yaml:"statics,omitempty"`
 	//Stash allows to capture data from the log line and store it in an accessible cache
-	Stash []types.DataCapture `yaml:"stash,omitempty"`
+	Stash []DataCapture `yaml:"stash,omitempty"`
 	//Whitelists
 	Whitelist Whitelist           `yaml:"whitelist,omitempty"`
 	Data      []*types.DataSource `yaml:"data,omitempty"`

--- a/pkg/parser/node_test.go
+++ b/pkg/parser/node_test.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"testing"
 
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -20,7 +19,7 @@ func TestParserConfigs(t *testing.T) {
 		Valid    bool
 	}{
 		//valid node with grok pattern
-		{&Node{Debug: true, Stage: "s00", Grok: types.GrokPattern{RegexpValue: "^x%{DATA:extr}$", TargetField: "t"}}, true, true},
+		{&Node{Debug: true, Stage: "s00", Grok: GrokPattern{RegexpValue: "^x%{DATA:extr}$", TargetField: "t"}}, true, true},
 		//bad filter
 		{&Node{Debug: true, Stage: "s00", Filter: "ratata"}, false, false},
 		//empty node
@@ -28,25 +27,25 @@ func TestParserConfigs(t *testing.T) {
 		//bad subgrok
 		{&Node{Debug: true, Stage: "s00", SubGroks: yaml.MapSlice{{Key: string("FOOBAR"), Value: string("[a-$")}}}, false, true},
 		//valid node with grok pattern
-		{&Node{Debug: true, Stage: "s00", SubGroks: yaml.MapSlice{{Key: string("FOOBAR"), Value: string("[a-z]")}}, Grok: types.GrokPattern{RegexpValue: "^x%{FOOBAR:extr}$", TargetField: "t"}}, true, true},
+		{&Node{Debug: true, Stage: "s00", SubGroks: yaml.MapSlice{{Key: string("FOOBAR"), Value: string("[a-z]")}}, Grok: GrokPattern{RegexpValue: "^x%{FOOBAR:extr}$", TargetField: "t"}}, true, true},
 		//bad node success
-		{&Node{Debug: true, Stage: "s00", OnSuccess: "ratat", Grok: types.GrokPattern{RegexpValue: "^x%{DATA:extr}$", TargetField: "t"}}, false, false},
+		{&Node{Debug: true, Stage: "s00", OnSuccess: "ratat", Grok: GrokPattern{RegexpValue: "^x%{DATA:extr}$", TargetField: "t"}}, false, false},
 		//ok node success
-		{&Node{Debug: true, Stage: "s00", OnSuccess: "continue", Grok: types.GrokPattern{RegexpValue: "^x%{DATA:extr}$", TargetField: "t"}}, true, true},
+		{&Node{Debug: true, Stage: "s00", OnSuccess: "continue", Grok: GrokPattern{RegexpValue: "^x%{DATA:extr}$", TargetField: "t"}}, true, true},
 		//valid node with grok sub-pattern used by name
-		{&Node{Debug: true, Stage: "s00", SubGroks: yaml.MapSlice{{Key: string("FOOBARx"), Value: string("[a-z] %{DATA:lol}$")}}, Grok: types.GrokPattern{RegexpName: "FOOBARx", TargetField: "t"}}, true, true},
+		{&Node{Debug: true, Stage: "s00", SubGroks: yaml.MapSlice{{Key: string("FOOBARx"), Value: string("[a-z] %{DATA:lol}$")}}, Grok: GrokPattern{RegexpName: "FOOBARx", TargetField: "t"}}, true, true},
 		//node with unexisting grok pattern
-		{&Node{Debug: true, Stage: "s00", Grok: types.GrokPattern{RegexpName: "RATATA", TargetField: "t"}}, false, true},
+		{&Node{Debug: true, Stage: "s00", Grok: GrokPattern{RegexpName: "RATATA", TargetField: "t"}}, false, true},
 		//node with grok pattern dependencies
 		{&Node{Debug: true, Stage: "s00", SubGroks: yaml.MapSlice{
 			{Key: string("SUBGROK"), Value: string("[a-z]")},
 			{Key: string("MYGROK"), Value: string("[a-z]%{SUBGROK}")},
-		}, Grok: types.GrokPattern{RegexpValue: "^x%{MYGROK:extr}$", TargetField: "t"}}, true, true},
+		}, Grok: GrokPattern{RegexpValue: "^x%{MYGROK:extr}$", TargetField: "t"}}, true, true},
 		//node with broken grok pattern dependencies
 		{&Node{Debug: true, Stage: "s00", SubGroks: yaml.MapSlice{
 			{Key: string("SUBGROKBIS"), Value: string("[a-z]%{MYGROKBIS}")},
 			{Key: string("MYGROKBIS"), Value: string("[a-z]")},
-		}, Grok: types.GrokPattern{RegexpValue: "^x%{MYGROKBIS:extr}$", TargetField: "t"}}, false, true},
+		}, Grok: GrokPattern{RegexpValue: "^x%{MYGROKBIS:extr}$", TargetField: "t"}}, false, true},
 	}
 	for idx := range CfgTests {
 		err := CfgTests[idx].NodeCfg.compile(pctx, EnricherCtx{})

--- a/pkg/parser/runtime.go
+++ b/pkg/parser/runtime.go
@@ -94,7 +94,7 @@ func SetTargetByName(target string, value string, evt *types.Event) bool {
 	return true
 }
 
-func printStaticTarget(static types.ExtraField) string {
+func printStaticTarget(static ExtraField) string {
 
 	if static.Method != "" {
 		return static.Method
@@ -111,7 +111,7 @@ func printStaticTarget(static types.ExtraField) string {
 	}
 }
 
-func (n *Node) ProcessStatics(statics []types.ExtraField, event *types.Event) error {
+func (n *Node) ProcessStatics(statics []ExtraField, event *types.Event) error {
 	//we have a few cases :
 	//(meta||key) + (static||reference||expr)
 	var value string


### PR DESCRIPTION
The right place seems pkg/parser, and all files using grok_pattern already import it.