### PR TITLE
[hubtest] escape scenario assert meta keys

### DIFF
--- a/pkg/hubtest/scenario_assert.go
+++ b/pkg/hubtest/scenario_assert.go
@@ -205,7 +205,7 @@ func (s *ScenarioAssert) AutoGenScenarioAssert() string {
 		}
 		for evtIndex, evt := range event.Overflow.Alert.Events {
 			for _, meta := range evt.Meta {
-				ret += fmt.Sprintf(`results[%d].Overflow.Alert.Events[%d].GetMeta("%s") == "%s"`+"\n", eventIndex, evtIndex, meta.Key, meta.Value)
+				ret += fmt.Sprintf(`results[%d].Overflow.Alert.Events[%d].GetMeta("%s") == "%s"`+"\n", eventIndex, evtIndex, meta.Key, Escape(meta.Value))
 			}
 		}
 		ret += fmt.Sprintf(`results[%d].Overflow.Alert.GetScenario() == "%s"`+"\n", eventIndex, *event.Overflow.Alert.Scenario)


### PR DESCRIPTION
Whilst working on [issue](https://github.com/crowdsecurity/hub/issues/855)

I found we do not escape meta keys passed into scenario.assert so some values may cause it to never be able to compare, this PR fixes this

```
(L.100)  🔴  => results[0].Overflow.Alert.Events[10].GetMeta("http_path") == "A\x00\x00\x00\x03fH\xBBd~\x8E\xFC\x94g\xD2\xDB\xFC\xEE\x8D\xFF\x98 \xB1\xBET\xA4\x9AZ\x9A\xA0?\x90\xE0\xF2t0\x5C\xED\xAE\xACX\x98\xDEJ\xEC\xF2\xC8\x9Cl\xD0\x9C\xC0\xE0\x98\x12\x8F\xE7\xCB\x8F\xA1\xA3\x16\xF1J\xA9<\xBD\xDA`"
Actual expression values:
results[0].Overflow.Alert.Events[10].GetMeta("http_path") = 'A\x00\x00\x00\x03fH\xBBd~\x8E\xFC\x94g\xD2\xDB\xFC\xEE\x8D\xFF\x98 \xB1\xBET\xA4\x9AZ\x9A\xA0?\x90\xE0\xF2t0\x5C\xED\xAE\xACX\x98\xDEJ\xEC\xF2\xC8\x9Cl\xD0\x9C\xC0\xE0\x98\x12\x8F\xE7\xCB\x8F\xA1\xA3\x16\xF1J\xA9<\xBD\xDA`'
```