### PR TITLE
append vendor.tgz to each release

### DIFF
--- a/.github/workflows/release_publish-package.yml
+++ b/.github/workflows/release_publish-package.yml
@@ -44,11 +44,11 @@ jobs:
             ${{ runner.os }}-${{ matrix.go-version }}-go-
 
       - name: Build the binaries
-        run: make release
+        run: make vendor release
 
       - name: Upload to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag_name="${GITHUB_REF##*/}"
-          hub release edit -a crowdsec-release.tgz -m "" "$tag_name"
+          hub release edit -a crowdsec-release.tgz -a vendor.tgz -m "" "$tag_name"

--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,10 @@ test/coverage/*
 *.swp
 *.swo
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# Dependencies are not vendored by default, but a tarball is created by "make vendor"
+# and provided in the release. Used by freebsd, gentoo, etc.
+vendor/
+vendor.tgz
 
 # crowdsec binaries
 cmd/crowdsec-cli/cscli

--- a/plugins/notifications/dummy/Makefile
+++ b/plugins/notifications/dummy/Makefile
@@ -16,8 +16,3 @@ build: clean
 .PHONY: clean
 clean:
 	@$(RM) $(BINARY_NAME) $(WIN_IGNORE_ERR)
-
-.PHONY: vendor
-vendor:
-	@echo "vendoring $(PLUGIN) plugin..."
-	@$(GOCMD) mod vendor

--- a/plugins/notifications/email/Makefile
+++ b/plugins/notifications/email/Makefile
@@ -16,8 +16,3 @@ build: clean
 .PHONY: clean
 clean:
 	@$(RM) $(BINARY_NAME) $(WIN_IGNORE_ERR)
-
-.PHONY: vendor
-vendor:
-	@echo "vendoring $(PLUGIN) plugin..."
-	@$(GOCMD) mod vendor

--- a/plugins/notifications/http/Makefile
+++ b/plugins/notifications/http/Makefile
@@ -16,8 +16,3 @@ build: clean
 .PHONY: clean
 clean:
 	@$(RM) $(BINARY_NAME) $(WIN_IGNORE_ERR)
-
-.PHONY: vendor
-vendor:
-	@echo "vendoring $(PLUGIN) plugin..."
-	@$(GOCMD) mod vendor

--- a/plugins/notifications/slack/Makefile
+++ b/plugins/notifications/slack/Makefile
@@ -16,8 +16,3 @@ build: clean
 .PHONY: clean
 clean:
 	@$(RM) $(BINARY_NAME) $(WIN_IGNORE_ERR)
-
-.PHONY: vendor
-vendor:
-	@echo "vendoring $(PLUGIN) plugin..."
-	@$(GOCMD) mod vendor

--- a/plugins/notifications/splunk/Makefile
+++ b/plugins/notifications/splunk/Makefile
@@ -16,8 +16,3 @@ build: clean
 .PHONY: clean
 clean:
 	@$(RM) $(BINARY_NAME) $(WIN_IGNORE_ERR)
-
-.PHONY: vendor
-vendor:
-	@echo "vendoring $(PLUGIN) plugin..."
-	@$(GOCMD) mod vendor


### PR DESCRIPTION
This can be used by ports that don't allow internet access during builds, like freebsd, gentoo etc.