### PR TITLE
Fix SSHD_FAIL pattern.

### DIFF
--- a/config/patterns/ssh
+++ b/config/patterns/ssh
@@ -27,7 +27,7 @@ SSHD_TCPWRAP_FAIL2  warning: %{DATA:sshd_tcpd_file}, line %{NUMBER}: host name/a
 SSHD_TCPWRAP_FAIL3  warning: %{DATA:sshd_tcpd_file}, line %{NUMBER}: host name/name mismatch: %{HOSTNAME:sshd_paranoid_hostname_1} != %{HOSTNAME:sshd_paranoid_hostname_2}
 SSHD_TCPWRAP_FAIL4  warning: %{DATA:sshd_tcpd_file}, line %{NUMBER}: host name/name mismatch: reverse lookup results in non-FQDN %{HOSTNAME:sshd_paranoid_hostname}
 SSHD_TCPWRAP_FAIL5  warning: can't get client address: Connection reset by peer
-SSHD_FAIL           Failed %{WORD:sshd_auth_type} for %{USERNAME:sshd_invalid_user} from %{IP:sshd_client_ip} port %{NUMBER:sshd_port} %{WORD:sshd_protocol}
+SSHD_FAIL           Failed %{NOTSPACE:sshd_auth_type} for %{USERNAME:sshd_invalid_user} from %{IP:sshd_client_ip} port %{NUMBER:sshd_port} %{WORD:sshd_protocol}
 SSHD_USER_FAIL      Failed password for invalid user %{USERNAME:sshd_invalid_user} from %{IP:sshd_client_ip} port %{NUMBER:sshd_port} %{WORD:sshd_protocol}
 SSHD_INVAL_USER     Invalid user\s*%{USERNAME:sshd_invalid_user}? from %{IP:sshd_client_ip}
 


### PR DESCRIPTION
Previously auth_type was expected to be a WORD, however this failed to match auth types like `keyboard-interactive` or `keyboard-interactive/pam`.

Example log line that was not being parsed before:

```
Failed keyboard-interactive/pam for invalid user supervisor from 191.5.98.238 port 47846 ssh2
```

SSH server Version Details below
```
❯ sshd -V
OpenSSH_9.3, OpenSSL 3.0.9 30 May 2023
```