### PR TITLE
post-install: reduce verbosity

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -61,7 +61,7 @@ if [ "$1" = configure ]; then
             [ -s /etc/crowdsec/local_api_credentials.yaml ] || cscli machines add -a --force --error
 
             if [ "$CAPI" = true ]; then
-                cscli capi register
+                cscli capi register --error
             fi
 
         else

--- a/rpm/SPECS/crowdsec.spec
+++ b/rpm/SPECS/crowdsec.spec
@@ -169,7 +169,7 @@ if [ $1 == 1 ]; then
     fi
     if [ ! -f "%{_sysconfdir}/crowdsec/online_api_credentials.yaml" ] ; then
         install -m 600 /dev/null  /etc/crowdsec/online_api_credentials.yaml
-        cscli capi register
+        cscli capi register --error
     fi
     if [ ! -f "%{_sysconfdir}/crowdsec/local_api_credentials.yaml" ] ; then
         install -m 600 /dev/null  /etc/crowdsec/local_api_credentials.yaml

--- a/wizard.sh
+++ b/wizard.sh
@@ -191,7 +191,6 @@ log_locations[linux]='/var/log/syslog,/var/log/kern.log,/var/log/messages'
 
 # $1 is service name, such those in SUPPORTED_SERVICES
 find_logs_for() {
-    ret=""
     x=${1}
     # we have trailing and starting quotes because of whiptail
     SVC="${x%\"}"
@@ -209,7 +208,7 @@ find_logs_for() {
         # Split /var/log/nginx/*.log into '/var/log/nginx' and '*.log' so we can use find
 	    path=${poss_path%/*}
 	    fname=${poss_path##*/}
-	    candidates=`find "${path}" -type f -mtime -5 -ctime -5 -name "$fname"`
+	    candidates=$(find "${path}" -type f -mtime -5 -ctime -5 -name "$fname" 2>/dev/null)
 	    # We have some candidates, add them
 	    for final_file in ${candidates} ; do
 	        log_dbg "Found logs file for '${SVC}': ${final_file}"

--- a/wizard.sh
+++ b/wizard.sh
@@ -130,9 +130,9 @@ detect_services () {
     DETECTED_SERVICES=()
     HMENU=()
     # list systemd services
-    SYSTEMD_SERVICES=`systemctl  --state=enabled list-unit-files '*.service' | cut -d ' ' -f1`
+    SYSTEMD_SERVICES=$(systemctl  --state=enabled list-unit-files '*.service' | cut -d ' ' -f1)
     # raw ps
-    PSAX=`ps ax -o comm=`
+    PSAX=$(ps ax -o comm=)
     for SVC in ${SUPPORTED_SERVICES} ; do
         log_dbg "Checking if service '${SVC}' is running (ps+systemd)"
         for SRC in "${SYSTEMD_SERVICES}" "${PSAX}" ; do

--- a/wizard.sh
+++ b/wizard.sh
@@ -712,7 +712,7 @@ main() {
         ${CSCLI_BIN_INSTALLED} machines add --force "$(cat /etc/machine-id)" -a -f "${CROWDSEC_CONFIG_PATH}/${CLIENT_SECRETS}" || log_fatal "unable to add machine to the local API"
         log_dbg "Crowdsec LAPI registered"
 
-        ${CSCLI_BIN_INSTALLED} capi register || log_fatal "unable to register to the Central API"
+        ${CSCLI_BIN_INSTALLED} capi register --error || log_fatal "unable to register to the Central API"
         log_dbg "Crowdsec CAPI registered"
 
         systemctl enable -q crowdsec >/dev/null || log_fatal "unable to enable crowdsec"

--- a/wizard.sh
+++ b/wizard.sh
@@ -713,7 +713,6 @@ main() {
         log_dbg "Crowdsec LAPI registered"
 
         ${CSCLI_BIN_INSTALLED} capi register --error || log_fatal "unable to register to the Central API"
-        log_dbg "Crowdsec CAPI registered"
 
         systemctl enable -q crowdsec >/dev/null || log_fatal "unable to enable crowdsec"
         systemctl start crowdsec >/dev/null || log_fatal "unable to start crowdsec"


### PR DESCRIPTION
this removes the initial WAL warning too, is that ok or should I put it back?

Otherwise, we don't see anymore:

```
find: '/usr/local/openresty/nginx/logs': No such file or directory
...
WARN[2024-01-17T11:24:37Z] can't load CAPI credentials from '/etc/crowdsec/online_api_credentials.yaml' (missing login field)
INFO[2024-01-17T11:24:37Z] push and pull to Central API disabled       
```