### PR TITLE
[Explain] s02 can cause panic if empty

### DIFF
--- a/pkg/hubtest/parser_assert.go
+++ b/pkg/hubtest/parser_assert.go
@@ -316,12 +316,14 @@ func LoadParserDump(filepath string) (*ParserResults, error) {
 		stages = append(stages, k)
 	}
 	sort.Strings(stages)
-	/*the very last one is set to 'success' which is just a bool indicating if the line was successfully parsed*/
-	lastStage := stages[len(stages)-2]
-
-	//If last stage is empty, we can't check anything to warn the user
-	if len(pdump[lastStage]) == 0 {
-		return &pdump, nil
+	var lastStage string
+	//Loop over stages to find last successful one with at least one parser
+	for i := len(stages) - 2; i >= 0; i-- {
+		if len(pdump[stages[i]]) == 0 {
+			continue
+		}
+		lastStage = stages[i]
+		break
 	}
 	parsers := make([]string, 0, len(pdump[lastStage]))
 	for k := range pdump[lastStage] {

--- a/pkg/hubtest/parser_assert.go
+++ b/pkg/hubtest/parser_assert.go
@@ -319,11 +319,10 @@ func LoadParserDump(filepath string) (*ParserResults, error) {
 	var lastStage string
 	//Loop over stages to find last successful one with at least one parser
 	for i := len(stages) - 2; i >= 0; i-- {
-		if len(pdump[stages[i]]) == 0 {
-			continue
+		if len(pdump[stages[i]]) != 0 {
+			lastStage = stages[i]
+			break
 		}
-		lastStage = stages[i]
-		break
 	}
 	parsers := make([]string, 0, len(pdump[lastStage]))
 	for k := range pdump[lastStage] {

--- a/pkg/hubtest/parser_assert.go
+++ b/pkg/hubtest/parser_assert.go
@@ -319,6 +319,10 @@ func LoadParserDump(filepath string) (*ParserResults, error) {
 	/*the very last one is set to 'success' which is just a bool indicating if the line was successfully parsed*/
 	lastStage := stages[len(stages)-2]
 
+	//If last stage is empty, we can't check anything to warn the user
+	if len(pdump[lastStage]) == 0 {
+		return &pdump, nil
+	}
 	parsers := make([]string, 0, len(pdump[lastStage]))
 	for k := range pdump[lastStage] {
 		parsers = append(parsers, k)


### PR DESCRIPTION
User reported running `cscli explain` on a log line that never enter `s02-enrich` causes to panic since we try to "access" to last parser and if the parser is null it panics

```
panic: runtime error: index out of range [-1]
 
goroutine 1 [running]:
github.com/crowdsecurity/crowdsec/pkg/hubtest.LoadParserDump({0xc000351f80, 0x2c})
        github.com/crowdsecurity/crowdsec/pkg/hubtest/parser_assert.go:323 +0x891
main.runExplain(0xc000542600?, {0xc000139780?, 0x4?, 0x4?})
        github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/explain.go:178 +0xb9e
github.com/spf13/cobra.(*Command).execute(0xc000542600, {0xc000139740, 0x4, 0x4})
        github.com/spf13/cobra@v1.7.0/command.go:940 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc000004f00)
        github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.7.0/command.go:992
main.main()
        github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/main.go:267 +0xe69
```

This PR patches this to check if event ever made it to enrich stage if not we dont care about telling them about str.EvtTime