### PR TITLE
docker: replace cp -an with rsync to allow bind-mount of files in /etc/crowdsec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN make clean release DOCKER_BUILD=1 BUILD_STATIC=1 && \
 
 FROM alpine:latest as slim
 
-RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community tzdata bash && \
+RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community tzdata bash rsync && \
     mkdir -p /staging/etc/crowdsec && \
     mkdir -p /staging/etc/crowdsec/acquis.d && \
     mkdir -p /staging/var/lib/crowdsec && \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -47,7 +47,8 @@ RUN apt-get update && \
     iproute2 \
     ca-certificates \
     bash \
-    tzdata && \
+    tzdata \
+    rsync && \
     mkdir -p /staging/etc/crowdsec && \
     mkdir -p /staging/etc/crowdsec/acquis.d && \
     mkdir -p /staging/var/lib/crowdsec && \

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -174,7 +174,7 @@ if [ ! -e "/etc/crowdsec/local_api_credentials.yaml" ] && [ ! -e "/etc/crowdsec/
         mkdir -p /etc/crowdsec/
         # if you change this, check that it still works
         # under alpine and k8s, with and without tls
-        cp -an /staging/etc/crowdsec/* /etc/crowdsec/
+        rsync -av --ignore-existing /staging/etc/crowdsec/* /etc/crowdsec
     fi
 fi
 

--- a/docker/test/tests/test_local_item.py
+++ b/docker/test/tests/test_local_item.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+"""
+Test bind-mounting local items
+"""
+
+from http import HTTPStatus
+import json
+
+import pytest
+
+pytestmark = pytest.mark.docker
+
+
+def test_inject_local_item(crowdsec, tmp_path_factory, flavor):
+    """Test mounting a custom whitelist at startup"""
+
+    localitems = tmp_path_factory.mktemp('localitems')
+    custom_whitelists = localitems / 'custom_whitelists.yaml'
+
+    with open(custom_whitelists, 'w') as f:
+        f.write('{"whitelist":{"reason":"Good IPs","ip":["1.2.3.4"]}}')
+
+    volumes = {
+        custom_whitelists: {'bind': '/etc/crowdsec/parsers/s02-enrich/custom_whitelists.yaml'}
+    }
+
+    with crowdsec(flavor=flavor, volumes=volumes) as cs:
+        cs.wait_for_log([
+            "*Starting processing data*"
+        ])
+        cs.wait_for_http(8080, '/health', want_status=HTTPStatus.OK)
+
+        # the parser should be enabled
+        res = cs.cont.exec_run('cscli parsers list -o json')
+        assert res.exit_code == 0
+        j = json.loads(res.output)
+        items = {c['name']: c for c in j['parsers']}
+        assert items['custom_whitelists.yaml']['status'] == 'enabled,local'
+
+        # regression test: the linux collection should not be tainted
+        # (the parsers were not copied from /staging when using "cp -an" with local parsers)
+        res = cs.cont.exec_run('cscli collections inspect crowdsecurity/linux -o json')
+        assert res.exit_code == 0
+        j = json.loads(res.output)
+        # crowdsec <= 1.5.5 omits a "tainted" when it's false
+        assert j.get('tainted', False) is False


### PR DESCRIPTION
For https://github.com/crowdsecurity/crowdsec/issues/2480

The alternative - without this change - is to mount inside /staging/etc/crowdsec instead of /etc/crowdsec