### PR TITLE
Update jsonextract.go

### DIFF
--- a/pkg/exprhelpers/jsonextract.go
+++ b/pkg/exprhelpers/jsonextract.go
@@ -175,8 +175,8 @@ func UnmarshalJSON(params ...any) (any, error) {
 	err := json.Unmarshal([]byte(jsonBlob), &out)
 	if err != nil {
 		log.Errorf("UnmarshalJSON : %s", err)
-		return "", err
+		return nil, err
 	}
 	target[key] = out
-	return "", nil
+	return nil, nil
 }


### PR DESCRIPTION
Fix #2286 
Return nil instead of empty string as ParseKV does the same