### PR TITLE
Dedicated whitelist metrics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,7 @@ linters-settings:
 
   gocyclo:
     # lower this after refactoring
-    min-complexity: 64
+    min-complexity: 66
 
   funlen:
     # Checks the number of lines in a function.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,7 @@ linters-settings:
 
   gocyclo:
     # lower this after refactoring
-    min-complexity: 66
+    min-complexity: 67
 
   funlen:
     # Checks the number of lines in a function.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ run:
 linters-settings:
   cyclop:
     # lower this after refactoring
-    max-complexity: 66
+    max-complexity: 70
 
   gci:
     sections:
@@ -22,11 +22,11 @@ linters-settings:
 
   gocognit:
     # lower this after refactoring
-    min-complexity: 149
+    min-complexity: 150
 
   gocyclo:
     # lower this after refactoring
-    min-complexity: 67
+    min-complexity: 70
 
   funlen:
     # Checks the number of lines in a function.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,7 @@ linters-settings:
 
   gocognit:
     # lower this after refactoring
-    min-complexity: 145
+    min-complexity: 149
 
   gocyclo:
     # lower this after refactoring

--- a/cmd/crowdsec/metrics.go
+++ b/cmd/crowdsec/metrics.go
@@ -161,7 +161,7 @@ func registerPrometheus(config *csconfig.PrometheusCfg) {
 			leaky.BucketsUnderflow, leaky.BucketsCanceled, leaky.BucketsInstantiation, leaky.BucketsOverflow,
 			v1.LapiRouteHits,
 			leaky.BucketsCurrentCount,
-			cache.CacheMetrics, exprhelpers.RegexpCacheMetrics,
+			cache.CacheMetrics, exprhelpers.RegexpCacheMetrics, parser.NodesWlHitsOk, parser.NodesWlHits,
 		)
 	} else {
 		log.Infof("Loading prometheus collectors")
@@ -170,7 +170,7 @@ func registerPrometheus(config *csconfig.PrometheusCfg) {
 			globalCsInfo, globalParsingHistogram, globalPourHistogram,
 			v1.LapiRouteHits, v1.LapiMachineHits, v1.LapiBouncerHits, v1.LapiNilDecisions, v1.LapiNonNilDecisions, v1.LapiResponseTime,
 			leaky.BucketsPour, leaky.BucketsUnderflow, leaky.BucketsCanceled, leaky.BucketsInstantiation, leaky.BucketsOverflow, leaky.BucketsCurrentCount,
-			globalActiveDecisions, globalAlerts,
+			globalActiveDecisions, globalAlerts, parser.NodesWlHitsOk, parser.NodesWlHits,
 			cache.CacheMetrics, exprhelpers.RegexpCacheMetrics,
 		)
 

--- a/pkg/parser/node.go
+++ b/pkg/parser/node.go
@@ -168,9 +168,9 @@ func (n *Node) process(p *types.Event, ctx UnixParserCtx, expressionEnv map[stri
 		NodesHits.With(prometheus.Labels{"source": p.Line.Src, "type": p.Line.Module, "name": n.Name}).Inc()
 	}
 	exprErr := error(nil)
-	isWhitelisted := n.CheckIPsWL(p.ParseIPSources())
+	isWhitelisted := n.CheckIPsWL(p)
 	if !isWhitelisted {
-		isWhitelisted, exprErr = n.CheckExprWL(cachedExprEnv)
+		isWhitelisted, exprErr = n.CheckExprWL(cachedExprEnv, p)
 	}
 	if exprErr != nil {
 		// Previous code returned nil if there was an error, so we keep this behavior

--- a/pkg/parser/runtime.go
+++ b/pkg/parser/runtime.go
@@ -221,6 +221,24 @@ var NodesHitsKo = prometheus.NewCounterVec(
 	[]string{"source", "type", "name"},
 )
 
+//
+
+var NodesWlHitsOk = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "cs_node_wl_hits_ok_total",
+		Help: "Total events successfully whitelisted by node.",
+	},
+	[]string{"source", "type", "name", "reason"},
+)
+
+var NodesWlHits = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "cs_node_wl_hits_total",
+		Help: "Total events processed by whitelist node.",
+	},
+	[]string{"source", "type", "name", "reason"},
+)
+
 func stageidx(stage string, stages []string) int {
 	for i, v := range stages {
 		if stage == v {

--- a/pkg/parser/whitelist_test.go
+++ b/pkg/parser/whitelist_test.go
@@ -289,9 +289,9 @@ func TestWhitelistCheck(t *testing.T) {
 			var err error
 			node.Whitelist = tt.whitelist
 			node.CompileWLs()
-			isWhitelisted := node.CheckIPsWL(tt.event.ParseIPSources())
+			isWhitelisted := node.CheckIPsWL(tt.event)
 			if !isWhitelisted {
-				isWhitelisted, err = node.CheckExprWL(map[string]interface{}{"evt": tt.event})
+				isWhitelisted, err = node.CheckExprWL(map[string]interface{}{"evt": tt.event}, tt.event)
 			}
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, isWhitelisted)


### PR DESCRIPTION
 - track whitelists effect (hits/whitelists)
 - dedicated `cscli metrics` table
 - adding a `whitelisted` column to existing acquis metrics/table



## dedicated table

```
Whitelist Metrics:
╭────────────────────────────────┬────────────────────────┬──────┬─────────────╮
│           Whitelist            │         Reason         │ Hits │ Whitelisted │
├────────────────────────────────┼────────────────────────┼──────┼─────────────┤
│ child-crowdsecurity/whitelists │ local ipv6 ip/ranges   │ 20   │ -           │
│ child-crowdsecurity/whitelists │ private ipv4 ip/ranges │ 20   │ 10          │
╰────────────────────────────────┴────────────────────────┴──────┴─────────────╯

```

## addition to acquis metrics

```
cquisition Metrics:
╭─────────────────┬────────────┬──────────────┬────────────────┬────────────────────────┬───────────────────╮
│     Source      │ Lines read │ Lines parsed │ Lines unparsed │ Lines poured to bucket │ Lines whitelisted │
├─────────────────┼────────────┼──────────────┼────────────────┼────────────────────────┼───────────────────┤
│ file:/tmp/x.log │ 20         │ 20           │ -              │ 22                     │ 10                │
╰─────────────────┴────────────┴──────────────┴────────────────┴────────────────────────┴───────────────────╯

```