### PR TITLE
Reduce log verbosity at startup

### DIFF
--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -344,7 +344,7 @@ func Serve(cConfig *csconfig.Config, apiReady chan bool, agentReady chan bool) e
 	}
 
 	if flags.TestMode {
-		log.Infof("test done")
+		log.Infof("Configuration test done")
 		pluginBroker.Kill()
 		os.Exit(0)
 	}

--- a/config/crowdsec.service
+++ b/config/crowdsec.service
@@ -5,7 +5,7 @@ After=syslog.target network.target remote-fs.target nss-lookup.target
 [Service]
 Type=notify
 Environment=LC_ALL=C LANG=C
-ExecStartPre=/usr/local/bin/crowdsec -c /etc/crowdsec/config.yaml -t
+ExecStartPre=/usr/local/bin/crowdsec -c /etc/crowdsec/config.yaml -t -error
 ExecStart=/usr/local/bin/crowdsec -c /etc/crowdsec/config.yaml
 #ExecStartPost=/bin/sleep 0.1
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
A configuration syntax test is performed every time the service is started from systemd. The resulting error, if any, is shown on journalctl logs.
This PR removes the unnecessary output in crowdsec.log generated by the configuration test.