### PR TITLE
Appsec additional fixes

### DIFF
--- a/cmd/crowdsec-cli/hubappsec.go
+++ b/cmd/crowdsec-cli/hubappsec.go
@@ -48,6 +48,10 @@ cscli appsec-configs list crowdsecurity/vpatch`,
 
 func NewCLIAppsecRule() *cliItem {
 	inspectDetail := func(item *cwhub.Item) error {
+		//Only show the converted rules in human mode
+		if csConfig.Cscli.Output != "human" {
+			return nil
+		}
 		appsecRule := appsec.AppsecCollectionConfig{}
 
 		yamlContent, err := os.ReadFile(item.State.LocalPath)

--- a/cmd/crowdsec-cli/utils_table.go
+++ b/cmd/crowdsec-cli/utils_table.go
@@ -25,6 +25,19 @@ func listHubItemTable(out io.Writer, title string, items []*cwhub.Item) {
 	t.Render()
 }
 
+func appsecMetricsTable(out io.Writer, itemName string, metrics map[string]int) {
+	t := newTable(out)
+	t.SetHeaders("Inband Hits", "Outband Hits")
+
+	t.AddRow(
+		strconv.Itoa(metrics["inband_hits"]),
+		strconv.Itoa(metrics["outband_hits"]),
+	)
+
+	renderTableTitle(out, fmt.Sprintf("\n - (AppSec Rule) %s:", itemName))
+	t.Render()
+}
+
 func scenarioMetricsTable(out io.Writer, itemName string, metrics map[string]int) {
 	if metrics["instantiation"] == 0 {
 		return

--- a/pkg/acquisition/modules/appsec/appsec_runner.go
+++ b/pkg/acquisition/modules/appsec/appsec_runner.go
@@ -318,6 +318,7 @@ func (r *AppsecRunner) handleRequest(request *appsec.ParsedRequest) {
 
 	// time spent to process in band rules
 	inBandParsingElapsed := time.Since(startInBandParsing)
+	logger.Infof("Addind inband elapsed: %+v", inBandParsingElapsed.Seconds())
 	AppsecInbandParsingHistogram.With(prometheus.Labels{"source": request.RemoteAddrNormalized}).Observe(inBandParsingElapsed.Seconds())
 
 	if request.Tx.IsInterrupted() {
@@ -350,6 +351,8 @@ func (r *AppsecRunner) handleRequest(request *appsec.ParsedRequest) {
 	// time spent to process inband AND out of band rules
 	globalParsingElapsed := time.Since(startGlobalParsing)
 	AppsecGlobalParsingHistogram.With(prometheus.Labels{"source": request.RemoteAddrNormalized}).Observe(globalParsingElapsed.Seconds())
+
+	logger.Infof("Addind global elapsed: %+v", globalParsingElapsed.Seconds())
 
 	if request.Tx.IsInterrupted() {
 		r.handleOutBandInterrupt(request)

--- a/pkg/acquisition/modules/appsec/appsec_runner.go
+++ b/pkg/acquisition/modules/appsec/appsec_runner.go
@@ -318,7 +318,6 @@ func (r *AppsecRunner) handleRequest(request *appsec.ParsedRequest) {
 
 	// time spent to process in band rules
 	inBandParsingElapsed := time.Since(startInBandParsing)
-	logger.Infof("Addind inband elapsed: %+v", inBandParsingElapsed.Seconds())
 	AppsecInbandParsingHistogram.With(prometheus.Labels{"source": request.RemoteAddrNormalized, "appsec_engine": request.AppsecEngine}).Observe(inBandParsingElapsed.Seconds())
 
 	if request.Tx.IsInterrupted() {
@@ -357,8 +356,6 @@ func (r *AppsecRunner) handleRequest(request *appsec.ParsedRequest) {
 	// time spent to process inband AND out of band rules
 	globalParsingElapsed := time.Since(startGlobalParsing)
 	AppsecGlobalParsingHistogram.With(prometheus.Labels{"source": request.RemoteAddrNormalized, "appsec_engine": request.AppsecEngine}).Observe(globalParsingElapsed.Seconds())
-
-	logger.Infof("Addind global elapsed: %+v", globalParsingElapsed.Seconds())
 
 }
 

--- a/pkg/acquisition/modules/appsec/appsec_runner.go
+++ b/pkg/acquisition/modules/appsec/appsec_runner.go
@@ -319,7 +319,7 @@ func (r *AppsecRunner) handleRequest(request *appsec.ParsedRequest) {
 	// time spent to process in band rules
 	inBandParsingElapsed := time.Since(startInBandParsing)
 	logger.Infof("Addind inband elapsed: %+v", inBandParsingElapsed.Seconds())
-	AppsecInbandParsingHistogram.With(prometheus.Labels{"source": request.RemoteAddrNormalized}).Observe(inBandParsingElapsed.Seconds())
+	AppsecInbandParsingHistogram.With(prometheus.Labels{"source": request.RemoteAddrNormalized, "appsec_engine": request.AppsecEngine}).Observe(inBandParsingElapsed.Seconds())
 
 	if request.Tx.IsInterrupted() {
 		r.handleInBandInterrupt(request)
@@ -346,11 +346,11 @@ func (r *AppsecRunner) handleRequest(request *appsec.ParsedRequest) {
 
 	// time spent to process out of band rules
 	outOfBandParsingElapsed := time.Since(startOutOfBandParsing)
-	AppsecOutbandParsingHistogram.With(prometheus.Labels{"source": request.RemoteAddrNormalized}).Observe(outOfBandParsingElapsed.Seconds())
+	AppsecOutbandParsingHistogram.With(prometheus.Labels{"source": request.RemoteAddrNormalized, "appsec_engine": request.AppsecEngine}).Observe(outOfBandParsingElapsed.Seconds())
 
 	// time spent to process inband AND out of band rules
 	globalParsingElapsed := time.Since(startGlobalParsing)
-	AppsecGlobalParsingHistogram.With(prometheus.Labels{"source": request.RemoteAddrNormalized}).Observe(globalParsingElapsed.Seconds())
+	AppsecGlobalParsingHistogram.With(prometheus.Labels{"source": request.RemoteAddrNormalized, "appsec_engine": request.AppsecEngine}).Observe(globalParsingElapsed.Seconds())
 
 	logger.Infof("Addind global elapsed: %+v", globalParsingElapsed.Seconds())
 

--- a/pkg/acquisition/modules/appsec/metrics.go
+++ b/pkg/acquisition/modules/appsec/metrics.go
@@ -6,7 +6,7 @@ var AppsecGlobalParsingHistogram = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Help:    "Time spent processing a request by the Application Security Engine.",
 		Name:    "cs_appsec_parsing_time_seconds",
-		Buckets: []float64{0.001, 0.0025, 0.005, 0.01, 0.025, 0.050, 0.1, 0.2, 0.3, 0.4, 0.5, 1},
+		Buckets: []float64{0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.0050, 0.01, 0.025, 0.05, 0.1, 0.25},
 	},
 	[]string{"source", "appsec_engine"},
 )
@@ -15,7 +15,7 @@ var AppsecInbandParsingHistogram = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Help:    "Time spent processing a request by the inband Application Security Engine.",
 		Name:    "cs_appsec_inband_parsing_time_seconds",
-		Buckets: []float64{0.001, 0.0025, 0.005, 0.01, 0.025, 0.050, 0.1, 0.2, 0.3, 0.4, 0.5, 1},
+		Buckets: []float64{0.0001, 0.00025, 0.0005, 0.001, 0.025, 0.050, 0.01, 0.025, 0.05, 0.1, 0.25},
 	},
 	[]string{"source", "appsec_engine"},
 )
@@ -24,7 +24,7 @@ var AppsecOutbandParsingHistogram = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Help:    "Time spent processing a request by the Application Security Engine.",
 		Name:    "cs_appsec_outband_parsing_time_seconds",
-		Buckets: []float64{0.001, 0.0025, 0.005, 0.01, 0.025, 0.050, 0.1, 0.2, 0.3, 0.4, 0.5, 1},
+		Buckets: []float64{0.0001, 0.00025, 0.0005, 0.001, 0.025, 0.050, 0.01, 0.025, 0.05, 0.1, 0.25},
 	},
 	[]string{"source", "appsec_engine"},
 )

--- a/pkg/acquisition/modules/appsec/metrics.go
+++ b/pkg/acquisition/modules/appsec/metrics.go
@@ -15,7 +15,7 @@ var AppsecInbandParsingHistogram = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Help:    "Time spent processing a request by the inband Application Security Engine.",
 		Name:    "cs_appsec_inband_parsing_time_seconds",
-		Buckets: []float64{0.0001, 0.00025, 0.0005, 0.001, 0.025, 0.050, 0.01, 0.025, 0.05, 0.1, 0.25},
+		Buckets: []float64{0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.0050, 0.01, 0.025, 0.05, 0.1, 0.25},
 	},
 	[]string{"source", "appsec_engine"},
 )
@@ -24,7 +24,7 @@ var AppsecOutbandParsingHistogram = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Help:    "Time spent processing a request by the Application Security Engine.",
 		Name:    "cs_appsec_outband_parsing_time_seconds",
-		Buckets: []float64{0.0001, 0.00025, 0.0005, 0.001, 0.025, 0.050, 0.01, 0.025, 0.05, 0.1, 0.25},
+		Buckets: []float64{0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.0050, 0.01, 0.025, 0.05, 0.1, 0.25},
 	},
 	[]string{"source", "appsec_engine"},
 )

--- a/pkg/acquisition/modules/appsec/metrics.go
+++ b/pkg/acquisition/modules/appsec/metrics.go
@@ -6,27 +6,27 @@ var AppsecGlobalParsingHistogram = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Help:    "Time spent processing a request by the Application Security Engine.",
 		Name:    "cs_appsec_parsing_time_seconds",
-		Buckets: []float64{0.005, 0.01, 0.025, 0.050, 0.1, 0.2, 0.3, 0.4, 0.5, 1},
+		Buckets: []float64{0.001, 0.0025, 0.005, 0.01, 0.025, 0.050, 0.1, 0.2, 0.3, 0.4, 0.5, 1},
 	},
-	[]string{"source"},
+	[]string{"source", "appsec_engine"},
 )
 
 var AppsecInbandParsingHistogram = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Help:    "Time spent processing a request by the inband Application Security Engine.",
 		Name:    "cs_appsec_inband_parsing_time_seconds",
-		Buckets: []float64{0.005, 0.01, 0.025, 0.050, 0.1, 0.2, 0.3, 0.4, 0.5, 1},
+		Buckets: []float64{0.001, 0.0025, 0.005, 0.01, 0.025, 0.050, 0.1, 0.2, 0.3, 0.4, 0.5, 1},
 	},
-	[]string{"source"},
+	[]string{"source", "appsec_engine"},
 )
 
 var AppsecOutbandParsingHistogram = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Help:    "Time spent processing a request by the Application Security Engine.",
 		Name:    "cs_appsec_outband_parsing_time_seconds",
-		Buckets: []float64{0.005, 0.01, 0.025, 0.050, 0.1, 0.2, 0.3, 0.4, 0.5, 1},
+		Buckets: []float64{0.001, 0.0025, 0.005, 0.01, 0.025, 0.050, 0.1, 0.2, 0.3, 0.4, 0.5, 1},
 	},
-	[]string{"source"},
+	[]string{"source", "appsec_engine"},
 )
 
 var AppsecReqCounter = prometheus.NewCounterVec(

--- a/pkg/appsec/appsec.go
+++ b/pkg/appsec/appsec.go
@@ -30,7 +30,6 @@ const (
 	hookOnMatch
 )
 
-// @tko : todo - debug mode
 func (h *Hook) Build(hookStage int) error {
 
 	ctx := map[string]interface{}{}

--- a/pkg/appsec/appsec_rule/modsecurity.go
+++ b/pkg/appsec/appsec_rule/modsecurity.go
@@ -21,6 +21,7 @@ var zonesMap map[string]string = map[string]string{
 	"PROTOCOL":        "REQUEST_PROTOCOL",
 	"URI":             "REQUEST_URI",
 	"RAW_BODY":        "REQUEST_BODY",
+	"FILENAMES":       "FILES",
 }
 
 var transformMap map[string]string = map[string]string{

--- a/pkg/appsec/request.go
+++ b/pkg/appsec/request.go
@@ -247,7 +247,7 @@ func (r *ReqDumpFilter) GetFilteredRequest() *ParsedRequest {
 }
 
 func (r *ReqDumpFilter) ToJSON() error {
-	fd, err := os.CreateTemp("/tmp/", "crowdsec_req_dump_*.json")
+	fd, err := os.CreateTemp("", "crowdsec_req_dump_*.json")
 	if err != nil {
 		return fmt.Errorf("while creating temp file: %w", err)
 	}

--- a/pkg/appsec/request.go
+++ b/pkg/appsec/request.go
@@ -78,7 +78,7 @@ func (r *ReqDumpFilter) WithEmptyHeadersFilters() *ReqDumpFilter {
 	return r
 }
 
-func (r *ReqDumpFilter) WithHeadersContentFilters(filter string) *ReqDumpFilter {
+func (r *ReqDumpFilter) WithHeadersContentFilter(filter string) *ReqDumpFilter {
 	r.HeadersContentFilters = append(r.HeadersContentFilters, filter)
 	return r
 }

--- a/pkg/appsec/request.go
+++ b/pkg/appsec/request.go
@@ -114,7 +114,7 @@ func (r *ReqDumpFilter) WithEmptyArgsFilters() *ReqDumpFilter {
 	return r
 }
 
-func (r *ReqDumpFilter) WithArgsContentFilters(filter string) *ReqDumpFilter {
+func (r *ReqDumpFilter) WithArgsContentFilter(filter string) *ReqDumpFilter {
 	r.ArgsContentFilters = append(r.ArgsContentFilters, filter)
 	return r
 }

--- a/pkg/appsec/request_test.go
+++ b/pkg/appsec/request_test.go
@@ -153,7 +153,7 @@ func TestBodyDumper(t *testing.T) {
 				Args: map[string][]string{"test": {"lol"}},
 			},
 			filter: func(r *ReqDumpFilter) *ReqDumpFilter {
-				return r.WithArgsContentFilters("toto")
+				return r.WithArgsContentFilter("toto")
 			},
 		},
 	}

--- a/pkg/appsec/request_test.go
+++ b/pkg/appsec/request_test.go
@@ -63,7 +63,7 @@ func TestBodyDumper(t *testing.T) {
 				Headers: map[string][]string{"test1": {"toto"}},
 			},
 			filter: func(r *ReqDumpFilter) *ReqDumpFilter {
-				return r.WithHeadersContentFilters("tata")
+				return r.WithHeadersContentFilter("tata")
 			},
 		},
 		{

--- a/pkg/hubtest/hubtest_item.go
+++ b/pkg/hubtest/hubtest_item.go
@@ -89,7 +89,7 @@ const (
 
 	TestBouncerApiKey = "this_is_a_bad_password"
 
-	DefaultNucleiTarget = "http://127.0.0.1:80/"
+	DefaultNucleiTarget = "http://127.0.0.1:7822/"
 	DefaultAppsecHost   = "127.0.0.1:4241"
 )
 


### PR DESCRIPTION
 - Make `DumpRequest()` work on any OS
 - Show rules metrics in `cscli appsec-rules inspect`
 - Rename some `DumpRequest()` config to be more consistent
 - Only show converted appsec rules when cscli is in human output mode