### PR TITLE
cscli hubtest whitelist

### DIFF
--- a/pkg/hubtest/parser_assert.go
+++ b/pkg/hubtest/parser_assert.go
@@ -255,6 +255,12 @@ func (p *ParserAssert) AutoGenParserAssert() string {
 						ret += base + line
 					}
 				}
+				if result.Evt.Whitelisted {
+					ret += fmt.Sprintf(`results["%s"]["%s"][%d].Evt.Whitelisted == true`+"\n", stage, parser, pidx)
+					if result.Evt.WhitelistReason != "" {
+						ret += fmt.Sprintf(`results["%s"]["%s"][%d].Evt.WhitelistReason == "%s"`+"\n", stage, parser, pidx, Escape(result.Evt.WhitelistReason))
+					}
+				}
 			}
 		}
 	}

--- a/pkg/hubtest/parser_assert.go
+++ b/pkg/hubtest/parser_assert.go
@@ -255,11 +255,9 @@ func (p *ParserAssert) AutoGenParserAssert() string {
 						ret += base + line
 					}
 				}
-				if result.Evt.Whitelisted {
-					ret += fmt.Sprintf(`results["%s"]["%s"][%d].Evt.Whitelisted == true`+"\n", stage, parser, pidx)
-					if result.Evt.WhitelistReason != "" {
-						ret += fmt.Sprintf(`results["%s"]["%s"][%d].Evt.WhitelistReason == "%s"`+"\n", stage, parser, pidx, Escape(result.Evt.WhitelistReason))
-					}
+				ret += fmt.Sprintf(`results["%s"]["%s"][%d].Evt.Whitelisted == %t`+"\n", stage, parser, pidx, result.Evt.Whitelisted)
+				if result.Evt.WhitelistReason != "" {
+					ret += fmt.Sprintf(`results["%s"]["%s"][%d].Evt.WhitelistReason == "%s"`+"\n", stage, parser, pidx, Escape(result.Evt.WhitelistReason))
 				}
 			}
 		}


### PR DESCRIPTION
Add whitelist properties to the gen parser assert function so when crowdsec pulls in the file it can actually check those properties.

ONLY TESTED ON s02-enrich parsers for now as those are the one we have in the hub