### PR TITLE
fix double push of metrics by properly handling tickers

### DIFF
--- a/pkg/apiserver/apic_metrics_test.go
+++ b/pkg/apiserver/apic_metrics_test.go
@@ -26,15 +26,15 @@ func TestAPICSendMetrics(t *testing.T) {
 	}{
 		{
 			name:            "basic",
-			duration:        time.Millisecond * 30,
-			metricsInterval: time.Millisecond * 5,
+			duration:        time.Millisecond * 60,
+			metricsInterval: time.Millisecond * 10,
 			expectedCalls:   5,
 			setUp:           func(api *apic) {},
 		},
 		{
 			name:            "with some metrics",
-			duration:        time.Millisecond * 30,
-			metricsInterval: time.Millisecond * 5,
+			duration:        time.Millisecond * 60,
+			metricsInterval: time.Millisecond * 10,
 			expectedCalls:   5,
 			setUp: func(api *apic) {
 				api.dbClient.Ent.Machine.Delete().ExecX(context.Background())


### PR DESCRIPTION
if the initial ticker interval is too small, metrics are sent twice every time crowdsec is reload or a machines is added