### PR TITLE
add cpu-profile flag

### DIFF
--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -357,6 +357,7 @@ func main() {
 
 	err := StartRunSvc()
 	if err != nil {
+		pprof.StopCPUProfile()
 		log.Fatal(err)
 	}
 	os.Exit(0)

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -347,10 +347,11 @@ func main() {
 			log.Fatalf("could not create CPU profile: %s", err)
 		}
 		log.Infof("CPU profile will be written to %s", flags.CpuProfile)
-		defer f.Close()
 		if err := pprof.StartCPUProfile(f); err != nil {
+			f.Close()
 			log.Fatalf("could not start CPU profile: %s", err)
 		}
+		defer f.Close()
 		defer pprof.StopCPUProfile()
 	}
 

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -372,7 +372,7 @@ func main() {
 	err := StartRunSvc()
 	if err != nil {
 		pprof.StopCPUProfile()
-		log.Fatal(err)
+		log.Fatal(err) //nolint:gocritic // Disable warning for the defer pprof.StopCPUProfile() call
 	}
 
 	os.Exit(0)

--- a/cmd/crowdsec/run_in_svc.go
+++ b/cmd/crowdsec/run_in_svc.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime/pprof"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/writer"
@@ -23,6 +24,10 @@ func StartRunSvc() error {
 	)
 
 	defer trace.CatchPanic("crowdsec/StartRunSvc")
+
+	//Always try to stop CPU profiling to avoid passing flags around
+	//It's a noop if profiling is not enabled
+	defer pprof.StopCPUProfile()
 
 	// Set a default logger with level=fatal on stderr,
 	// in addition to the one we configure afterwards

--- a/cmd/crowdsec/run_in_svc_windows.go
+++ b/cmd/crowdsec/run_in_svc_windows.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"runtime/pprof"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows/svc"
@@ -65,6 +66,10 @@ func WindowsRun() error {
 	if err != nil {
 		return err
 	}
+
+	//Always try to stop CPU profiling to avoid passing flags around
+	//It's a noop if profiling is not enabled
+	defer pprof.StopCPUProfile()
 
 	log.Infof("Crowdsec %s", version.String())
 

--- a/cmd/crowdsec/run_in_svc_windows.go
+++ b/cmd/crowdsec/run_in_svc_windows.go
@@ -20,6 +20,10 @@ func StartRunSvc() error {
 
 	defer trace.CatchPanic("crowdsec/StartRunSvc")
 
+	//Always try to stop CPU profiling to avoid passing flags around
+	//It's a noop if profiling is not enabled
+	defer pprof.StopCPUProfile()
+
 	isRunninginService, err := svc.IsWindowsService()
 	if err != nil {
 		return fmt.Errorf("failed to determine if we are running in windows service mode: %w", err)
@@ -66,10 +70,6 @@ func WindowsRun() error {
 	if err != nil {
 		return err
 	}
-
-	//Always try to stop CPU profiling to avoid passing flags around
-	//It's a noop if profiling is not enabled
-	defer pprof.StopCPUProfile()
 
 	log.Infof("Crowdsec %s", version.String())
 

--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime/pprof"
 	"syscall"
 	"time"
 
@@ -244,6 +245,10 @@ func HandleSignals(cConfig *csconfig.Config) error {
 		os.Interrupt)
 
 	exitChan := make(chan error)
+
+	//Always try to stop CPU profiling to avoid passing flags around
+	//It's a noop if profiling is not enabled
+	defer pprof.StopCPUProfile()
 
 	go func() {
 		defer trace.CatchPanic("crowdsec/HandleSignals")


### PR DESCRIPTION
Add a `cpu-profile` flag to make crowdsec generate a CPU profile by itself (without querying the pprof HTTP endpoint).

Closes #2715 