### PR TITLE
Add CAPI whitelist length check

### DIFF
--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -621,7 +621,7 @@ func (a *apic) PullTop(forcePull bool) error {
 }
 
 func (a *apic) ApplyApicWhitelists(decisions []*models.Decision) []*models.Decision {
-	if a.whitelists == nil {
+	if a.whitelists == nil || len(a.whitelists.Cidrs) == 0 && len(a.whitelists.Ips) == 0 {
 		return decisions
 	}
 	//deal with CAPI whitelists for fire. We want to avoid having a second list, so we shrink in place

--- a/pkg/csconfig/api.go
+++ b/pkg/csconfig/api.go
@@ -344,12 +344,15 @@ func (s *LocalApiServerCfg) LoadCapiWhitelists() error {
 	}
 
 	var fromCfg capiWhitelists
-	s.CapiWhitelists = &CapiWhitelist{}
 
 	defer fd.Close()
 	decoder := yaml.NewDecoder(fd)
 	if err := decoder.Decode(&fromCfg); err != nil {
 		return fmt.Errorf("while parsing capi whitelist file '%s': %s", s.CapiWhitelistsPath, err)
+	}
+	s.CapiWhitelists = &CapiWhitelist{
+		Ips:   make([]net.IP, len(fromCfg.Ips)),
+		Cidrs: make([]*net.IPNet, len(fromCfg.Cidrs)),
 	}
 	for _, v := range fromCfg.Ips {
 		ip := net.ParseIP(v)


### PR DESCRIPTION
If user configures the file but fails to define an actual whitelist we should check length to save allocs