### PR TITLE
Properly match new files on windows when doing file acquisition

### DIFF
--- a/pkg/acquisition/modules/file/file.go
+++ b/pkg/acquisition/modules/file/file.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -371,12 +370,13 @@ func (f *FileSource) monitorNewFiles(out chan types.Event, t *tomb.Tomb) error {
 				matched := false
 				for _, pattern := range f.config.Filenames {
 					logger.Debugf("Matching %s with %s", pattern, event.Name)
-					matched, err = path.Match(pattern, event.Name)
+					matched, err = filepath.Match(pattern, event.Name)
 					if err != nil {
 						logger.Errorf("Could not match pattern : %s", err)
 						continue
 					}
 					if matched {
+						logger.Debugf("Matched %s with %s", pattern, event.Name)
 						break
 					}
 				}

--- a/pkg/acquisition/modules/file/file_test.go
+++ b/pkg/acquisition/modules/file/file_test.go
@@ -260,7 +260,7 @@ func TestLiveAcquisition(t *testing.T) {
 		// if we do not have access to the file
 		permDeniedFile = `C:\Windows\System32\config\SAM`
 		permDeniedError = `unable to read C:\Windows\System32\config\SAM : open C:\Windows\System32\config\SAM: The process cannot access the file because it is being used by another process`
-		testPattern = `test_files\\*.log` // the \ must be escaped for the yaml config
+		testPattern = `test_files\*.log`
 	}
 
 	tests := []struct {


### PR DESCRIPTION
`path.Match` does not actually work on Windows as `\` is treated as an escape character, so it will never matches.

Use `filepath.Match` which properly handles `\` (at the cost of disabling escaping, but this is likely a non-issue).