### PR TITLE
[parser/scenarios] defer yaml file closure

### DIFF
--- a/pkg/leakybucket/manager_load.go
+++ b/pkg/leakybucket/manager_load.go
@@ -225,7 +225,7 @@ func LoadBuckets(cscfg *csconfig.CrowdsecServiceCfg, hub *cwhub.Hub, files []str
 			}
 			ok, err := cwversion.Satisfies(bucketFactory.FormatVersion, cwversion.Constraint_scenario)
 			if err != nil {
-				log.Fatalf("Failed to check version : %s", err)
+				return nil, nil, fmt.Errorf("failed to check version : %s", err)
 			}
 			if !ok {
 				log.Errorf("can't load %s : %s doesn't satisfy scenario format %s, skip", bucketFactory.Name, bucketFactory.FormatVersion, cwversion.Constraint_scenario)

--- a/pkg/leakybucket/manager_load.go
+++ b/pkg/leakybucket/manager_load.go
@@ -198,6 +198,7 @@ func LoadBuckets(cscfg *csconfig.CrowdsecServiceCfg, hub *cwhub.Hub, files []str
 			log.Errorf("Can't access leaky configuration file %s", f)
 			return nil, nil, err
 		}
+		defer bucketConfigurationFile.Close()
 		dec := yaml.NewDecoder(bucketConfigurationFile)
 		dec.SetStrict(true)
 		for {

--- a/pkg/parser/stage.go
+++ b/pkg/parser/stage.go
@@ -57,6 +57,7 @@ func LoadStages(stageFiles []Stagefile, pctx *UnixParserCtx, ectx EnricherCtx) (
 		if err != nil {
 			return nil, fmt.Errorf("can't access parsing configuration file %s : %s", stageFile.Filename, err)
 		}
+		defer yamlFile.Close()
 		//process the yaml
 		dec := yaml.NewDecoder(yamlFile)
 		dec.SetStrict(true)

--- a/pkg/parser/stage.go
+++ b/pkg/parser/stage.go
@@ -71,7 +71,7 @@ func LoadStages(stageFiles []Stagefile, pctx *UnixParserCtx, ectx EnricherCtx) (
 					log.Tracef("End of yaml file")
 					break
 				}
-				log.Fatalf("Error decoding parsing configuration file '%s': %v", stageFile.Filename, err)
+				return nil, fmt.Errorf("error decoding parsing configuration file '%s': %v", stageFile.Filename, err)
 			}
 
 			//check for empty bucket
@@ -86,7 +86,7 @@ func LoadStages(stageFiles []Stagefile, pctx *UnixParserCtx, ectx EnricherCtx) (
 			}
 			ok, err := cwversion.Satisfies(node.FormatVersion, cwversion.Constraint_parser)
 			if err != nil {
-				log.Fatalf("Failed to check version : %s", err)
+				return nil, fmt.Errorf("failed to check version : %s", err)
 			}
 			if !ok {
 				log.Errorf("%s : %s doesn't satisfy parser format %s, skip", node.Name, node.FormatVersion, cwversion.Constraint_parser)


### PR DESCRIPTION
Whilst debugging an issue I saw we kept the FD's of parsers and scenario open even after being fully loaded. Turns out we never explicitly defer the func so this adds it