### PR TITLE
Remove "and exit." when showing list of commands when running cscli

### DIFF
--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -188,7 +188,7 @@ It is meant to allow you to manage bans, parsers/scenarios/etc, api and generall
 	/*usage*/
 	var cmdVersion = &cobra.Command{
 		Use:               "version",
-		Short:             "Display version and exit.",
+		Short:             "Display version",
 		Args:              cobra.ExactArgs(0),
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
![image](https://github.com/crowdsecurity/crowdsec/assets/67839982/ffaee1a3-df4f-46ed-b53f-f6a4b78bc514)
After version it says "Display version and exit.". 
I can't seem to see it necessary to have `and exit.`? Can it be removed?