### PR TITLE
pkg/csconfig: set prometheus address:port defaults

### DIFF
--- a/cmd/crowdsec-cli/metrics.go
+++ b/cmd/crowdsec-cli/metrics.go
@@ -306,7 +306,7 @@ func runMetrics(cmd *cobra.Command, args []string) error {
 
 	err := FormatPrometheusMetrics(color.Output, prometheusURL+"/metrics", csConfig.Cscli.Output)
 	if err != nil {
-		return fmt.Errorf("could not fetch prometheus metrics: %w", err)
+		return err
 	}
 	return nil
 }

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -214,13 +214,7 @@ func InspectItem(name string, objecitemType string) {
 		//This is technically wrong to do this, as the prometheus section contains a listen address, not an URL to query prometheus
 		//But for ease of use, we will use the listen address as the prometheus URL because it will be 127.0.0.1 in the default case
 		listenAddr := csConfig.Prometheus.ListenAddr
-		if listenAddr == "" {
-			listenAddr = "127.0.0.1"
-		}
 		listenPort := csConfig.Prometheus.ListenPort
-		if listenPort == 0 {
-			listenPort = 6060
-		}
 		prometheusURL = fmt.Sprintf("http://%s:%d/metrics", listenAddr, listenPort)
 		log.Debugf("No prometheus URL provided using: %s", prometheusURL)
 	}

--- a/cmd/crowdsec/metrics.go
+++ b/cmd/crowdsec/metrics.go
@@ -151,14 +151,6 @@ func registerPrometheus(config *csconfig.PrometheusCfg) {
 	if !config.Enabled {
 		return
 	}
-	if config.ListenAddr == "" {
-		log.Warning("prometheus is enabled, but the listen address is empty, using '127.0.0.1'")
-		config.ListenAddr = "127.0.0.1"
-	}
-	if config.ListenPort == 0 {
-		log.Warning("prometheus is enabled, but the listen port is empty, using '6060'")
-		config.ListenPort = 6060
-	}
 
 	// Registering prometheus
 	// If in aggregated mode, do not register events associated with a source, to keep the cardinality low

--- a/pkg/csconfig/config.go
+++ b/pkg/csconfig/config.go
@@ -58,6 +58,21 @@ func NewConfig(configFile string, disableAgent bool, disableAPI bool, quiet bool
 		// this is actually the "merged" yaml
 		return nil, "", fmt.Errorf("%s: %w", configFile, err)
 	}
+
+	if cfg.Prometheus == nil {
+		cfg.Prometheus = &PrometheusCfg{}
+	}
+
+	if cfg.Prometheus.ListenAddr == "" {
+		cfg.Prometheus.ListenAddr = "127.0.0.1"
+		log.Debugf("prometheus.listen_addr is empty, defaulting to %s", cfg.Prometheus.ListenAddr)
+	}
+
+	if cfg.Prometheus.ListenPort == 0 {
+		cfg.Prometheus.ListenPort = 6060
+		log.Debugf("prometheus.listen_port is empty or zero, defaulting to %d", cfg.Prometheus.ListenPort)
+	}
+
 	return &cfg, configData, nil
 }
 

--- a/test/bats/08_metrics.bats
+++ b/test/bats/08_metrics.bats
@@ -25,8 +25,7 @@ teardown() {
 @test "cscli metrics (crowdsec not running)" {
     rune -1 cscli metrics
     # crowdsec is down
-    assert_stderr --partial "failed to fetch prometheus metrics"
-    assert_stderr --partial "connect: connection refused"
+    assert_stderr --partial 'failed to fetch prometheus metrics: executing GET request for URL \"http://127.0.0.1:6060/metrics\" failed: Get \"http://127.0.0.1:6060/metrics\": dial tcp 127.0.0.1:6060: connect: connection refused'
 }
 
 @test "cscli metrics (bad configuration)" {
@@ -43,18 +42,20 @@ teardown() {
 
 @test "cscli metrics (missing listen_addr)" {
     config_set 'del(.prometheus.listen_addr)'
-    rune -1 cscli metrics
-    assert_stderr --partial "no prometheus url, please specify"
+    rune -0 ./instance-crowdsec start
+    rune -0 cscli metrics --debug
+    assert_stderr --partial "prometheus.listen_addr is empty, defaulting to 127.0.0.1"
 }
 
 @test "cscli metrics (missing listen_port)" {
-    config_set 'del(.prometheus.listen_addr)'
-    rune -1 cscli metrics
-    assert_stderr --partial "no prometheus url, please specify"
+    config_set 'del(.prometheus.listen_port)'
+    rune -0 ./instance-crowdsec start
+    rune -0 cscli metrics --debug
+    assert_stderr --partial "prometheus.listen_port is empty or zero, defaulting to 6060"
 }
 
 @test "cscli metrics (missing prometheus section)" {
     config_set 'del(.prometheus)'
     rune -1 cscli metrics
-    assert_stderr --partial "prometheus section missing, can't show metrics"
+    assert_stderr --partial "prometheus is not enabled, can't show metrics"
 }


### PR DESCRIPTION
We should set these default in one place (after loading the configuration) instead of leaving that to both metric server and consumer.