### PR TITLE
Add method name to child logger 

### DIFF
--- a/pkg/parser/runtime.go
+++ b/pkg/parser/runtime.go
@@ -152,7 +152,7 @@ func (n *Node) ProcessStatics(statics []ExtraField, event *types.Event) error {
 			/*still way too hackish, but : inject all the results in enriched, and */
 			if enricherPlugin, ok := n.EnrichFunctions.Registered[static.Method]; ok {
 				clog.Tracef("Found method '%s'", static.Method)
-				ret, err := enricherPlugin.EnrichFunc(value, event, enricherPlugin.Ctx, n.Logger)
+				ret, err := enricherPlugin.EnrichFunc(value, event, enricherPlugin.Ctx, n.Logger.WithField("method", static.Method))
 				if err != nil {
 					clog.Errorf("method '%s' returned an error : %v", static.Method, err)
 				}


### PR DESCRIPTION
so we can see which function is outputting info

```
time="07-08-2023 10:50:54" level=error msg="Unable to enrich ip '90.235.85.117'" id=frosty-cherry name=crowdsecurity/geoip-enrich stage=s02-enrich
time="07-08-2023 10:50:54" level=error msg="Failed to fetch network for 90.235.85.117 : unknown type: 22" id=frosty-cherry name=crowdsecurity/geoip-enrich stage=s02-enrich
```

We know which enricher but not which method within the enricher whcih outputted this error