### PR TITLE
[feat] cscli explain --labels

### DIFF
--- a/cmd/crowdsec-cli/explain.go
+++ b/cmd/crowdsec-cli/explain.go
@@ -74,6 +74,11 @@ func runExplain(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	labels, err := flags.GetString("labels")
+	if err != nil {
+		return err
+	}
+
 	fileInfo, _ := os.Stdin.Stat()
 
 	if logType == "" || (logLine == "" && logFile == "" && dsn == "") {
@@ -149,7 +154,7 @@ func runExplain(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no acquisition (--file or --dsn) provided, can't run cscli test")
 	}
 
-	cmdArgs := []string{"-c", ConfigFilePath, "-type", logType, "-dsn", dsn, "-dump-data", dir, "-no-api"}
+	cmdArgs := []string{"-c", ConfigFilePath, "-type", logType, "-dsn", dsn, "-dump-data", dir, "-label", labels, "-no-api"}
 	crowdsecCmd := exec.Command(crowdsec, cmdArgs...)
 	output, err := crowdsecCmd.CombinedOutput()
 	if err != nil {
@@ -209,6 +214,7 @@ tail -n 5 myfile.log | cscli explain --type nginx -f -
 	flags.StringP("dsn", "d", "", "DSN to test")
 	flags.StringP("log", "l", "", "Log line to test")
 	flags.StringP("type", "t", "", "Type of the acquisition to test")
+	flags.String("labels", "", "Additional labels to add to the acquisition format (key:value,key2:value2)")
 	flags.BoolP("verbose", "v", false, "Display individual changes")
 	flags.Bool("failures", false, "Only show failed lines")
 	flags.Bool("only-successful-parsers", false, "Only show successful parsers")

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -138,11 +138,17 @@ func (l *labelsMap) String() string {
 }
 
 func (l labelsMap) Set(label string) error {
-	split := strings.Split(label, ":")
-	if len(split) != 2 {
-		return errors.Wrapf(errors.New("Bad Format"), "for Label '%s'", label)
+	if label == "" {
+		//Explain will pass empty string if no labels are provided
+		return nil
 	}
-	l[split[0]] = split[1]
+	for _, pair := range strings.Split(label, ",") {
+		split := strings.Split(pair, ":")
+		if len(split) != 2 {
+			return fmt.Errorf("invalid format for label '%s', must be key:value", pair)
+		}
+		l[split[0]] = split[1]
+	}
 	return nil
 }
 


### PR DESCRIPTION
Currently there is noway to use explain with docker and cri-logs this will now enable this feature

By allowing the user to pass `--labels` to the explain command they can inject new and needed variables to the `acquisition` labels here is an example of a cri-logs command

```
cscli explain --log '2023-09-09T10:36:44.52870427+02:00 stderr F [2023-09-09 10:36:44,527] [INFO] [paperless.auth] Login failed for user `fdsf` from private IP `192.168.252.5`.' --type containerd  --labels program:paperless-ngx -v
```

Also updates the `-label` parameters to handle multiple value by splitting on `,` as we normally do. Also if the user passes the flag and no value we just skip and do not error this is needed for explain as the flag is passed. We can do an elif statement but if user passes the flag and no value we can safely ignore it.