### PR TITLE
Iterate over sub-items in Remove(), not in disable() -- fix mutual dependency issue

### DIFF
--- a/pkg/cwhub/cwhub.go
+++ b/pkg/cwhub/cwhub.go
@@ -10,5 +10,5 @@ import (
 )
 
 var hubClient = &http.Client{
-	Timeout: 20 * time.Second,
+	Timeout: 120 * time.Second,
 }

--- a/pkg/cwhub/enable.go
+++ b/pkg/cwhub/enable.go
@@ -146,35 +146,10 @@ func (i *Item) removeInstallLink() error {
 // disable removes the symlink to the downloaded content, also removes the content if purge is true
 func (i *Item) disable(purge bool, force bool) error {
 	// XXX: should return the number of disabled/purged items to inform the upper layer whether to reload or not
-	if i.IsLocal() {
-		return fmt.Errorf("%s isn't managed by hub. Please delete manually", i.Name)
-	}
-
-	if i.Tainted && !force {
-		return fmt.Errorf("%s is tainted, use '--force' to overwrite", i.Name)
-	}
-
-	for _, sub := range i.SubItems() {
-		// TODO XXX: if the other collection(s) are direct or indirect dependencies of the current one, it's good to go
-		if len(sub.BelongsToCollections) > 1 {
-			log.Infof("%s was not removed because it belongs to another collection", sub.Name)
-			continue
-		}
-
-		if err := sub.disable(purge, force); err != nil {
-			return fmt.Errorf("while disabling %s: %w", sub.Name, err)
-		}
-	}
-
-	if !i.Installed && !purge {
-		log.Infof("removing %s: not installed -- no need to remove", i.Name)
-		return nil
-	}
-
 	err := i.removeInstallLink()
 	if os.IsNotExist(err) {
 		if !purge && !force {
-			return fmt.Errorf("can't disable %s: %s doesn't exist", i.Name, i.installLink())
+			return fmt.Errorf("link %s does not exist (override with --force or --purge)", i.installLink())
 		}
 	} else if err != nil {
 		return err

--- a/pkg/cwhub/items.go
+++ b/pkg/cwhub/items.go
@@ -186,6 +186,21 @@ func (i *Item) logMissingSubItems() {
 	}
 }
 
+func (i *Item) parentCollections() []*Item {
+	ret := make([]*Item, 0)
+
+	for _, parentName := range i.BelongsToCollections {
+		parent := i.hub.GetItem(COLLECTIONS, parentName)
+		if parent == nil {
+			continue
+		}
+
+		ret = append(ret, parent)
+	}
+
+	return ret
+}
+
 // Status returns the status of the item as a string and an emoji
 // ie. "enabled,update-available" and emoji.Warning
 func (i *Item) Status() (string, emoji.Emoji) {

--- a/pkg/cwhub/sync.go
+++ b/pkg/cwhub/sync.go
@@ -393,6 +393,8 @@ func (h *Hub) syncDir(dir string) ([]string, error) {
 
 	// For each, scan PARSERS, POSTOVERFLOWS, SCENARIOS and COLLECTIONS last
 	for _, scan := range ItemTypes {
+		// cpath: top-level item directory, either downloaded or installed items.
+		// i.e. /etc/crowdsec/parsers, /etc/crowdsec/hub/parsers, ...
 		cpath, err := filepath.Abs(fmt.Sprintf("%s/%s", dir, scan))
 		if err != nil {
 			log.Errorf("failed %s: %s", cpath, err)

--- a/test/bats/20_hub_items.bats
+++ b/test/bats/20_hub_items.bats
@@ -80,7 +80,7 @@ teardown() {
     rune -0 rm "$(output)"
 
     rune -0 cscli parsers remove crowdsecurity/syslog-logs --debug
-    assert_stderr --partial "Removed crowdsecurity/syslog-logs"
+    assert_stderr --partial "removing crowdsecurity/syslog-logs: not installed -- no need to remove"
 
     rune -0 cscli parsers inspect crowdsecurity/syslog-logs -o json
     rune -0 jq -r '.path' <(output)


### PR DESCRIPTION
When two collections share a parser and one is a sub-collection of the other, removing the parent collection leaves the parser installed. This PR attempts to fix the issue, with a regression test.