### PR TITLE
[1.5.4] slight mem ops

### DIFF
--- a/pkg/exprhelpers/helpers.go
+++ b/pkg/exprhelpers/helpers.go
@@ -156,9 +156,9 @@ func FileInit(fileFolder string, filename string, fileType string) error {
 		case "regex", "regexp":
 			if fflag.Re2RegexpInfileSupport.IsEnabled() {
 				dataFileRe2[filename] = append(dataFileRe2[filename], re2.MustCompile(scanner.Text()))
-			} else {
-				dataFileRegex[filename] = append(dataFileRegex[filename], regexp.MustCompile(scanner.Text()))
+				continue
 			}
+			dataFileRegex[filename] = append(dataFileRegex[filename], regexp.MustCompile(scanner.Text()))
 		case "string":
 			dataFile[filename] = append(dataFile[filename], scanner.Text())
 		default:

--- a/pkg/exprhelpers/helpers.go
+++ b/pkg/exprhelpers/helpers.go
@@ -132,7 +132,7 @@ func FileInit(fileFolder string, filename string, fileType string) error {
 		log.Debugf("ignored file %s%s because no type specified", fileFolder, filename)
 		return nil
 	}
-	if _, ok := dataFile[filename]; ok {
+	if ok := existsInFileMaps(filename, fileType); ok {
 		log.Debugf("ignored file %s%s because already loaded", fileFolder, filename)
 		return nil
 	}
@@ -170,6 +170,21 @@ func FileInit(fileFolder string, filename string, fileType string) error {
 		return err
 	}
 	return nil
+}
+
+func existsInFileMaps(filename string, ftype string) bool {
+	ok := false
+	switch ftype {
+	case "regex", "regexp":
+		if fflag.Re2RegexpInfileSupport.IsEnabled() {
+			_, ok = dataFileRe2[filename]
+		} else {
+			_, ok = dataFileRegex[filename]
+		}
+	case "string":
+		_, ok = dataFile[filename]
+	}
+	return ok
 }
 
 //Expr helpers

--- a/pkg/exprhelpers/helpers.go
+++ b/pkg/exprhelpers/helpers.go
@@ -136,7 +136,7 @@ func FileInit(fileFolder string, filename string, fileType string) error {
 		log.Debugf("ignored file %s%s because already loaded", fileFolder, filename)
 		return nil
 	}
-	dataFile[filename] = []string{}
+
 	filepath := filepath.Join(fileFolder, filename)
 	file, err := os.Open(filepath)
 	if err != nil {

--- a/pkg/exprhelpers/helpers.go
+++ b/pkg/exprhelpers/helpers.go
@@ -128,6 +128,15 @@ func UpdateRegexpCacheMetrics() {
 
 func FileInit(fileFolder string, filename string, fileType string) error {
 	log.Debugf("init (folder:%s) (file:%s) (type:%s)", fileFolder, filename, fileType)
+	if fileType == "" {
+		log.Debugf("ignored file %s%s because no type specified", fileFolder, filename)
+		return nil
+	}
+	if _, ok := dataFile[filename]; ok {
+		log.Debugf("ignored file %s%s because already loaded", fileFolder, filename)
+		return nil
+	}
+	dataFile[filename] = []string{}
 	filepath := filepath.Join(fileFolder, filename)
 	file, err := os.Open(filepath)
 	if err != nil {
@@ -135,13 +144,6 @@ func FileInit(fileFolder string, filename string, fileType string) error {
 	}
 	defer file.Close()
 
-	if fileType == "" {
-		log.Debugf("ignored file %s%s because no type specified", fileFolder, filename)
-		return nil
-	}
-	if _, ok := dataFile[filename]; !ok {
-		dataFile[filename] = []string{}
-	}
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		if strings.HasPrefix(scanner.Text(), "#") { // allow comments

--- a/pkg/leakybucket/bucket.go
+++ b/pkg/leakybucket/bucket.go
@@ -73,12 +73,15 @@ type Leaky struct {
 	orderEvent          bool
 }
 
+var promLabelName = []string{"name"}
+var promLabelFull = []string{"source", "type", "name"}
+
 var BucketsPour = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "cs_bucket_poured_total",
 		Help: "Total events were poured in bucket.",
 	},
-	[]string{"source", "type", "name"},
+	promLabelFull,
 )
 
 var BucketsOverflow = prometheus.NewCounterVec(
@@ -86,7 +89,7 @@ var BucketsOverflow = prometheus.NewCounterVec(
 		Name: "cs_bucket_overflowed_total",
 		Help: "Total buckets overflowed.",
 	},
-	[]string{"name"},
+	promLabelName,
 )
 
 var BucketsCanceled = prometheus.NewCounterVec(
@@ -94,7 +97,7 @@ var BucketsCanceled = prometheus.NewCounterVec(
 		Name: "cs_bucket_canceled_total",
 		Help: "Total buckets canceled.",
 	},
-	[]string{"name"},
+	promLabelName,
 )
 
 var BucketsUnderflow = prometheus.NewCounterVec(
@@ -102,7 +105,7 @@ var BucketsUnderflow = prometheus.NewCounterVec(
 		Name: "cs_bucket_underflowed_total",
 		Help: "Total buckets underflowed.",
 	},
-	[]string{"name"},
+	promLabelName,
 )
 
 var BucketsInstantiation = prometheus.NewCounterVec(
@@ -110,7 +113,7 @@ var BucketsInstantiation = prometheus.NewCounterVec(
 		Name: "cs_bucket_created_total",
 		Help: "Total buckets were instantiated.",
 	},
-	[]string{"name"},
+	promLabelName,
 )
 
 var BucketsCurrentCount = prometheus.NewGaugeVec(
@@ -118,7 +121,7 @@ var BucketsCurrentCount = prometheus.NewGaugeVec(
 		Name: "cs_buckets",
 		Help: "Number of buckets that currently exist.",
 	},
-	[]string{"name"},
+	promLabelName,
 )
 
 var LeakyRoutineCount int64

--- a/pkg/parser/expr_cache.go
+++ b/pkg/parser/expr_cache.go
@@ -1,0 +1,39 @@
+package parser
+
+import (
+	"hash/fnv"
+
+	"github.com/antonmedv/expr"
+	"github.com/antonmedv/expr/vm"
+)
+
+type ExprCache struct {
+	cache map[uint32]*vm.Program
+}
+
+func hash(s string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(s))
+	return h.Sum32()
+}
+
+func NewExprCache() *ExprCache {
+	return &ExprCache{
+		cache: make(map[uint32]*vm.Program),
+	}
+}
+
+// Get returns a compiled expression from the cache if it exists, otherwise it compiles it and adds it to the cache
+func (c *ExprCache) Get(toParse string, opts []expr.Option) (*vm.Program, error) {
+	var err error
+	key := hash(toParse)
+	program, ok := c.cache[key]
+	if !ok {
+		program, err = expr.Compile(toParse, opts...)
+		if err != nil {
+			return nil, err
+		}
+		c.cache[key] = program
+	}
+	return program, err
+}

--- a/pkg/parser/expr_cache.go
+++ b/pkg/parser/expr_cache.go
@@ -32,11 +32,12 @@ func (c *ExprCache) Get(toParse string, opts []expr.Option) (*vm.Program, error)
 	c.mu.Lock()
 	program, ok := c.cache[key]
 	if !ok {
+		c.mu.Unlock()
 		program, err = expr.Compile(toParse, opts...)
 		if err != nil {
-			c.mu.Unlock()
 			return nil, err
 		}
+		c.mu.Lock()
 		c.cache[key] = program
 	}
 	c.mu.Unlock()

--- a/pkg/parser/expr_cache_test.go
+++ b/pkg/parser/expr_cache_test.go
@@ -41,7 +41,7 @@ func TestExprCache(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(_t *testing.T) {
 			_u := make(map[string]bool, tt.expected_unique_count)
 			cache := NewExprCache()
 			for _, expr := range tt.expressions {

--- a/pkg/parser/expr_cache_test.go
+++ b/pkg/parser/expr_cache_test.go
@@ -1,0 +1,64 @@
+package parser
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestExprCache(t *testing.T) {
+	tests := []struct {
+		name                  string
+		expressions           []string
+		expected_unique_count int
+	}{
+		{
+			name: "3 unique expressions",
+			expressions: []string{
+				"1==1",
+				"1==2",
+				"1==3",
+			},
+			expected_unique_count: 3,
+		},
+		{
+			name: "2 unique expressions with 1 duplicate",
+			expressions: []string{
+				"1==1",
+				"1==2",
+				"1==1",
+			},
+			expected_unique_count: 2,
+		},
+		{
+			name: "1 unique expression with 2 duplicates",
+			expressions: []string{
+				"1==1",
+				"1==1",
+				"1==1",
+			},
+			expected_unique_count: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_u := make(map[string]bool, tt.expected_unique_count)
+			_c := 0
+			cache := NewExprCache()
+			for _, expr := range tt.expressions {
+				program, err := cache.Get(expr, nil)
+				if err != nil {
+					t.Errorf("error while compiling expression: %s", err)
+				}
+				address := fmt.Sprintf("%p", program)
+				if _, ok := _u[address]; !ok {
+					_u[address] = true
+					_c++
+				}
+			}
+			if _c != tt.expected_unique_count {
+				t.Errorf("expected %d unique expressions, got %d", tt.expected_unique_count, _c)
+			}
+		})
+	}
+}

--- a/pkg/parser/expr_cache_test.go
+++ b/pkg/parser/expr_cache_test.go
@@ -43,7 +43,6 @@ func TestExprCache(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_u := make(map[string]bool, tt.expected_unique_count)
-			_c := 0
 			cache := NewExprCache()
 			for _, expr := range tt.expressions {
 				program, err := cache.Get(expr, nil)
@@ -53,11 +52,10 @@ func TestExprCache(t *testing.T) {
 				address := fmt.Sprintf("%p", program)
 				if _, ok := _u[address]; !ok {
 					_u[address] = true
-					_c++
 				}
 			}
-			if _c != tt.expected_unique_count {
-				t.Errorf("expected %d unique expressions, got %d", tt.expected_unique_count, _c)
+			if len(_u) != tt.expected_unique_count {
+				t.Errorf("expected %d unique expressions, got %d", tt.expected_unique_count, len(_u))
 			}
 		})
 	}

--- a/pkg/parser/node.go
+++ b/pkg/parser/node.go
@@ -242,7 +242,7 @@ func (n *Node) process(p *types.Event, ctx UnixParserCtx, expressionEnv map[stri
 		}
 	}
 
-	if isWhitelisted {
+	if isWhitelisted && !p.Whitelisted {
 		p.Whitelisted = true
 		p.WhitelistReason = n.Whitelist.Reason
 		/*huglily wipe the ban order if the event is whitelisted and it's an overflow */

--- a/pkg/parser/runtime.go
+++ b/pkg/parser/runtime.go
@@ -300,6 +300,7 @@ func Parse(ctx UnixParserCtx, xp types.Event, nodes []Node) (types.Event, error)
 		}
 
 		isStageOK := false
+		exprEnv := map[string]interface{}{"evt": &event}
 		for idx, node := range nodes {
 			//Only process current stage's nodes
 			if event.Stage != node.Stage {
@@ -313,7 +314,7 @@ func Parse(ctx UnixParserCtx, xp types.Event, nodes []Node) (types.Event, error)
 			if ctx.Profiling {
 				node.Profiling = true
 			}
-			ret, err := node.process(&event, ctx, map[string]interface{}{"evt": &event})
+			ret, err := node.process(&event, &ctx, exprEnv)
 			if err != nil {
 				clog.Errorf("Error while processing node : %v", err)
 				return event, err

--- a/pkg/parser/runtime.go
+++ b/pkg/parser/runtime.go
@@ -194,12 +194,14 @@ func (n *Node) ProcessStatics(statics []ExtraField, event *types.Event) error {
 	return nil
 }
 
+var promLabels = []string{"source", "type", "name"}
+
 var NodesHits = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "cs_node_hits_total",
 		Help: "Total events entered node.",
 	},
-	[]string{"source", "type", "name"},
+	promLabels,
 )
 
 var NodesHitsOk = prometheus.NewCounterVec(
@@ -207,7 +209,7 @@ var NodesHitsOk = prometheus.NewCounterVec(
 		Name: "cs_node_hits_ok_total",
 		Help: "Total events successfully exited node.",
 	},
-	[]string{"source", "type", "name"},
+	promLabels,
 )
 
 var NodesHitsKo = prometheus.NewCounterVec(
@@ -215,7 +217,7 @@ var NodesHitsKo = prometheus.NewCounterVec(
 		Name: "cs_node_hits_ko_total",
 		Help: "Total events unsuccessfully exited node.",
 	},
-	[]string{"source", "type", "name"},
+	promLabels,
 )
 
 func stageidx(stage string, stages []string) int {

--- a/pkg/parser/stage.go
+++ b/pkg/parser/stage.go
@@ -57,6 +57,7 @@ func LoadStages(stageFiles []Stagefile, pctx *UnixParserCtx, ectx EnricherCtx) (
 		if err != nil {
 			return nil, fmt.Errorf("can't access parsing configuration file %s : %s", stageFile.Filename, err)
 		}
+		defer yamlFile.Close()
 		//process the yaml
 		dec := yaml.NewDecoder(yamlFile)
 		dec.SetStrict(true)

--- a/pkg/parser/stage.go
+++ b/pkg/parser/stage.go
@@ -71,8 +71,8 @@ func LoadStages(stageFiles []Stagefile, pctx *UnixParserCtx, ectx EnricherCtx) (
 					log.Tracef("End of yaml file")
 					break
 				}
-				yamlFile.Close()
-				log.Fatalf("Error decoding parsing configuration file '%s': %v", stageFile.Filename, err)
+				log.Errorf("Error decoding parsing configuration file '%s': %v", stageFile.Filename, err)
+				break
 			}
 
 			//check for empty bucket
@@ -87,8 +87,8 @@ func LoadStages(stageFiles []Stagefile, pctx *UnixParserCtx, ectx EnricherCtx) (
 			}
 			ok, err := cwversion.Satisfies(node.FormatVersion, cwversion.Constraint_parser)
 			if err != nil {
-				yamlFile.Close()
-				log.Fatalf("Failed to check version : %s", err)
+				log.Errorf("Failed to check version : %s", err)
+				break
 			}
 			if !ok {
 				log.Errorf("%s : %s doesn't satisfy parser format %s, skip", node.Name, node.FormatVersion, cwversion.Constraint_parser)

--- a/pkg/parser/stage.go
+++ b/pkg/parser/stage.go
@@ -71,6 +71,7 @@ func LoadStages(stageFiles []Stagefile, pctx *UnixParserCtx, ectx EnricherCtx) (
 					log.Tracef("End of yaml file")
 					break
 				}
+				yamlFile.Close()
 				log.Fatalf("Error decoding parsing configuration file '%s': %v", stageFile.Filename, err)
 			}
 
@@ -86,6 +87,7 @@ func LoadStages(stageFiles []Stagefile, pctx *UnixParserCtx, ectx EnricherCtx) (
 			}
 			ok, err := cwversion.Satisfies(node.FormatVersion, cwversion.Constraint_parser)
 			if err != nil {
+				yamlFile.Close()
 				log.Fatalf("Failed to check version : %s", err)
 			}
 			if !ok {

--- a/pkg/parser/unix_parser.go
+++ b/pkg/parser/unix_parser.go
@@ -151,5 +151,7 @@ func LoadParsers(cConfig *csconfig.Config, parsers *Parsers) (*Parsers, error) {
 
 	parsers.Ctx.Grok = grokky.Host{}
 	parsers.Povfwctx.Grok = grokky.Host{}
+	parsers.StageFiles = []Stagefile{}
+	parsers.PovfwStageFiles = []Stagefile{}
 	return parsers, nil
 }

--- a/pkg/parser/unix_parser.go
+++ b/pkg/parser/unix_parser.go
@@ -149,5 +149,7 @@ func LoadParsers(cConfig *csconfig.Config, parsers *Parsers) (*Parsers, error) {
 		parsers.Povfwctx.Profiling = true
 	}
 
+	parsers.Ctx.Grok = grokky.Host{}
+	parsers.Povfwctx.Grok = grokky.Host{}
 	return parsers, nil
 }

--- a/pkg/parser/whitelist.go
+++ b/pkg/parser/whitelist.go
@@ -18,6 +18,14 @@ type Whitelist struct {
 	B_Exprs []*ExprWhitelist
 }
 
+// returns true if the whitelist has at least one IP or CIDR
+func (W Whitelist) ContainsIPLists() bool {
+	if len(W.B_Ips) > 0 || len(W.B_Cidrs) > 0 {
+		return true
+	}
+	return false
+}
+
 type ExprWhitelist struct {
 	Filter       *vm.Program
 	ExprDebugger *exprhelpers.ExprDebugger // used to debug expression by printing the content of each variable of the expression

--- a/pkg/parser/whitelist.go
+++ b/pkg/parser/whitelist.go
@@ -20,10 +20,7 @@ type Whitelist struct {
 
 // returns true if the whitelist has at least one IP or CIDR
 func (W Whitelist) ContainsIPLists() bool {
-	if len(W.B_Ips) > 0 || len(W.B_Cidrs) > 0 {
-		return true
-	}
-	return false
+	return len(W.B_Ips) > 0 || len(W.B_Cidrs) > 0
 }
 
 type ExprWhitelist struct {


### PR DESCRIPTION
After we compile all parsers / postoverflows we can nil / empty grokky as it is not reused and can save more in RE2 FF