### PR TITLE
Add merge helpers to merge maps into maps if the value is string

### DIFF
--- a/pkg/exprhelpers/expr_lib.go
+++ b/pkg/exprhelpers/expr_lib.go
@@ -419,6 +419,20 @@ var exprFuncs = []exprCustomFunc{
 			new(func() (string, error)),
 		},
 	},
+	{
+		name:     "Merge",
+		function: Merge,
+		signature: []interface{}{
+			new(func(map[string]interface{}, map[string]string) error),
+		},
+	},
+	{
+		name:     "MergeSafe",
+		function: MergeSafe,
+		signature: []interface{}{
+			new(func(map[string]interface{}, map[string]string) error),
+		},
+	},
 }
 
 //go 1.20 "CutPrefix":              strings.CutPrefix,

--- a/pkg/exprhelpers/exprlib_test.go
+++ b/pkg/exprhelpers/exprlib_test.go
@@ -1453,6 +1453,13 @@ func TestMerge(t *testing.T) {
 			expected: map[string]string{"foo": "bar"},
 			expr:     `Merge(value, out)`,
 		},
+		{
+			name:               "Merge() test: error on nil source",
+			value:              nil,
+			expected:           nil,
+			expr:               `Merge(value, out)`,
+			expectedRuntimeErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -1464,8 +1471,16 @@ func TestMerge(t *testing.T) {
 				"out":   outMap,
 			}
 			vm, err := expr.Compile(tc.expr, GetExprOptions(env)...)
+			if tc.expectedBuildErr {
+				assert.Error(t, err)
+				return
+			}
 			assert.NoError(t, err)
 			_, err = expr.Run(vm, env)
+			if tc.expectedRuntimeErr {
+				assert.Error(t, err)
+				return
+			}
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, outMap)
 		})
@@ -1501,6 +1516,13 @@ func TestMergeSafe(t *testing.T) {
 			expected: map[string]string{"foo": "bar"},
 			expr:     `MergeSafe(value, out)`,
 		},
+		{
+			name:               "MergeSafe() test: error on nil source",
+			value:              nil,
+			expected:           nil,
+			expr:               `MergeSafe(value, out)`,
+			expectedRuntimeErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -1515,8 +1537,16 @@ func TestMergeSafe(t *testing.T) {
 				"out":   outMap,
 			}
 			vm, err := expr.Compile(tc.expr, GetExprOptions(env)...)
+			if tc.expectedBuildErr {
+				assert.Error(t, err)
+				return
+			}
 			assert.NoError(t, err)
 			_, err = expr.Run(vm, env)
+			if tc.expectedRuntimeErr {
+				assert.Error(t, err)
+				return
+			}
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, outMap)
 		})

--- a/pkg/exprhelpers/helpers.go
+++ b/pkg/exprhelpers/helpers.go
@@ -643,3 +643,33 @@ func Hostname(params ...any) (any, error) {
 	}
 	return hostname, nil
 }
+
+func Merge(params ...any) (any, error) {
+	source := params[0].(map[string]interface{})
+	target := params[1].(map[string]string)
+	if source == nil || target == nil {
+		return "", fmt.Errorf("invalid input format must provide two maps")
+	}
+	for k, v := range source {
+		if p, _ := ToString(v); p != "" {
+			target[k] = p.(string)
+		}
+	}
+	return nil, nil
+}
+
+func MergeSafe(params ...any) (any, error) {
+	source := params[0].(map[string]interface{})
+	target := params[1].(map[string]string)
+	if source == nil || target == nil {
+		return "", fmt.Errorf("invalid input format must provide two maps")
+	}
+	for k, v := range source {
+		if _, ok := target[k]; !ok {
+			if p, _ := ToString(v); p != "" {
+				target[k] = p.(string)
+			}
+		}
+	}
+	return nil, nil
+}

--- a/pkg/exprhelpers/helpers.go
+++ b/pkg/exprhelpers/helpers.go
@@ -647,6 +647,7 @@ func Hostname(params ...any) (any, error) {
 func Merge(params ...any) (any, error) {
 	source := params[0].(map[string]interface{})
 	target := params[1].(map[string]string)
+	fmt.Println(source, target)
 	if source == nil || target == nil {
 		return "", fmt.Errorf("invalid input format must provide two maps")
 	}


### PR DESCRIPTION
This is useful with the new unmarshaled on the event. You may want to move everything from `evt.Unmarshaled.traefik` to `evt.Parsed` I provide two methods one that will override any key on the target or a safe option.

Since `evt.Parsed` and `evt.Meta` expect the value to be a string. I have to use to ToString method, however, we should explore to expand this helper function as any other type it pretty much fails.

This above situation does **NOT** affect ParseKV since it always returns a string, however, UnmarshalJSON has the potential to return other values.

If PR is accepted I will add explicit documentation that if the values are not strings you will need to set them manually after the merge example:

```
onsuccess: next_stage
debug: true
name: crowdsecurity/kafka-logs
description: "Parse kafka json logs"
## 1.5.2 returns "" , 1.5.3 returns nil
filter: evt.Parsed.program == 'kafka' && UnmarshalJSON(evt.Parsed.message, evt.Unmarshaled, "kafka") in [
"", nil]
statics:
    - meta: service
      value: kafka
   -  meta: unused
      expression: MergeSafe(evt.Unmarshaled.kafka, evt.Meta)
 ## Since connectionScore is float/int it is ignore be Merge and MergeSafe so user must explicitly set the value since ToString (Our helper) does NOT type cast it correctly.
    - meta: connection_score
      expression: int(evt.Unmarshaled.kafka.connectionScore)
```