### PR TITLE
Fix PO expr whitelist

### DIFF
--- a/pkg/parser/node.go
+++ b/pkg/parser/node.go
@@ -226,7 +226,6 @@ func (n *Node) process(p *types.Event, ctx UnixParserCtx, expressionEnv map[stri
 			}
 			if out {
 				clog.Debugf("Event is whitelisted by expr, reason [%s]", n.Whitelist.Reason)
-				p.Whitelisted = true
 				isWhitelisted = true
 			}
 			hasWhitelist = true


### PR DESCRIPTION
In the newly released crowdsec 1.5.3 there is a change introduced by this PR https://github.com/crowdsecurity/crowdsec/pull/2439

I have a postoverflow whitelist that uses an expression that looks like this:
```
name: localwhitelists/whitelist_hungary
description: "Whitelist Hungarian IP addresses"
whitelist:
        reason: "Whitelisted country HU"
        expression:
            - evt.Overflow.Sources[evt.Overflow.Alert.Source.IP].Cn in ['HU']
```

It seems that when expressions are used in whitelists both isWhitelisted and p.Whitelisted is set to true, which causes the code to skip setting the whitelist on the overflow here

https://github.com/LaurenceJJones/crowdsec/blob/4f995bbd671e664a4aaa066f6e1c98c7b79b2552/pkg/parser/node.go#L247

Issue is caused because we set it earlier for expressions which shouldnt be the case

https://github.com/LaurenceJJones/crowdsec/blob/4f995bbd671e664a4aaa066f6e1c98c7b79b2552/pkg/parser/node.go#L229