### PR TITLE
"cscli bouncers add": increase key size, deprecate and ignore --length option 

### DIFF
--- a/test/bats/10_bouncers.bats
+++ b/test/bats/10_bouncers.bats
@@ -36,6 +36,18 @@ teardown() {
     assert_output '[]'
 }
 
+@test "we can create a bouncer with a known key" {
+    # also test the output formats since we know the key
+    rune -0 cscli bouncers add ciTestBouncer --key "foobarbaz" -o human
+    assert_output --partial 'foobarbaz'
+    rune -0 cscli bouncers delete ciTestBouncer
+    rune -0 cscli bouncers add ciTestBouncer --key "foobarbaz" -o json
+    assert_output '"foobarbaz"'
+    rune -0 cscli bouncers delete ciTestBouncer
+    rune -0 cscli bouncers add ciTestBouncer --key "foobarbaz" -o raw
+    assert_output foobarbaz
+}
+
 @test "we can't add the same bouncer twice" {
     rune -0 cscli bouncers add ciTestBouncer
     rune -1 cscli bouncers add ciTestBouncer -o json


### PR DESCRIPTION
the switch to base64 made the keys shorter (24 characters), this PR increases their size to 32 bytes, 42 chars once encoded

Also deprecate the --length option, users can already provide a key