### PR TITLE
add journalctl for ssh by default

### DIFF
--- a/config/acquis.yaml
+++ b/config/acquis.yaml
@@ -10,6 +10,12 @@ filenames:
  - /var/log/syslog
 labels:
   type: syslog
+--- 
+source: journalctl
+journalctl_filter:
+ - "_SYSTEMD_UNIT=ssh.service"
+labels:
+  type: syslog
 ---
 filename: /var/log/apache2/*.log
 labels:


### PR DESCRIPTION
add journalctl for ssh by default since crowdsec wont't return nor crash if the datasource is not usable.