### PR TITLE
[Loki] Set headers/basic auth if set for queryRange

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -114,6 +114,7 @@ jobs:
           --health-timeout 10s
           --health-retries 5
           --health-start-period 30s
+          --auth.enabled=true
 
     steps:
 

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -114,7 +114,6 @@ jobs:
           --health-timeout 10s
           --health-retries 5
           --health-start-period 30s
-          --auth.enabled=true
 
     steps:
 

--- a/pkg/acquisition/modules/loki/internal/lokiclient/loki_client.go
+++ b/pkg/acquisition/modules/loki/internal/lokiclient/loki_client.go
@@ -316,7 +316,7 @@ func NewLokiClient(config Config) *LokiClient {
 
 // Create a wrapper for http.Get to be able to set headers and auth
 func (lc *LokiClient) Get(url string) (*http.Response, error) {
-	request, err := http.NewRequest("GET", url, nil)
+	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/acquisition/modules/loki/internal/lokiclient/loki_client.go
+++ b/pkg/acquisition/modules/loki/internal/lokiclient/loki_client.go
@@ -128,6 +128,7 @@ func (lc *LokiClient) queryRange(uri string, ctx context.Context, c chan *LokiQu
 			}
 
 			if resp.StatusCode != http.StatusOK {
+				lc.Logger.Warnf("bad HTTP response code for query range: %d", resp.StatusCode)
 				body, _ := io.ReadAll(resp.Body)
 				resp.Body.Close()
 				if ok := lc.shouldRetry(); !ok {

--- a/pkg/acquisition/modules/loki/loki_test.go
+++ b/pkg/acquisition/modules/loki/loki_test.go
@@ -371,30 +371,26 @@ func TestStreamingAcquisition(t *testing.T) {
 	}{
 		{
 			name: "Bad port",
-			config: `
-				mode: tail
-				source: loki
-				url: http://127.0.0.1:3101
-				headers:
-				  x-scope-orgid: "1234"
-				query: >
-				  {server="demo"}
-				`, // No Loki server here
+			config: `mode: tail
+source: loki
+url: "http://127.0.0.1:3101"
+headers:
+  x-scope-orgid: "1234"
+query: >
+  {server="demo"}`, // No Loki server here
 			expectedErr:   "",
 			streamErr:     `loki is not ready: context deadline exceeded`,
 			expectedLines: 0,
 		},
 		{
 			name: "ok",
-			config: `
-mode: tail
+			config: `mode: tail
 source: loki
-url: http://127.0.0.1:3100
+url: "http://127.0.0.1:3100"
 headers:
   x-scope-orgid: "1234"
 query: >
-  {server="demo"}
-`,
+  {server="demo"}`,
 			expectedErr:   "",
 			streamErr:     "",
 			expectedLines: 20,


### PR DESCRIPTION
Fix #2814 

Seems query range was never using the headers and was only the websocket 🤷🏻 

I have little experience with the integration, however, this should patch it

LMK if we should write some tests or unless the current test fail 😆 