### PR TITLE
Change api_key encoding to base64 to comply with bcrypt max size

### DIFF
--- a/pkg/apiserver/middlewares/v1/api_key.go
+++ b/pkg/apiserver/middlewares/v1/api_key.go
@@ -3,7 +3,7 @@ package v1
 import (
 	"crypto/rand"
 	"crypto/sha512"
-	"encoding/hex"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"strings"
@@ -15,9 +15,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var (
+const (
 	APIKeyHeader      = "X-Api-Key"
 	bouncerContextKey = "bouncer_info"
+	// max allowed by bcrypt 72 = 54 bytes in base64
+	dummyAPIKeySize   = 54
 )
 
 type APIKey struct {
@@ -31,7 +33,7 @@ func GenerateAPIKey(n int) (string, error) {
 	if _, err := rand.Read(bytes); err != nil {
 		return "", err
 	}
-	return hex.EncodeToString(bytes), nil
+	return base64.StdEncoding.EncodeToString(bytes), nil
 }
 
 func NewAPIKey(dbClient *database.Client) *APIKey {
@@ -82,7 +84,7 @@ func (a *APIKey) MiddlewareFunc() gin.HandlerFunc {
 			if err != nil && strings.Contains(err.Error(), "bouncer not found") {
 				//Because we have a valid cert, automatically create the bouncer in the database if it does not exist
 				//Set a random API key, but it will never be used
-				apiKey, err := GenerateAPIKey(64)
+				apiKey, err := GenerateAPIKey(dummyAPIKeySize)
 				if err != nil {
 					log.WithFields(log.Fields{
 						"ip": c.ClientIP(),

--- a/pkg/apiserver/middlewares/v1/jwt.go
+++ b/pkg/apiserver/middlewares/v1/jwt.go
@@ -81,7 +81,7 @@ func (j *JWT) Authenticator(c *gin.Context) (interface{}, error) {
 			//Machine was not found, let's create it
 			log.Printf("machine %s not found, create it", machineID)
 			//let's use an apikey as the password, doesn't matter in this case (generatePassword is only available in cscli)
-			pwd, err := GenerateAPIKey(64)
+			pwd, err := GenerateAPIKey(dummyAPIKeySize)
 			if err != nil {
 				log.WithFields(log.Fields{
 					"ip": c.ClientIP(),


### PR DESCRIPTION
This is required to update gin to >= 1.9.0 which has a strict check. Previously generated keys are not affected.

The change is also applied to automatically generated bouncer keys, which are now of the form "Dtm/JLkMwr9WhH06FApNNA=="
