### PR TITLE
Used asterisk for Defender Firewall log name

### DIFF
--- a/config/acquis_win.yaml
+++ b/config/acquis_win.yaml
@@ -10,7 +10,7 @@ labels:
 ---
 ##Firewall
 filenames:
-  - C:\Windows\System32\LogFiles\Firewall\pfirewall.log
+  - C:\Windows\System32\LogFiles\Firewall\*.log
 labels:
   type: windows-firewall
 ---


### PR DESCRIPTION
Log name is configurable. [MS Docs recommend a log file per profile](https://learn.microsoft.com/en-us/windows/security/operating-system-security/network-security/windows-firewall/configure-logging?tabs=intune):
```
For each profile (Domain, Private, and Public) change the default log file name from %windir%\system32\logfiles\firewall\pfirewall.log to:
- %windir%\system32\logfiles\firewall\pfirewall_Domain.log
- %windir%\system32\logfiles\firewall\pfirewall_Private.log
- %windir%\system32\logfiles\firewall\pfirewall_Public.log
```

Current configuration misses these files if the user implements best practices.