### PR TITLE
fix a confusing debug message

### DIFF
--- a/pkg/csplugin/helpers.go
+++ b/pkg/csplugin/helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/crowdsecurity/crowdsec/pkg/exprhelpers"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
+	log "github.com/sirupsen/logrus"
 )
 
 var helpers = template.FuncMap{
@@ -20,8 +21,14 @@ var helpers = template.FuncMap{
 		}
 		return metaValues
 	},
-	"CrowdsecCTI": exprhelpers.CrowdsecCTI,
-	"Hostname":    os.Hostname,
+	"CrowdsecCTI": func(x string) any {
+		ret, err := exprhelpers.CrowdsecCTI(x)
+		if err != nil {
+			log.Warningf("error while calling CrowdsecCTI : %s", err)
+		}
+		return ret
+	},
+	"Hostname": os.Hostname,
 }
 
 func funcMap() template.FuncMap {

--- a/pkg/csprofiles/csprofiles.go
+++ b/pkg/csprofiles/csprofiles.go
@@ -168,7 +168,7 @@ func (Profile *Runtime) EvaluateProfile(Alert *models.Alert) ([]*models.Decision
 	for eIdx, expression := range Profile.RuntimeFilters {
 		output, err := expr.Run(expression, map[string]interface{}{"Alert": Alert})
 		if err != nil {
-			Profile.Logger.Warningf("failed to run whitelist expr : %v", err)
+			Profile.Logger.Warningf("failed to run profile expr for %s : %v", Profile.Cfg.Name, err)
 			return nil, matched, errors.Wrapf(err, "while running expression %s", Profile.Cfg.Filters[eIdx])
 		}
 		switch out := output.(type) {


### PR DESCRIPTION
Previously, if you used `CTIHelper` in ie. a template while having reached your quotas, CTIHelper's error will prevent template rendering (and thus you won't get notification at all). This approach logs the error and moves on :)
