### PR TITLE
rename status to state in fire response

### DIFF
--- a/pkg/cticlient/example/fire.go
+++ b/pkg/cticlient/example/fire.go
@@ -44,6 +44,9 @@ func main() {
 		}
 
 		for _, item := range items {
+			if item.State == "refused" {
+				continue
+			}
 			banDuration := time.Until(item.Expiration.Time)
 			allItems = append(allItems, []string{
 				item.Ip,

--- a/pkg/cticlient/types.go
+++ b/pkg/cticlient/types.go
@@ -120,7 +120,7 @@ type FireItem struct {
 	BackgroundNoiseScore *int                `json:"background_noise_score"`
 	Scores               CTIScores           `json:"scores"`
 	References           []CTIReferences     `json:"references"`
-	Status               string              `json:"status"`
+	State                string              `json:"state"`
 	Expiration           CustomTime          `json:"expiration"`
 }
 


### PR DESCRIPTION
The swagger used to implement the client was incorrect: the `status` field is actually called `state`.
Fix the name, and use it in the dump example to ignore refused IPs.