### PR TITLE
default "cscli machines add" to write credentials to stdout, require explicit path to overwrite local_api_credentials.yaml

### DIFF
--- a/cmd/crowdsec-cli/config_restore.go
+++ b/cmd/crowdsec-cli/config_restore.go
@@ -215,7 +215,7 @@ func restoreConfigFromDirectory(dirPath string, oldBackup bool) error {
 			if csConfig.API.Server.OnlineClient != nil && csConfig.API.Server.OnlineClient.CredentialsFilePath != "" {
 				apiConfigDumpFile = csConfig.API.Server.OnlineClient.CredentialsFilePath
 			}
-			err = os.WriteFile(apiConfigDumpFile, apiConfigDump, 0o644)
+			err = os.WriteFile(apiConfigDumpFile, apiConfigDump, 0o600)
 			if err != nil {
 				return fmt.Errorf("write api credentials in '%s' failed: %s", apiConfigDumpFile, err)
 			}

--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -149,7 +149,7 @@ func runLapiRegister(cmd *cobra.Command, args []string) error {
 		log.Fatalf("unable to marshal api credentials: %s", err)
 	}
 	if dumpFile != "" {
-		err = os.WriteFile(dumpFile, apiConfigDump, 0644)
+		err = os.WriteFile(dumpFile, apiConfigDump, 0o600)
 		if err != nil {
 			log.Fatalf("write api credentials in '%s' failed: %s", dumpFile, err)
 		}

--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -290,7 +290,7 @@ func runMachinesAdd(cmd *cobra.Command, args []string) error {
 	if dumpFile == "" {
 		fmt.Printf("%s\n", string(apiConfigDump))
 	} else {
-		err = os.WriteFile(dumpFile, apiConfigDump, 0644)
+		err = os.WriteFile(dumpFile, apiConfigDump, 0o600)
 		if err != nil {
 			return fmt.Errorf("writing api credentials to '%s': %s", dumpFile, err)
 		}

--- a/test/bats/30_machines.bats
+++ b/test/bats/30_machines.bats
@@ -13,6 +13,7 @@ teardown_file() {
 
 setup() {
     load "../lib/setup.sh"
+    load "../lib/bats-file/load.bash"
     ./instance-data load
     ./instance-crowdsec start
 }
@@ -46,11 +47,12 @@ teardown() {
     rune -0 yq -o json . <(output)
     assert_json '{login: "testmachine2", password: "testpassword", url: "http://127.0.0.1:8080"}'
 
-    tempfile="${BATS_TEST_DIRNAME}/testmachine.yml"
+    tempfile="${BATS_TEST_TMPDIR}/testmachine.yml"
     rune -0 cscli machines add testmachine3 --password testpassword -f "${tempfile}"
     assert_stderr --partial "API credentials dumped to '${tempfile}'"
     rune -0 yq -o json . < "$tempfile"
     assert_json '{login: "testmachine3", password: "testpassword", url: "http://127.0.0.1:8080"}'
+    assert_file_permission 600 "$tempfile"
 }
 
 @test "add a new machine and delete it" {


### PR DESCRIPTION
Draft until we decide a deprecation path, if the change is accepted.

Notably, the installation scripts have to be updated before this change goes into effect.