### PR TITLE
CI: remove explicit cache-dependency-path

### DIFF
--- a/.github/workflows/bats-hub.yml
+++ b/.github/workflows/bats-hub.yml
@@ -37,7 +37,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-        cache-dependency-path: "**/go.sum"
 
     - name: "Install bats dependencies"
       env:

--- a/.github/workflows/bats-mysql.yml
+++ b/.github/workflows/bats-mysql.yml
@@ -44,7 +44,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-        cache-dependency-path: "**/go.sum"
 
     - name: "Install bats dependencies"
       env:

--- a/.github/workflows/bats-postgres.yml
+++ b/.github/workflows/bats-postgres.yml
@@ -53,7 +53,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-        cache-dependency-path: "**/go.sum"
 
     - name: "Install bats dependencies"
       env:

--- a/.github/workflows/bats-sqlite-coverage.yml
+++ b/.github/workflows/bats-sqlite-coverage.yml
@@ -34,7 +34,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-        cache-dependency-path: "**/go.sum"
 
     - name: "Install bats dependencies"
       env:

--- a/.github/workflows/ci-windows-build-msi.yml
+++ b/.github/workflows/ci-windows-build-msi.yml
@@ -40,7 +40,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-        cache-dependency-path: "**/go.sum"
 
     - name: Build
       run: make windows_installer BUILD_RE2_WASM=1

--- a/.github/workflows/go-tests-windows.yml
+++ b/.github/workflows/go-tests-windows.yml
@@ -39,7 +39,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-        cache-dependency-path: "**/go.sum"
 
     - name: Build
       run: |

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -120,7 +120,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-        cache-dependency-path: "**/go.sum"
 
     - name: Build and run tests, static
       run: |

--- a/.github/workflows/release_publish-package.yml
+++ b/.github/workflows/release_publish-package.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-          cache-dependency-path: "**/go.sum"
 
       - name: Build the binaries
         run: |


### PR DESCRIPTION
not required anymore after moving the plugins to cmd/