### PR TITLE
non-fatal error if some datasource can't be run (i.e. journalctl but systemd is missing)

### DIFF
--- a/cmd/crowdsec/crowdsec.go
+++ b/cmd/crowdsec/crowdsec.go
@@ -24,22 +24,22 @@ func initCrowdsec(cConfig *csconfig.Config) (*parser.Parsers, error) {
 	var err error
 
 	// Populate cwhub package tools
-	if err := cwhub.GetHubIdx(cConfig.Hub); err != nil {
-		return &parser.Parsers{}, fmt.Errorf("Failed to load hub index : %s", err)
+	if err = cwhub.GetHubIdx(cConfig.Hub); err != nil {
+		return nil, fmt.Errorf("while loading hub index: %w", err)
 	}
 
 	// Start loading configs
 	csParsers := parser.NewParsers()
 	if csParsers, err = parser.LoadParsers(cConfig, csParsers); err != nil {
-		return &parser.Parsers{}, fmt.Errorf("Failed to load parsers: %s", err)
+		return nil, fmt.Errorf("while loading parsers: %w", err)
 	}
 
 	if err := LoadBuckets(cConfig); err != nil {
-		return &parser.Parsers{}, fmt.Errorf("Failed to load scenarios: %s", err)
+		return nil, fmt.Errorf("while loading scenarios: %w", err)
 	}
 
 	if err := LoadAcquisition(cConfig); err != nil {
-		return &parser.Parsers{}, fmt.Errorf("Error while loading acquisition config : %s", err)
+		return nil, fmt.Errorf("while loading acquisition config: %w", err)
 	}
 	return csParsers, nil
 }

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -120,7 +120,7 @@ func LoadAcquisition(cConfig *csconfig.Config) error {
 	}
 
 	if len(dataSources) == 0 {
-		return fmt.Errorf("no data source enabled")
+		return fmt.Errorf("no datasource enabled")
 	}
 
 	return nil

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -119,6 +119,10 @@ func LoadAcquisition(cConfig *csconfig.Config) error {
 		}
 	}
 
+	if len(dataSources) == 0 {
+		return fmt.Errorf("no data source enabled")
+	}
+
 	return nil
 }
 

--- a/pkg/acquisition/acquisition_test.go
+++ b/pkg/acquisition/acquisition_test.go
@@ -167,7 +167,7 @@ log_level: debug
 source: mock_cant_run
 wowo: ajsajasjas
 `,
-			ExpectedError: "datasource mock_cant_run cannot be run: can't run bro",
+			ExpectedError: "datasource 'mock_cant_run' is not available: can't run bro",
 		},
 	}
 

--- a/test/bats/01_crowdsec.bats
+++ b/test/bats/01_crowdsec.bats
@@ -151,9 +151,10 @@ teardown() {
     rm -f "$ACQUIS_DIR"
 
     config_set '.common.log_media="stdout"'
-    rune -124 timeout 2s "${CROWDSEC}"
+    rune -1 timeout 2s "${CROWDSEC}"
     # check warning
-    assert_stderr_line --partial "no acquisition file found"
+    assert_stderr --partial "no acquisition file found"
+    assert_stderr --partial "crowdsec init: while loading acquisition config: no data source enabled"
 }
 
 @test "crowdsec (error if acquisition_path and acquisition_dir are not defined)" {
@@ -166,19 +167,56 @@ teardown() {
     config_set '.crowdsec_service.acquisition_dir=""'
 
     config_set '.common.log_media="stdout"'
-    rune -124 timeout 2s "${CROWDSEC}"
+    rune -1 timeout 2s "${CROWDSEC}"
     # check warning
-    assert_stderr_line --partial "no acquisition_path or acquisition_dir specified"
+    assert_stderr --partial "no acquisition_path or acquisition_dir specified"
+    assert_stderr --partial "crowdsec init: while loading acquisition config: no data source enabled"
 }
 
 @test "crowdsec (no error if acquisition_path is empty string but acquisition_dir is not empty)" {
     ACQUIS_YAML=$(config_get '.crowdsec_service.acquisition_path')
-    rm -f "$ACQUIS_YAML"
     config_set '.crowdsec_service.acquisition_path=""'
 
     ACQUIS_DIR=$(config_get '.crowdsec_service.acquisition_dir')
     mkdir -p "$ACQUIS_DIR"
-    touch "$ACQUIS_DIR"/foo.yaml
+    mv "$ACQUIS_YAML" "$ACQUIS_DIR"/foo.yaml
 
     rune -124 timeout 2s "${CROWDSEC}"
+
+    # now, if foo.yaml is empty instead, there won't be valid datasources.
+
+    cat /dev/null >"$ACQUIS_DIR"/foo.yaml
+
+    rune -1 timeout 2s "${CROWDSEC}"
+    assert_stderr --partial "crowdsec init: while loading acquisition config: no data source enabled"
 }
+
+@test "crowdsec (disabled datasources)" {
+    config_set '.common.log_media="stdout"'
+
+    # a datasource cannot run - missing journalctl command
+
+    ACQUIS_DIR=$(config_get '.crowdsec_service.acquisition_dir')
+    mkdir -p "$ACQUIS_DIR"
+    cat >"$ACQUIS_DIR"/foo.yaml <<-EOT
+	source: journalctl
+	journalctl_filter:
+	 - "_SYSTEMD_UNIT=ssh.service"
+	labels:
+	  type: syslog
+	EOT
+
+    rune -124 timeout 2s env PATH='' "${CROWDSEC}"
+    #shellcheck disable=SC2016
+    assert_stderr --partial 'datasource journalctl cannot be run: exec: "journalctl": executable file not found in $PATH'
+
+    # if all datasources are disabled, crowdsec should exit
+
+    ACQUIS_YAML=$(config_get '.crowdsec_service.acquisition_path')
+    rm -f "$ACQUIS_YAML"
+    config_set '.crowdsec_service.acquisition_path=""'
+
+    rune -1 timeout 2s env PATH='' "${CROWDSEC}"
+    assert_stderr --partial "crowdsec init: while loading acquisition config: no data source enabled"
+}
+

--- a/test/bats/01_crowdsec.bats
+++ b/test/bats/01_crowdsec.bats
@@ -154,7 +154,7 @@ teardown() {
     rune -1 timeout 2s "${CROWDSEC}"
     # check warning
     assert_stderr --partial "no acquisition file found"
-    assert_stderr --partial "crowdsec init: while loading acquisition config: no data source enabled"
+    assert_stderr --partial "crowdsec init: while loading acquisition config: no datasource enabled"
 }
 
 @test "crowdsec (error if acquisition_path and acquisition_dir are not defined)" {
@@ -170,7 +170,7 @@ teardown() {
     rune -1 timeout 2s "${CROWDSEC}"
     # check warning
     assert_stderr --partial "no acquisition_path or acquisition_dir specified"
-    assert_stderr --partial "crowdsec init: while loading acquisition config: no data source enabled"
+    assert_stderr --partial "crowdsec init: while loading acquisition config: no datasource enabled"
 }
 
 @test "crowdsec (no error if acquisition_path is empty string but acquisition_dir is not empty)" {
@@ -188,7 +188,7 @@ teardown() {
     cat /dev/null >"$ACQUIS_DIR"/foo.yaml
 
     rune -1 timeout 2s "${CROWDSEC}"
-    assert_stderr --partial "crowdsec init: while loading acquisition config: no data source enabled"
+    assert_stderr --partial "crowdsec init: while loading acquisition config: no datasource enabled"
 }
 
 @test "crowdsec (disabled datasources)" {
@@ -217,6 +217,6 @@ teardown() {
     config_set '.crowdsec_service.acquisition_path=""'
 
     rune -1 timeout 2s env PATH='' "${CROWDSEC}"
-    assert_stderr --partial "crowdsec init: while loading acquisition config: no data source enabled"
+    assert_stderr --partial "crowdsec init: while loading acquisition config: no datasource enabled"
 }
 

--- a/test/bats/01_crowdsec.bats
+++ b/test/bats/01_crowdsec.bats
@@ -208,7 +208,7 @@ teardown() {
 
     rune -124 timeout 2s env PATH='' "${CROWDSEC}"
     #shellcheck disable=SC2016
-    assert_stderr --partial 'datasource journalctl cannot be run: exec: "journalctl": executable file not found in $PATH'
+    assert_stderr --partial 'datasource '\''journalctl'\'' is not available: exec: "journalctl": executable file not found in $PATH'
 
     # if all datasources are disabled, crowdsec should exit
 


### PR DESCRIPTION
This on the other hand, gives a new fatal error when there are no valid datasources. In the previous version, crowdsec kept running with just a warning if no acquisition yaml or dir were specified.