### PR TITLE
cscli machines add: don't overwrite existing credential file

### DIFF
--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -110,7 +110,7 @@ func NewCapiRegisterCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("write api credentials in '%s' failed: %w", dumpFile, err)
 				}
-				log.Printf("Central API credentials dumped to '%s'", dumpFile)
+				log.Printf("Central API credentials written to '%s'", dumpFile)
 			} else {
 				fmt.Printf("%s\n", string(apiConfigDump))
 			}

--- a/cmd/crowdsec-cli/config_restore.go
+++ b/cmd/crowdsec-cli/config_restore.go
@@ -183,7 +183,7 @@ func restoreConfigFromDirectory(dirPath string, oldBackup bool) error {
 			if csConfig.API.Server.OnlineClient != nil && csConfig.API.Server.OnlineClient.CredentialsFilePath != "" {
 				apiConfigDumpFile = csConfig.API.Server.OnlineClient.CredentialsFilePath
 			}
-			err = os.WriteFile(apiConfigDumpFile, apiConfigDump, 0o644)
+			err = os.WriteFile(apiConfigDumpFile, apiConfigDump, 0o600)
 			if err != nil {
 				return fmt.Errorf("write api credentials in '%s' failed: %s", apiConfigDumpFile, err)
 			}

--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -150,11 +150,11 @@ func runLapiRegister(cmd *cobra.Command, args []string) error {
 		log.Fatalf("unable to marshal api credentials: %s", err)
 	}
 	if dumpFile != "" {
-		err = os.WriteFile(dumpFile, apiConfigDump, 0644)
+		err = os.WriteFile(dumpFile, apiConfigDump, 0o600)
 		if err != nil {
 			log.Fatalf("write api credentials in '%s' failed: %s", dumpFile, err)
 		}
-		log.Printf("Local API credentials dumped to '%s'", dumpFile)
+		log.Printf("Local API credentials written to '%s'", dumpFile)
 	} else {
 		fmt.Printf("%s\n", string(apiConfigDump))
 	}

--- a/cmd/crowdsec-cli/machines.go
+++ b/cmd/crowdsec-cli/machines.go
@@ -220,7 +220,7 @@ func runMachinesAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	forceAdd, err := flags.GetBool("force")
+	force, err := flags.GetBool("force")
 	if err != nil {
 		return err
 	}
@@ -247,12 +247,12 @@ func runMachinesAdd(cmd *cobra.Command, args []string) error {
 		// use the default only if the file does not exist
 		_, err := os.Stat(credFile)
 		switch {
-		case os.IsNotExist(err):
+		case os.IsNotExist(err) || force:
 			dumpFile = csConfig.API.Client.CredentialsFilePath
 		case err != nil:
 			return fmt.Errorf("unable to stat '%s': %s", credFile, err)
 		default:
-			return fmt.Errorf(`credentials file '%s' already exists, please remove it or specify a different file with -f ("-f -" for standard output)`, credFile)
+			return fmt.Errorf(`credentials file '%s' already exists: please remove it, use "--force" or specify a different file with "-f" ("-f -" for standard output)`, credFile)
 		}
 	}
 
@@ -273,7 +273,7 @@ func runMachinesAdd(cmd *cobra.Command, args []string) error {
 		survey.AskOne(qs, &machinePassword)
 	}
 	password := strfmt.Password(machinePassword)
-	_, err = dbClient.CreateMachine(&machineID, &password, "", true, forceAdd, types.PasswordAuthType)
+	_, err = dbClient.CreateMachine(&machineID, &password, "", true, force, types.PasswordAuthType)
 	if err != nil {
 		return fmt.Errorf("unable to create machine: %s", err)
 	}

--- a/test/bats/30_machines.bats
+++ b/test/bats/30_machines.bats
@@ -23,20 +23,23 @@ teardown() {
 
 #----------
 
-@test "can list machines as regular user" {
-    rune -0 cscli machines list
-}
-
 @test "we have exactly one machine" {
     rune -0 cscli machines list -o json
     rune -0 jq -c '[. | length, .[0].machineId[0:32], .[0].isValidated]' <(output)
     assert_output '[1,"githubciXXXXXXXXXXXXXXXXXXXXXXXX",true]'
 }
 
+@test "don't overwrite local credentials" {
+    rune -1 cscli machines add -a
+    local_credentials=$(config_get '.api.client.credentials_path')
+    assert_stderr --partial "credentials file '$local_credentials' already exists, please remove it or specify a different file with -f"
+    refute_output
+}
+
 @test "add a new machine and delete it" {
     rune -0 cscli machines add -a -f /dev/null CiTestMachine -o human
     assert_stderr --partial "Machine 'CiTestMachine' successfully added to the local API"
-    assert_stderr --partial "API credentials dumped to '/dev/null'"
+    assert_stderr --partial "API credentials written to '/dev/null'"
 
     # we now have two machines
     rune -0 cscli machines list -o json
@@ -56,7 +59,7 @@ teardown() {
 @test "register, validate and then remove a machine" {
     rune -0 cscli lapi register --machine CiTestMachineRegister -f /dev/null -o human
     assert_stderr --partial "Successfully registered to Local API (LAPI)"
-    assert_stderr --partial "Local API credentials dumped to '/dev/null'"
+    assert_stderr --partial "Local API credentials written to '/dev/null'"
 
     # the machine is not validated yet
     rune -0 cscli machines list -o json

--- a/test/bats/30_machines.bats
+++ b/test/bats/30_machines.bats
@@ -29,11 +29,12 @@ teardown() {
     assert_output '[1,"githubciXXXXXXXXXXXXXXXXXXXXXXXX",true]'
 }
 
-@test "don't overwrite local credentials" {
-    rune -1 cscli machines add -a
-    local_credentials=$(config_get '.api.client.credentials_path')
-    assert_stderr --partial "credentials file '$local_credentials' already exists, please remove it or specify a different file with -f"
-    refute_output
+@test "don't overwrite local credentials by default" {
+    rune -1 cscli machines add local -a -o json
+    rune -0 jq -r '.msg' <(stderr)
+    assert_output --partial 'already exists: please remove it, use "--force" or specify a different file with "-f"'
+    rune -0 cscli machines add local -a --force
+    assert_stderr --partial "Machine 'local' successfully added to the local API"
 }
 
 @test "add a new machine and delete it" {

--- a/test/lib/config/config-global
+++ b/test/lib/config/config-global
@@ -66,7 +66,7 @@ make_init_data() {
 
     ./bin/preload-hub-items
 
-    [[ "${DB_BACKEND}" == "sqlite" ]] || ${CSCLI} machines add --auto
+    [[ "${DB_BACKEND}" == "sqlite" ]] || ${CSCLI} machines add --auto -f "$($CSCLI config show --key Config.API.Client.CredentialsFilePath)"
 
     mkdir -p "$LOCAL_INIT_DIR"
 

--- a/test/lib/config/config-global
+++ b/test/lib/config/config-global
@@ -61,12 +61,12 @@ make_init_data() {
     ./instance-db config-yaml
     ./instance-db setup
 
+    ./bin/preload-hub-items
+
     # when installed packages are always using sqlite, so no need to regenerate
     # local credz for sqlite
 
-    ./bin/preload-hub-items
-
-    [[ "${DB_BACKEND}" == "sqlite" ]] || ${CSCLI} machines add --auto -f "$($CSCLI config show --key Config.API.Client.CredentialsFilePath)"
+    [[ "${DB_BACKEND}" == "sqlite" ]] || ${CSCLI} machines add githubciXXXXXXXXXXXXXXXXXXXXXXXX --auto --force
 
     mkdir -p "$LOCAL_INIT_DIR"
 

--- a/test/lib/config/config-local
+++ b/test/lib/config/config-local
@@ -115,10 +115,11 @@ make_init_data() {
     ./instance-db config-yaml
     ./instance-db setup
 
-    "$CSCLI" --warning machines add githubciXXXXXXXXXXXXXXXXXXXXXXXX --auto -f "$($CSCLI config show --key Config.API.Client.CredentialsFilePath)"
     "$CSCLI" --warning hub update
 
     ./bin/preload-hub-items
+
+    "$CSCLI" --warning machines add githubciXXXXXXXXXXXXXXXXXXXXXXXX --auto --force
 
     mkdir -p "$LOCAL_INIT_DIR"
 

--- a/test/lib/config/config-local
+++ b/test/lib/config/config-local
@@ -115,7 +115,7 @@ make_init_data() {
     ./instance-db config-yaml
     ./instance-db setup
 
-    "$CSCLI" --warning machines add githubciXXXXXXXXXXXXXXXXXXXXXXXX --auto
+    "$CSCLI" --warning machines add githubciXXXXXXXXXXXXXXXXXXXXXXXX --auto -f "$($CSCLI config show --key Config.API.Client.CredentialsFilePath)"
     "$CSCLI" --warning hub update
 
     ./bin/preload-hub-items


### PR DESCRIPTION
Simpler alternative to https://github.com/crowdsecurity/crowdsec/pull/2594
to fix https://github.com/crowdsecurity/crowdsec/issues/2567

The command returns with an error if a file is not specified and the local credentials file already exists. Explicitly providing a path will happily overwrite. Using --force will also overwrite.