### PR TITLE
cwhub: context type

### DIFF
--- a/cmd/crowdsec-cli/hubcontext.go
+++ b/cmd/crowdsec-cli/hubcontext.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
+)
+
+func NewContextCLI() *itemCLI {
+	return &itemCLI{
+		name:      cwhub.CONTEXTS,
+		singular:  "context",
+		oneOrMore: "context(s)",
+		help: cliHelp{
+			example: `cscli contexts list -a
+cscli contexts install crowdsecurity/yyy crowdsecurity/zzz
+cscli contexts inspect crowdsecurity/yyy crowdsecurity/zzz
+cscli contexts upgrade crowdsecurity/yyy crowdsecurity/zzz
+cscli contexts remove crowdsecurity/yyy crowdsecurity/zzz
+`,
+		},
+		installHelp: cliHelp{
+			example: `cscli contexts install crowdsecurity/yyy crowdsecurity/zzz`,
+		},
+		removeHelp: cliHelp{
+			example: `cscli contexts remove crowdsecurity/yyy crowdsecurity/zzz`,
+		},
+		upgradeHelp: cliHelp{
+			example: `cscli contexts upgrade crowdsecurity/yyy crowdsecurity/zzz`,
+		},
+		inspectHelp: cliHelp{
+			example: `cscli contexts inspect crowdsecurity/yyy crowdsecurity/zzz`,
+		},
+		listHelp: cliHelp{
+			example: `cscli contexts list
+cscli contexts list -a
+cscli contexts list crowdsecurity/yyy crowdsecurity/zzz
+
+List only enabled contexts unless "-a" or names are specified.`,
+		},
+	}
+}

--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -270,6 +270,15 @@ cscli lapi context add --value evt.Meta.source_ip --value evt.Meta.target_user
 		`,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			hub, err := require.Hub(csConfig, nil)
+			if err != nil {
+				return err
+			}
+
+			if err = alertcontext.LoadConsoleContext(csConfig, hub); err != nil {
+				return fmt.Errorf("while loading context: %w", err)
+			}
+
 			if keyToAdd != "" {
 				if err := AddContext(keyToAdd, valuesToAdd); err != nil {
 					return err
@@ -299,6 +308,15 @@ cscli lapi context add --value evt.Meta.source_ip --value evt.Meta.target_user
 		Short:             "List context to send with alerts",
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			hub, err := require.Hub(csConfig, nil)
+			if err != nil {
+				return err
+			}
+
+			if err = alertcontext.LoadConsoleContext(csConfig, hub); err != nil {
+				return fmt.Errorf("while loading context: %w", err)
+			}
+
 			if len(csConfig.Crowdsec.ContextToSend) == 0 {
 				fmt.Println("No context found on this agent. You can use 'cscli lapi context add' to add context to your alerts.")
 				return nil
@@ -309,7 +327,7 @@ cscli lapi context add --value evt.Meta.source_ip --value evt.Meta.target_user
 				return fmt.Errorf("unable to show context status: %w", err)
 			}
 
-			fmt.Println(string(dump))
+			fmt.Print(string(dump))
 
 			return nil
 		},
@@ -413,6 +431,12 @@ cscli lapi context delete --value evt.Line.Src
 		`,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// pass a nil hub to load only from console/context.yaml
+
+			if err := alertcontext.LoadConsoleContext(csConfig, nil); err != nil {
+				return fmt.Errorf("while loading context: %w", err)
+			}
+
 			if len(keysToDelete) == 0 && len(valuesToDelete) == 0 {
 				return errors.New("please provide at least a key or a value to delete")
 			}

--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -421,61 +421,10 @@ cscli lapi context detect crowdsecurity/sshd-logs
 	cmdContextDetect.Flags().BoolVarP(&detectAll, "all", "a", false, "Detect evt field for all installed parser")
 	cmdContext.AddCommand(cmdContextDetect)
 
-	var keysToDelete []string
-	var valuesToDelete []string
 	cmdContextDelete := &cobra.Command{
 		Use:   "delete",
-		Short: "Delete context to send with alerts",
-		Example: `cscli lapi context delete --key source_ip
-cscli lapi context delete --value evt.Line.Src
-		`,
-		DisableAutoGenTag: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// pass a nil hub to load only from console/context.yaml
-
-			if err := alertcontext.LoadConsoleContext(csConfig, nil); err != nil {
-				return fmt.Errorf("while loading context: %w", err)
-			}
-
-			if len(keysToDelete) == 0 && len(valuesToDelete) == 0 {
-				return errors.New("please provide at least a key or a value to delete")
-			}
-
-			for _, key := range keysToDelete {
-				if _, ok := csConfig.Crowdsec.ContextToSend[key]; ok {
-					delete(csConfig.Crowdsec.ContextToSend, key)
-					log.Infof("key '%s' has been removed", key)
-				} else {
-					log.Warningf("key '%s' doesn't exist", key)
-				}
-			}
-
-			for _, value := range valuesToDelete {
-				valueFound := false
-				for key, context := range csConfig.Crowdsec.ContextToSend {
-					if slices.Contains(context, value) {
-						valueFound = true
-						csConfig.Crowdsec.ContextToSend[key] = removeFromSlice(value, context)
-						log.Infof("value '%s' has been removed from key '%s'", value, key)
-					}
-					if len(csConfig.Crowdsec.ContextToSend[key]) == 0 {
-						delete(csConfig.Crowdsec.ContextToSend, key)
-					}
-				}
-				if !valueFound {
-					log.Warningf("value '%s' not found", value)
-				}
-			}
-
-			if err := csConfig.Crowdsec.DumpContextConfigFile(); err != nil {
-				return err
-			}
-
-			return nil
-		},
+		Deprecated: "please manually edit the context file.",
 	}
-	cmdContextDelete.Flags().StringSliceVarP(&keysToDelete, "key", "k", []string{}, "The keys to delete")
-	cmdContextDelete.Flags().StringSliceVar(&valuesToDelete, "value", []string{}, "The expr fields to delete")
 	cmdContext.AddCommand(cmdContextDelete)
 
 	return cmdContext

--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -93,9 +93,10 @@ func initConfig() {
 }
 
 var validArgs = []string{
-	"scenarios", "parsers", "collections", "capi", "contexts", "lapi", "postoverflows", "machines",
-	"metrics", "bouncers", "alerts", "decisions", "simulation", "hub", "dashboard",
-	"config", "completion", "version", "console", "notifications", "support",
+	"alerts", "appsec-configs", "appsec-rules", "bouncers", "capi", "collections",
+	"completion", "config", "console", "contexts", "dashboard", "decisions", "explain",
+	"hub", "hubtest", "lapi", "machines", "metrics", "notifications", "parsers",
+	"postoverflows", "scenarios", "simulation", "support", "version",
 }
 
 func prepender(filename string) string {

--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -93,7 +93,7 @@ func initConfig() {
 }
 
 var validArgs = []string{
-	"scenarios", "parsers", "collections", "capi", "lapi", "postoverflows", "machines",
+	"scenarios", "parsers", "collections", "capi", "contexts", "lapi", "postoverflows", "machines",
 	"metrics", "bouncers", "alerts", "decisions", "simulation", "hub", "dashboard",
 	"config", "completion", "version", "console", "notifications", "support",
 }
@@ -246,6 +246,7 @@ It is meant to allow you to manage bans, parsers/scenarios/etc, api and generall
 	rootCmd.AddCommand(NewParserCLI().NewCommand())
 	rootCmd.AddCommand(NewScenarioCLI().NewCommand())
 	rootCmd.AddCommand(NewPostOverflowCLI().NewCommand())
+	rootCmd.AddCommand(NewContextCLI().NewCommand())
 	rootCmd.AddCommand(NewAppsecConfigCLI().NewCommand())
 	rootCmd.AddCommand(NewAppsecRuleCLI().NewCommand())
 

--- a/cmd/crowdsec-cli/support.go
+++ b/cmd/crowdsec-cli/support.go
@@ -37,6 +37,7 @@ const (
 	SUPPORT_OS_INFO_PATH                 = "osinfo.txt"
 	SUPPORT_PARSERS_PATH                 = "hub/parsers.txt"
 	SUPPORT_SCENARIOS_PATH               = "hub/scenarios.txt"
+	SUPPORT_CONTEXTS_PATH                = "hub/scenarios.txt"
 	SUPPORT_COLLECTIONS_PATH             = "hub/collections.txt"
 	SUPPORT_POSTOVERFLOWS_PATH           = "hub/postoverflows.txt"
 	SUPPORT_BOUNCERS_PATH                = "lapi/bouncers.txt"
@@ -260,6 +261,7 @@ func NewSupportCmd() *cobra.Command {
 - Installed parsers list
 - Installed scenarios list
 - Installed postoverflows list
+- Installed context list
 - Bouncers list
 - Machines list
 - CAPI status
@@ -309,6 +311,7 @@ cscli support dump -f /tmp/crowdsec-support.zip
 				infos[SUPPORT_PARSERS_PATH] = []byte(err.Error())
 				infos[SUPPORT_SCENARIOS_PATH] = []byte(err.Error())
 				infos[SUPPORT_POSTOVERFLOWS_PATH] = []byte(err.Error())
+				infos[SUPPORT_CONTEXTS_PATH] = []byte(err.Error())
 				infos[SUPPORT_COLLECTIONS_PATH] = []byte(err.Error())
 			}
 
@@ -344,6 +347,7 @@ cscli support dump -f /tmp/crowdsec-support.zip
 				infos[SUPPORT_PARSERS_PATH] = collectHubItems(hub, cwhub.PARSERS)
 				infos[SUPPORT_SCENARIOS_PATH] = collectHubItems(hub, cwhub.SCENARIOS)
 				infos[SUPPORT_POSTOVERFLOWS_PATH] = collectHubItems(hub, cwhub.POSTOVERFLOWS)
+				infos[SUPPORT_CONTEXTS_PATH] = collectHubItems(hub, cwhub.POSTOVERFLOWS)
 				infos[SUPPORT_COLLECTIONS_PATH] = collectHubItems(hub, cwhub.COLLECTIONS)
 			}
 

--- a/cmd/crowdsec/crowdsec.go
+++ b/cmd/crowdsec/crowdsec.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/crowdsecurity/crowdsec/pkg/acquisition"
 	"github.com/crowdsecurity/crowdsec/pkg/appsec"
+	"github.com/crowdsecurity/crowdsec/pkg/alertcontext"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	leaky "github.com/crowdsecurity/crowdsec/pkg/leakybucket"
@@ -23,6 +24,10 @@ import (
 
 func initCrowdsec(cConfig *csconfig.Config, hub *cwhub.Hub) (*parser.Parsers, error) {
 	var err error
+
+	if err = alertcontext.LoadConsoleContext(cConfig, hub); err != nil {
+		return nil, fmt.Errorf("while loading context: %w", err)
+	}
 
 	// Start loading configs
 	csParsers := parser.NewParsers(hub)
@@ -41,6 +46,7 @@ func initCrowdsec(cConfig *csconfig.Config, hub *cwhub.Hub) (*parser.Parsers, er
 	if err := LoadAcquisition(cConfig); err != nil {
 		return nil, fmt.Errorf("while loading acquisition config: %w", err)
 	}
+
 	return csParsers, nil
 }
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -320,10 +320,12 @@ config.yaml) each time the container is run.
 | `PARSERS`               | | Parsers to install, separated by space |
 | `SCENARIOS`             | | Scenarios to install, separated by space |
 | `POSTOVERFLOWS`         | | Postoverflows to install, separated by space |
+| `CONTEXTS`              | | Context files to install, separated by space |
 | `DISABLE_COLLECTIONS`   | | Collections to remove, separated by space: `-e DISABLE_COLLECTIONS="crowdsecurity/linux crowdsecurity/nginx"` |
 | `DISABLE_PARSERS`       | | Parsers to remove, separated by space |
 | `DISABLE_SCENARIOS`     | | Scenarios to remove, separated by space |
 | `DISABLE_POSTOVERFLOWS` | | Postoverflows to remove, separated by space |
+| `DISABLE_POSTOVERFLOWS` | | Context files to remove, separated by space |
 |                         | | |
 | __Log verbosity__       | | |
 | `LEVEL_INFO`            | false | Force INFO level for the container log |

--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -300,7 +300,7 @@ fi
 
 conf_set_if "$PLUGIN_DIR" '.config_paths.plugin_dir = strenv(PLUGIN_DIR)'
 
-## Install collections, parsers, scenarios & postoverflows
+## Install hub items
 cscli hub update
 
 cscli_if_clean collections upgrade crowdsecurity/linux
@@ -328,6 +328,11 @@ if [ "$POSTOVERFLOWS" != "" ]; then
     cscli_if_clean postoverflows install "$(difference "$POSTOVERFLOWS" "$DISABLE_POSTOVERFLOWS")"
 fi
 
+if [ "$CONTEXTS" != "" ]; then
+    # shellcheck disable=SC2086
+    cscli_if_clean contexts install "$(difference "$CONTEXTS" "$DISABLE_CONTEXTS")"
+fi
+
 ## Remove collections, parsers, scenarios & postoverflows
 if [ "$DISABLE_COLLECTIONS" != "" ]; then
     # shellcheck disable=SC2086
@@ -347,6 +352,11 @@ fi
 if [ "$DISABLE_POSTOVERFLOWS" != "" ]; then
     # shellcheck disable=SC2086
     cscli_if_clean postoverflows remove "$DISABLE_POSTOVERFLOWS" --force
+fi
+
+if [ "$DISABLE_CONTEXTS" != "" ]; then
+    # shellcheck disable=SC2086
+    cscli_if_clean contexts remove "$DISABLE_CONTEXTS" --force
 fi
 
 ## Register bouncers via env

--- a/pkg/alertcontext/alertcontext.go
+++ b/pkg/alertcontext/alertcontext.go
@@ -63,13 +63,21 @@ func NewAlertContext(contextToSend map[string][]string, valueLength int) error {
 	}
 
 	for key, values := range contextToSend {
-		alertContext.ContextToSendCompiled[key] = make([]*vm.Program, 0)
+		if _, ok := alertContext.ContextToSend[key]; !ok {
+			alertContext.ContextToSend[key] = make([]string, 0)
+		}
+
+		if _, ok := alertContext.ContextToSendCompiled[key]; !ok {
+			alertContext.ContextToSendCompiled[key] = make([]*vm.Program, 0)
+		}
+
 		for _, value := range values {
 			valueCompiled, err := expr.Compile(value, exprhelpers.GetExprOptions(map[string]interface{}{"evt": &types.Event{}})...)
 			if err != nil {
 				return fmt.Errorf("compilation of '%s' context value failed: %v", value, err)
 			}
 			alertContext.ContextToSendCompiled[key] = append(alertContext.ContextToSendCompiled[key], valueCompiled)
+			alertContext.ContextToSend[key] = append(alertContext.ContextToSend[key], value)
 		}
 	}
 

--- a/pkg/alertcontext/config.go
+++ b/pkg/alertcontext/config.go
@@ -1,0 +1,125 @@
+package alertcontext
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+
+	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
+	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
+)
+
+// this file is here to avoid circular dependencies between the configuration and the hub
+
+// HubItemWrapper is a wrapper around a hub item to unmarshal only the context part
+// because there are other fields like name etc.
+type HubItemWrapper struct {
+	Context map[string][]string `yaml:"context"`
+}
+
+// mergeContext adds the context from src to dest.
+func mergeContext(dest map[string][]string, src map[string][]string) {
+	for k, v := range src {
+		if _, ok := dest[k]; !ok {
+			dest[k] = make([]string, 0)
+		}
+		for _, s := range v {
+			if !slices.Contains(dest[k], s) {
+				dest[k] = append(dest[k], s)
+			}
+		}
+	}
+}
+
+// addContextFromItem merges the context from an item into the context to send to the console.
+func addContextFromItem(toSend map[string][]string, item *cwhub.Item) error {
+	filePath := item.State.LocalPath
+	log.Tracef("loading console context from %s", filePath)
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	wrapper := &HubItemWrapper{}
+
+	err = yaml.Unmarshal(content, wrapper)
+	if err != nil {
+		return fmt.Errorf("%s: %w", filePath, err)
+	}
+
+	mergeContext(toSend, wrapper.Context)
+
+	return nil
+}
+
+// addContextFromFile merges the context from a file into the context to send to the console.
+func addContextFromFile(toSend map[string][]string, filePath string) error {
+	log.Tracef("loading console context from %s", filePath)
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	newContext := make(map[string][]string, 0)
+
+	err = yaml.Unmarshal(content, newContext)
+	if err != nil {
+		return fmt.Errorf("%s: %w", filePath, err)
+	}
+
+	mergeContext(toSend, newContext)
+
+	return nil
+}
+
+
+// LoadConsoleContext loads the context from the hub (if provided) and the file console_context_path.
+func LoadConsoleContext(c *csconfig.Config, hub *cwhub.Hub) error {
+	c.Crowdsec.ContextToSend = make(map[string][]string, 0)
+
+	if hub != nil {
+		items, err := hub.GetInstalledItems(cwhub.CONTEXTS)
+		if err != nil {
+			return err
+		}
+
+		for _, item := range items {
+			// context in item files goes under the key 'context'
+			if err = addContextFromItem(c.Crowdsec.ContextToSend, item); err != nil {
+				return err
+			}
+		}
+	}
+
+	ignoreMissing := false
+
+	if c.Crowdsec.ConsoleContextPath != "" {
+		// if it's provided, it must exist
+		if _, err := os.Stat(c.Crowdsec.ConsoleContextPath); err != nil {
+			return fmt.Errorf("while checking console_context_path: %w", err)
+		}
+	} else {
+		c.Crowdsec.ConsoleContextPath = filepath.Join(c.ConfigPaths.ConfigDir, "console", "context.yaml")
+		ignoreMissing = true
+	}
+
+	if err := addContextFromFile(c.Crowdsec.ContextToSend, c.Crowdsec.ConsoleContextPath); err != nil {
+		if !ignoreMissing || !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	feedback, err := json.Marshal(c.Crowdsec.ContextToSend)
+	if err != nil {
+		return fmt.Errorf("marshaling console context: %s", err)
+	}
+
+	log.Debugf("console context to send: %s", feedback)
+
+	return nil
+}

--- a/pkg/csconfig/crowdsec_service_test.go
+++ b/pkg/csconfig/crowdsec_service_test.go
@@ -60,9 +60,10 @@ func TestLoadCrowdsec(t *testing.T) {
 				ConsoleContextValueLength: 2500,
 				AcquisitionFiles:          []string{acquisFullPath},
 				SimulationFilePath:        "./testdata/simulation.yaml",
-				ContextToSend: map[string][]string{
-					"source_ip": {"evt.Parsed.source_ip"},
-				},
+				// context is loaded in pkg/alertcontext
+//				ContextToSend: map[string][]string{
+//					"source_ip": {"evt.Parsed.source_ip"},
+//				},
 				SimulationConfig: &SimulationConfig{
 					Simulation: ptr.Of(false),
 				},
@@ -98,9 +99,10 @@ func TestLoadCrowdsec(t *testing.T) {
 				OutputRoutinesCount:       1,
 				ConsoleContextValueLength: 0,
 				AcquisitionFiles:          []string{acquisFullPath, acquisInDirFullPath},
-				ContextToSend: map[string][]string{
-					"source_ip": {"evt.Parsed.source_ip"},
-				},
+				// context is loaded in pkg/alertcontext
+//				ContextToSend: map[string][]string{
+//					"source_ip": {"evt.Parsed.source_ip"},
+//				},
 				SimulationFilePath: "./testdata/simulation.yaml",
 				SimulationConfig: &SimulationConfig{
 					Simulation: ptr.Of(false),
@@ -136,9 +138,10 @@ func TestLoadCrowdsec(t *testing.T) {
 				ConsoleContextValueLength: 10,
 				AcquisitionFiles:          []string{},
 				SimulationFilePath:        "",
-				ContextToSend: map[string][]string{
-					"source_ip": {"evt.Parsed.source_ip"},
-				},
+				// context is loaded in pkg/alertcontext
+//				ContextToSend: map[string][]string{
+//					"source_ip": {"evt.Parsed.source_ip"},
+//				},
 				SimulationConfig: &SimulationConfig{
 					Simulation: ptr.Of(false),
 				},

--- a/pkg/cwhub/item.go
+++ b/pkg/cwhub/item.go
@@ -16,6 +16,7 @@ const (
 	PARSERS        = "parsers"
 	POSTOVERFLOWS  = "postoverflows"
 	SCENARIOS      = "scenarios"
+	CONTEXTS       = "contexts"
 	APPSEC_CONFIGS = "appsec-configs"
 	APPSEC_RULES   = "appsec-rules"
 )
@@ -29,7 +30,7 @@ const (
 
 var (
 	// The order is important, as it is used to range over sub-items in collections.
-	ItemTypes = []string{PARSERS, POSTOVERFLOWS, SCENARIOS, APPSEC_CONFIGS, APPSEC_RULES, COLLECTIONS}
+	ItemTypes = []string{PARSERS, POSTOVERFLOWS, SCENARIOS, CONTEXTS, APPSEC_CONFIGS, APPSEC_RULES, COLLECTIONS}
 )
 
 type HubItems map[string]map[string]*Item
@@ -120,6 +121,7 @@ type Item struct {
 	PostOverflows []string `json:"postoverflows,omitempty" yaml:"postoverflows,omitempty"`
 	Scenarios     []string `json:"scenarios,omitempty" yaml:"scenarios,omitempty"`
 	Collections   []string `json:"collections,omitempty" yaml:"collections,omitempty"`
+	Contexts      []string `json:"contexts,omitempty" yaml:"contexts,omitempty"`
 	AppsecConfigs []string `json:"appsec-configs,omitempty"   yaml:"appsec-configs,omitempty"`
 	AppsecRules   []string `json:"appsec-rules,omitempty"   yaml:"appsec-rules,omitempty"`
 }
@@ -231,6 +233,15 @@ func (i *Item) SubItems() []*Item {
 		sub = append(sub, s)
 	}
 
+	for _, name := range i.Contexts {
+		s := i.hub.GetItem(CONTEXTS, name)
+		if s == nil {
+			continue
+		}
+
+		sub = append(sub, s)
+	}
+
 	for _, name := range i.AppsecConfigs {
 		s := i.hub.GetItem(APPSEC_CONFIGS, name)
 		if s == nil {
@@ -281,6 +292,12 @@ func (i *Item) logMissingSubItems() {
 	for _, subName := range i.PostOverflows {
 		if i.hub.GetItem(POSTOVERFLOWS, subName) == nil {
 			log.Errorf("can't find %s in %s, required by %s", subName, POSTOVERFLOWS, i.Name)
+		}
+	}
+
+	for _, subName := range i.Contexts {
+		if i.hub.GetItem(CONTEXTS, subName) == nil {
+			log.Errorf("can't find %s in %s, required by %s", subName, CONTEXTS, i.Name)
 		}
 	}
 

--- a/pkg/cwhub/sync.go
+++ b/pkg/cwhub/sync.go
@@ -346,7 +346,7 @@ func (i *Item) checkSubItemVersions() error {
 
 // syncDir scans a directory for items, and updates the Hub state accordingly.
 func (h *Hub) syncDir(dir string) error {
-	// For each, scan PARSERS, POSTOVERFLOWS, SCENARIOS and COLLECTIONS last
+	// For each, scan PARSERS, POSTOVERFLOWS... and COLLECTIONS last
 	for _, scan := range ItemTypes {
 		// cpath: top-level item directory, either downloaded or installed items.
 		// i.e. /etc/crowdsec/parsers, /etc/crowdsec/hub/parsers, ...

--- a/test/bats.mk
+++ b/test/bats.mk
@@ -83,7 +83,7 @@ bats-build: bats-environment
 
 # Create a reusable package with initial configuration + data
 bats-fixture: bats-check-requirements bats-update-tools
-	@echo "Creating functional test fixture..."
+	@echo "Creating functional test fixture."
 	@$(TEST_DIR)/instance-data make
 
 # Remove the local crowdsec installation and the fixture config + data

--- a/test/bats/09_context.bats
+++ b/test/bats/09_context.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# vim: ft=bats:list:ts=8:sts=4:sw=4:et:ai:si:
+
+set -u
+
+setup_file() {
+    load "../lib/setup_file.sh"
+    CONFIG_DIR=$(config_get '.config_paths.config_dir')
+    export CONFIG_DIR
+    CONTEXT_YAML="$CONFIG_DIR/console/context.yaml"
+    export CONTEXT_YAML
+}
+
+teardown_file() {
+    load "../lib/teardown_file.sh"
+}
+
+setup() {
+    load "../lib/setup.sh"
+    load "../lib/bats-file/load.bash"
+    ./instance-data load
+    config_set '.common.log_media="stdout"'
+    mkdir -p "$CONFIG_DIR/console"
+}
+
+teardown() {
+    ./instance-crowdsec stop
+}
+
+#----------
+
+@test "attempt to load from default context file, ignore if missing" {
+    rune -0 rm -f "$CONTEXT_YAML"
+    rune -0 "$CROWDSEC" -t --trace
+    assert_stderr --partial "loading console context from $CONTEXT_YAML"
+}
+
+@test "error if context file is explicitly set but does not exist" {
+    config_set ".crowdsec_service.console_context_path=\"$CONTEXT_YAML\""
+    rune -0 rm -f "$CONTEXT_YAML"
+    rune -1 "$CROWDSEC" -t
+    assert_stderr --partial "while checking console_context_path: stat $CONTEXT_YAML: no such file or directory"
+}
+
+@test "context file is bad" {
+    echo "bad yaml" > "$CONTEXT_YAML"
+    rune -1 "$CROWDSEC" -t
+    assert_stderr --partial "while loading context from $CONTEXT_YAML: yaml: unmarshal errors"
+}
+
+@test "context file is good" {
+    echo '{"source_ip":["evt.Parsed.source_ip"]}' > "$CONTEXT_YAML"
+    rune -0 "$CROWDSEC" -t --debug
+    assert_stderr --partial 'console context to send: {"source_ip":["evt.Parsed.source_ip"]}'
+}

--- a/test/bats/20_hub.bats
+++ b/test/bats/20_hub.bats
@@ -36,7 +36,7 @@ teardown() {
     rune -0 cscli hub list
     assert_output "No items to display"
     rune -0 cscli hub list -o json
-    assert_json '{"appsec-configs":[],"appsec-rules":[],parsers:[],scenarios:[],collections:[],postoverflows:[]}'
+    assert_json '{"appsec-configs":[],"appsec-rules":[],parsers:[],scenarios:[],collections:[],contexts:[],postoverflows:[]}'
     rune -0 cscli hub list -o raw
     assert_output 'name,status,version,description,type'
 
@@ -47,6 +47,7 @@ teardown() {
     assert_output --regexp ".*PARSERS.*crowdsecurity/whitelists.*SCENARIOS.*crowdsecurity/telnet-bf.*"
     refute_output --partial 'POSTOVERFLOWS'
     refute_output --partial 'COLLECTIONS'
+
     rune -0 cscli hub list -o json
     rune -0 jq -e '(.parsers | length == 1) and (.scenarios | length == 1)' <(output)
     rune -0 cscli hub list -o raw
@@ -55,8 +56,11 @@ teardown() {
     refute_output --partial 'crowdsecurity/iptables'
 
     # all items
+    mkdir -p "$CONFIG_DIR/contexts"
+    # there are no contexts yet, so we create a local one
+    touch "$CONFIG_DIR/contexts/mycontext.yaml"
     rune -0 cscli hub list -a
-    assert_output --regexp ".*PARSERS.*crowdsecurity/whitelists.*POSTOVERFLOWS.*SCENARIOS.*crowdsecurity/telnet-bf.*COLLECTIONS.*crowdsecurity/iptables.*"
+    assert_output --regexp ".*PARSERS.*crowdsecurity/whitelists.*POSTOVERFLOWS.*SCENARIOS.*crowdsecurity/telnet-bf.*CONTEXTS.*mycontext.yaml.*COLLECTIONS.*crowdsecurity/iptables.*"
     rune -0 cscli hub list -a -o json
     rune -0 jq -e '(.parsers | length > 1) and (.scenarios | length > 1)' <(output)
     rune -0 cscli hub list -a -o raw
@@ -107,6 +111,8 @@ teardown() {
     assert_stderr --partial "Upgraded 0 postoverflows"
     assert_stderr --partial "Upgrading scenarios"
     assert_stderr --partial "Upgraded 0 scenarios"
+    assert_stderr --partial "Upgrading contexts"
+    assert_stderr --partial "Upgraded 0 contexts"
     assert_stderr --partial "Upgrading collections"
     assert_stderr --partial "Upgraded 0 collections"
 
@@ -134,10 +140,11 @@ teardown() {
     assert_line "parsers"
     assert_line "postoverflows"
     assert_line "scenarios"
+    assert_line "contexts"
     assert_line "collections"
     rune -0 cscli hub types -o human
     rune -0 yq -o json <(output)
-    assert_json '["parsers","postoverflows","scenarios","appsec-configs","appsec-rules","collections"]'
+    assert_json '["parsers","postoverflows","scenarios","contexts","appsec-configs","appsec-rules","collections"]'
     rune -0 cscli hub types -o json
-    assert_json '["parsers","postoverflows","scenarios","appsec-configs","appsec-rules","collections"]'
+    assert_json '["parsers","postoverflows","scenarios","contexts","appsec-configs","appsec-rules","collections"]'
 }

--- a/test/lib/setup_file.sh
+++ b/test/lib/setup_file.sh
@@ -247,12 +247,14 @@ hub_purge_all() {
         "$CONFIG_DIR"/collections/* \
         "$CONFIG_DIR"/parsers/*/* \
         "$CONFIG_DIR"/scenarios/* \
-        "$CONFIG_DIR"/postoverflows/*
+        "$CONFIG_DIR"/postoverflows/* \
+        "$CONFIG_DIR"/contexts/*
     rm -rf \
         "$CONFIG_DIR"/hub/collections/* \
         "$CONFIG_DIR"/hub/parsers/*/* \
         "$CONFIG_DIR"/hub/scenarios/* \
-        "$CONFIG_DIR"/hub/postoverflows/*
+        "$CONFIG_DIR"/hub/postoverflows/* \
+        "$CONFIG_DIR"/hub/contexts/*
     local DATA_DIR
     DATA_DIR=$(config_get .config_paths.data_dir)
     # should remove everything except the db (find $DATA_DIR -not -name "crowdsec.db*" -delete),


### PR DESCRIPTION
This support for items of type "context" in the hub, and is intended to replace the directory approach in https://github.com/crowdsecurity/crowdsec/pull/2498

 - add expr helpers
 - remove command "lapi context delete" to avoid ambiguity (the status command shows content from hub + console/context.yaml)