### PR TITLE
Reset grokky once all patterns are compiled

### DIFF
--- a/pkg/parser/unix_parser.go
+++ b/pkg/parser/unix_parser.go
@@ -148,6 +148,12 @@ func LoadParsers(cConfig *csconfig.Config, parsers *Parsers) (*Parsers, error) {
 		parsers.Ctx.Profiling = true
 		parsers.Povfwctx.Profiling = true
 	}
-
+	/*
+		Reset CTX grok to reduce memory footprint after we compile all the patterns
+	*/
+	parsers.Ctx.Grok = grokky.Host{}
+	parsers.Povfwctx.Grok = grokky.Host{}
+	parsers.StageFiles = []Stagefile{}
+	parsers.PovfwStageFiles = []Stagefile{}
 	return parsers, nil
 }


### PR DESCRIPTION
Since parserctx is passed to all nodes and held in memory the GC will not auto cleanup the memory footprint so resetting manually saves around 40mb RAM in my production systems

Keep in mind this RAM saving is extreme in my case since im using both RE2 FF, for other users it would still be sizable but not this extreme