### PR TITLE
cscli context detect: fix nil dereference

### DIFF
--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -499,9 +499,8 @@ func detectNode(node parser.Node, parserCTX parser.UnixParserCtx) []string {
 
 	if node.Grok.RegexpName != "" {
 		grokCompiled, err := parserCTX.Grok.Get(node.Grok.RegexpName)
-		if err != nil {
-			log.Warningf("Can't get subgrok: %s", err)
-		} else {
+		// ignore error (parser does not exist?)
+		if err == nil {
 			for _, capturedField := range grokCompiled.Names() {
 				fieldName := fmt.Sprintf("evt.Parsed.%s", capturedField)
 				if !slices.Contains(ret, fieldName) {
@@ -546,9 +545,8 @@ func detectSubNode(node parser.Node, parserCTX parser.UnixParserCtx) []string {
 		}
 		if subnode.Grok.RegexpName != "" {
 			grokCompiled, err := parserCTX.Grok.Get(subnode.Grok.RegexpName)
-			if err != nil {
-				log.Warningf("Can't get subgrok: %s", err)
-			} else {
+			if err == nil {
+				// ignore error (parser does not exist?)
 				for _, capturedField := range grokCompiled.Names() {
 					fieldName := fmt.Sprintf("evt.Parsed.%s", capturedField)
 					if !slices.Contains(ret, fieldName) {

--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -332,7 +332,7 @@ cscli lapi context detect crowdsecurity/sshd-logs
 			}
 
 			// to avoid all the log.Info from the loaders functions
-			log.SetLevel(log.ErrorLevel)
+			log.SetLevel(log.WarnLevel)
 
 			err = exprhelpers.Init(nil)
 			if err != nil {
@@ -501,11 +501,12 @@ func detectNode(node parser.Node, parserCTX parser.UnixParserCtx) []string {
 		grokCompiled, err := parserCTX.Grok.Get(node.Grok.RegexpName)
 		if err != nil {
 			log.Warningf("Can't get subgrok: %s", err)
-		}
-		for _, capturedField := range grokCompiled.Names() {
-			fieldName := fmt.Sprintf("evt.Parsed.%s", capturedField)
-			if !slices.Contains(ret, fieldName) {
-				ret = append(ret, fieldName)
+		} else {
+			for _, capturedField := range grokCompiled.Names() {
+				fieldName := fmt.Sprintf("evt.Parsed.%s", capturedField)
+				if !slices.Contains(ret, fieldName) {
+					ret = append(ret, fieldName)
+				}
 			}
 		}
 	}
@@ -547,11 +548,12 @@ func detectSubNode(node parser.Node, parserCTX parser.UnixParserCtx) []string {
 			grokCompiled, err := parserCTX.Grok.Get(subnode.Grok.RegexpName)
 			if err != nil {
 				log.Warningf("Can't get subgrok: %s", err)
-			}
-			for _, capturedField := range grokCompiled.Names() {
-				fieldName := fmt.Sprintf("evt.Parsed.%s", capturedField)
-				if !slices.Contains(ret, fieldName) {
-					ret = append(ret, fieldName)
+			} else {
+				for _, capturedField := range grokCompiled.Names() {
+					fieldName := fmt.Sprintf("evt.Parsed.%s", capturedField)
+					if !slices.Contains(ret, fieldName) {
+						ret = append(ret, fieldName)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Also remove the log.warnings, which were not shown because log level was set to Error