### PR TITLE
appsec: split return code for bouncer and user

### DIFF
--- a/pkg/acquisition/modules/appsec/appsec.go
+++ b/pkg/acquisition/modules/appsec/appsec.go
@@ -358,7 +358,7 @@ func (w *AppsecSource) appsecHandler(rw http.ResponseWriter, r *http.Request) {
 	statusCode := http.StatusOK
 
 	if response.InBandInterrupt {
-		statusCode = http.StatusForbidden
+		statusCode = response.RemediationComponentHTTPResponseCode
 		AppsecBlockCounter.With(prometheus.Labels{"source": parsedRequest.RemoteAddrNormalized, "appsec_engine": parsedRequest.AppsecEngine}).Inc()
 	}
 

--- a/pkg/acquisition/modules/appsec/appsec.go
+++ b/pkg/acquisition/modules/appsec/appsec.go
@@ -354,6 +354,10 @@ func (w *AppsecSource) appsecHandler(rw http.ResponseWriter, r *http.Request) {
 
 	w.InChan <- parsedRequest
 
+	/*
+		response is a copy of w.AppSecRuntime.Response that is safe to use.
+		As OutOfBand might still be running, the original one can be modified
+	*/
 	response := <-parsedRequest.ResponseChannel
 
 	if response.InBandInterrupt {

--- a/pkg/acquisition/modules/appsec/appsec.go
+++ b/pkg/acquisition/modules/appsec/appsec.go
@@ -355,14 +355,12 @@ func (w *AppsecSource) appsecHandler(rw http.ResponseWriter, r *http.Request) {
 	w.InChan <- parsedRequest
 
 	response := <-parsedRequest.ResponseChannel
-	statusCode := http.StatusOK
 
 	if response.InBandInterrupt {
-		statusCode = response.RemediationComponentHTTPResponseCode
 		AppsecBlockCounter.With(prometheus.Labels{"source": parsedRequest.RemoteAddrNormalized, "appsec_engine": parsedRequest.AppsecEngine}).Inc()
 	}
 
-	appsecResponse := w.AppsecRuntime.GenerateResponse(response, logger)
+	statusCode, appsecResponse := w.AppsecRuntime.GenerateResponse(response, logger)
 	logger.Debugf("Response: %+v", appsecResponse)
 
 	rw.WriteHeader(statusCode)

--- a/pkg/acquisition/modules/appsec/appsec_runner.go
+++ b/pkg/acquisition/modules/appsec/appsec_runner.go
@@ -226,8 +226,8 @@ func (r *AppsecRunner) handleInBandInterrupt(request *appsec.ParsedRequest) {
 	if in := request.Tx.Interruption(); in != nil {
 		r.logger.Debugf("inband rules matched : %d", in.RuleID)
 		r.AppsecRuntime.Response.InBandInterrupt = true
-		r.AppsecRuntime.Response.RemediationComponentHTTPResponseCode = r.AppsecRuntime.Config.BlockedHTTPCode
-		r.AppsecRuntime.Response.UserHTTPResponseCode = r.AppsecRuntime.Config.BlockedHTTPCode
+		r.AppsecRuntime.Response.BouncerHTTPResponseCode = r.AppsecRuntime.Config.BouncerBlockedHTTPCode
+		r.AppsecRuntime.Response.UserHTTPResponseCode = r.AppsecRuntime.Config.UserBlockedHTTPCode
 		r.AppsecRuntime.Response.Action = r.AppsecRuntime.DefaultRemediation
 
 		if _, ok := r.AppsecRuntime.RemediationById[in.RuleID]; ok {

--- a/pkg/acquisition/modules/appsec/appsec_runner.go
+++ b/pkg/acquisition/modules/appsec/appsec_runner.go
@@ -226,7 +226,8 @@ func (r *AppsecRunner) handleInBandInterrupt(request *appsec.ParsedRequest) {
 	if in := request.Tx.Interruption(); in != nil {
 		r.logger.Debugf("inband rules matched : %d", in.RuleID)
 		r.AppsecRuntime.Response.InBandInterrupt = true
-		r.AppsecRuntime.Response.HTTPResponseCode = r.AppsecRuntime.Config.BlockedHTTPCode
+		r.AppsecRuntime.Response.RemediationComponentHTTPResponseCode = r.AppsecRuntime.Config.BlockedHTTPCode
+		r.AppsecRuntime.Response.UserHTTPResponseCode = r.AppsecRuntime.Config.BlockedHTTPCode
 		r.AppsecRuntime.Response.Action = r.AppsecRuntime.DefaultRemediation
 
 		if _, ok := r.AppsecRuntime.RemediationById[in.RuleID]; ok {
@@ -252,7 +253,9 @@ func (r *AppsecRunner) handleInBandInterrupt(request *appsec.ParsedRequest) {
 				r.logger.Errorf("unable to generate appsec event : %s", err)
 				return
 			}
-			r.outChan <- *appsecOvlfw
+			if appsecOvlfw != nil {
+				r.outChan <- *appsecOvlfw
+			}
 		}
 
 		// Should the in band match trigger an event ?

--- a/pkg/acquisition/modules/appsec/appsec_test.go
+++ b/pkg/acquisition/modules/appsec/appsec_test.go
@@ -58,7 +58,7 @@ func TestAppsecOnMatchHooks(t *testing.T) {
 				require.Equal(t, types.APPSEC, events[0].Type)
 				require.Equal(t, types.LOG, events[1].Type)
 				require.Len(t, responses, 1)
-				require.Equal(t, 403, responses[0].RemediationComponentHTTPResponseCode)
+				require.Equal(t, 403, responses[0].BouncerHTTPResponseCode)
 				require.Equal(t, 403, responses[0].UserHTTPResponseCode)
 				require.Equal(t, "ban", responses[0].Action)
 
@@ -90,7 +90,7 @@ func TestAppsecOnMatchHooks(t *testing.T) {
 				require.Equal(t, types.APPSEC, events[0].Type)
 				require.Equal(t, types.LOG, events[1].Type)
 				require.Len(t, responses, 1)
-				require.Equal(t, 403, responses[0].RemediationComponentHTTPResponseCode)
+				require.Equal(t, 403, responses[0].BouncerHTTPResponseCode)
 				require.Equal(t, 413, responses[0].UserHTTPResponseCode)
 				require.Equal(t, "ban", responses[0].Action)
 			},

--- a/pkg/acquisition/modules/appsec/appsec_test.go
+++ b/pkg/acquisition/modules/appsec/appsec_test.go
@@ -729,8 +729,8 @@ func TestOnMatchRemediationHooks(t *testing.T) {
 
 				log.Errorf("http status : %d", statusCode)
 				require.Equal(t, appsec.CaptchaRemediation, appsecResponse.Action)
-				require.Equal(t, http.StatusForbidden, appsecResponse.HTTPStatus)
-				require.Equal(t, http.StatusTeapot, statusCode)
+				require.Equal(t, http.StatusTeapot, appsecResponse.HTTPStatus)
+				require.Equal(t, http.StatusForbidden, statusCode)
 			},
 		},
 	}

--- a/pkg/acquisition/modules/appsec/appsec_test.go
+++ b/pkg/acquisition/modules/appsec/appsec_test.go
@@ -64,7 +64,7 @@ func TestAppsecOnMatchHooks(t *testing.T) {
 				require.Len(t, responses, 1)
 				require.Equal(t, 403, responses[0].BouncerHTTPResponseCode)
 				require.Equal(t, 403, responses[0].UserHTTPResponseCode)
-				require.Equal(t, "ban", responses[0].Action)
+				require.Equal(t, appsec.BanRemediation, responses[0].Action)
 
 			},
 		},
@@ -96,7 +96,7 @@ func TestAppsecOnMatchHooks(t *testing.T) {
 				require.Len(t, responses, 1)
 				require.Equal(t, 403, responses[0].BouncerHTTPResponseCode)
 				require.Equal(t, 413, responses[0].UserHTTPResponseCode)
-				require.Equal(t, "ban", responses[0].Action)
+				require.Equal(t, appsec.BanRemediation, responses[0].Action)
 			},
 		},
 		{
@@ -154,7 +154,7 @@ func TestAppsecOnMatchHooks(t *testing.T) {
 				require.Equal(t, types.APPSEC, events[0].Type)
 				require.Equal(t, types.LOG, events[1].Type)
 				require.Len(t, responses, 1)
-				require.Equal(t, "allow", responses[0].Action)
+				require.Equal(t, appsec.AllowRemediation, responses[0].Action)
 			},
 		},
 		{
@@ -181,7 +181,7 @@ func TestAppsecOnMatchHooks(t *testing.T) {
 			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
 				require.Len(t, responses, 1)
 				//note: SetAction normalizes deny, ban and block to ban
-				require.Equal(t, "ban", responses[0].Action)
+				require.Equal(t, appsec.BanRemediation, responses[0].Action)
 			},
 		},
 		{
@@ -208,7 +208,7 @@ func TestAppsecOnMatchHooks(t *testing.T) {
 			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
 				require.Len(t, responses, 1)
 				//note: SetAction normalizes deny, ban and block to ban
-				require.Equal(t, "captcha", responses[0].Action)
+				require.Equal(t, appsec.CaptchaRemediation, responses[0].Action)
 			},
 		},
 		{
@@ -265,7 +265,7 @@ func TestAppsecOnMatchHooks(t *testing.T) {
 				require.Len(t, events, 1)
 				require.Equal(t, types.LOG, events[0].Type)
 				require.Len(t, responses, 1)
-				require.Equal(t, "ban", responses[0].Action)
+				require.Equal(t, appsec.BanRemediation, responses[0].Action)
 			},
 		},
 		{
@@ -293,7 +293,7 @@ func TestAppsecOnMatchHooks(t *testing.T) {
 				require.Len(t, events, 1)
 				require.Equal(t, types.APPSEC, events[0].Type)
 				require.Len(t, responses, 1)
-				require.Equal(t, "ban", responses[0].Action)
+				require.Equal(t, appsec.BanRemediation, responses[0].Action)
 			},
 		},
 	}
@@ -666,9 +666,9 @@ func TestAppsecRuleMatches(t *testing.T) {
 			DefaultRemediation: "allow",
 			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
 				spew.Dump(responses)
-				require.Equal(t, "allow", responses[0].Action)
+				require.Equal(t, appsec.AllowRemediation, responses[0].Action)
 				require.Equal(t, http.StatusOK, statusCode)
-				require.Equal(t, "allow", appsecResponse.Action)
+				require.Equal(t, appsec.AllowRemediation, appsecResponse.Action)
 				require.Equal(t, http.StatusOK, appsecResponse.HTTPStatus)
 			},
 		},
@@ -693,9 +693,9 @@ func TestAppsecRuleMatches(t *testing.T) {
 			DefaultRemediation: "captcha",
 			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
 				spew.Dump(responses)
-				require.Equal(t, "captcha", responses[0].Action)
+				require.Equal(t, appsec.CaptchaRemediation, responses[0].Action)
 				require.Equal(t, http.StatusForbidden, statusCode)
-				require.Equal(t, "captcha", appsecResponse.Action)
+				require.Equal(t, appsec.CaptchaRemediation, appsecResponse.Action)
 				require.Equal(t, http.StatusForbidden, appsecResponse.HTTPStatus)
 			},
 		},
@@ -720,9 +720,9 @@ func TestAppsecRuleMatches(t *testing.T) {
 			UserBlockedHTTPCode: 418,
 			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
 				spew.Dump(responses)
-				require.Equal(t, "ban", responses[0].Action)
+				require.Equal(t, appsec.BanRemediation, responses[0].Action)
 				require.Equal(t, http.StatusForbidden, statusCode)
-				require.Equal(t, "ban", appsecResponse.Action)
+				require.Equal(t, appsec.BanRemediation, appsecResponse.Action)
 				require.Equal(t, http.StatusTeapot, appsecResponse.HTTPStatus)
 			},
 		},

--- a/pkg/acquisition/modules/appsec/appsec_test.go
+++ b/pkg/acquisition/modules/appsec/appsec_test.go
@@ -58,7 +58,8 @@ func TestAppsecOnMatchHooks(t *testing.T) {
 				require.Equal(t, types.APPSEC, events[0].Type)
 				require.Equal(t, types.LOG, events[1].Type)
 				require.Len(t, responses, 1)
-				require.Equal(t, 403, responses[0].HTTPResponseCode)
+				require.Equal(t, 403, responses[0].RemediationComponentHTTPResponseCode)
+				require.Equal(t, 403, responses[0].UserHTTPResponseCode)
 				require.Equal(t, "ban", responses[0].Action)
 
 			},
@@ -89,7 +90,8 @@ func TestAppsecOnMatchHooks(t *testing.T) {
 				require.Equal(t, types.APPSEC, events[0].Type)
 				require.Equal(t, types.LOG, events[1].Type)
 				require.Len(t, responses, 1)
-				require.Equal(t, 413, responses[0].HTTPResponseCode)
+				require.Equal(t, 403, responses[0].RemediationComponentHTTPResponseCode)
+				require.Equal(t, 413, responses[0].UserHTTPResponseCode)
 				require.Equal(t, "ban", responses[0].Action)
 			},
 		},

--- a/pkg/acquisition/modules/appsec/appsec_test.go
+++ b/pkg/acquisition/modules/appsec/appsec_test.go
@@ -580,6 +580,177 @@ func TestAppsecPreEvalHooks(t *testing.T) {
 		})
 	}
 }
+
+func TestAppsecRemediationConfigs(t *testing.T) {
+
+	tests := []appsecRuleTest{
+		{
+			name:             "Basic matching rule",
+			expected_load_ok: true,
+			inband_rules: []appsec_rule.CustomRule{
+				{
+					Name:      "rule1",
+					Zones:     []string{"ARGS"},
+					Variables: []string{"foo"},
+					Match:     appsec_rule.Match{Type: "regex", Value: "^toto"},
+					Transform: []string{"lowercase"},
+				},
+			},
+			input_request: appsec.ParsedRequest{
+				RemoteAddr: "1.2.3.4",
+				Method:     "GET",
+				URI:        "/urllll",
+				Args:       url.Values{"foo": []string{"toto"}},
+			},
+			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
+				require.Equal(t, appsec.BanRemediation, responses[0].Action)
+				require.Equal(t, http.StatusForbidden, statusCode)
+				require.Equal(t, appsec.BanRemediation, appsecResponse.Action)
+				require.Equal(t, http.StatusForbidden, appsecResponse.HTTPStatus)
+			},
+		},
+		{
+			name:             "default remediation to ban (default)",
+			expected_load_ok: true,
+			inband_rules: []appsec_rule.CustomRule{
+				{
+					Name:      "rule42",
+					Zones:     []string{"ARGS"},
+					Variables: []string{"foo"},
+					Match:     appsec_rule.Match{Type: "regex", Value: "^toto"},
+					Transform: []string{"lowercase"},
+				},
+			},
+			input_request: appsec.ParsedRequest{
+				RemoteAddr: "1.2.3.4",
+				Method:     "GET",
+				URI:        "/urllll",
+				Args:       url.Values{"foo": []string{"toto"}},
+			},
+			DefaultRemediation: "ban",
+			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
+				require.Equal(t, appsec.BanRemediation, responses[0].Action)
+				require.Equal(t, http.StatusForbidden, statusCode)
+				require.Equal(t, appsec.BanRemediation, appsecResponse.Action)
+				require.Equal(t, http.StatusForbidden, appsecResponse.HTTPStatus)
+			},
+		},
+		{
+			name:             "default remediation to allow",
+			expected_load_ok: true,
+			inband_rules: []appsec_rule.CustomRule{
+				{
+					Name:      "rule42",
+					Zones:     []string{"ARGS"},
+					Variables: []string{"foo"},
+					Match:     appsec_rule.Match{Type: "regex", Value: "^toto"},
+					Transform: []string{"lowercase"},
+				},
+			},
+			input_request: appsec.ParsedRequest{
+				RemoteAddr: "1.2.3.4",
+				Method:     "GET",
+				URI:        "/urllll",
+				Args:       url.Values{"foo": []string{"toto"}},
+			},
+			DefaultRemediation: "allow",
+			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
+				require.Equal(t, appsec.AllowRemediation, responses[0].Action)
+				require.Equal(t, http.StatusOK, statusCode)
+				require.Equal(t, appsec.AllowRemediation, appsecResponse.Action)
+				require.Equal(t, http.StatusOK, appsecResponse.HTTPStatus)
+			},
+		},
+		{
+			name:             "default remediation to captcha",
+			expected_load_ok: true,
+			inband_rules: []appsec_rule.CustomRule{
+				{
+					Name:      "rule42",
+					Zones:     []string{"ARGS"},
+					Variables: []string{"foo"},
+					Match:     appsec_rule.Match{Type: "regex", Value: "^toto"},
+					Transform: []string{"lowercase"},
+				},
+			},
+			input_request: appsec.ParsedRequest{
+				RemoteAddr: "1.2.3.4",
+				Method:     "GET",
+				URI:        "/urllll",
+				Args:       url.Values{"foo": []string{"toto"}},
+			},
+			DefaultRemediation: "captcha",
+			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
+				require.Equal(t, appsec.CaptchaRemediation, responses[0].Action)
+				require.Equal(t, http.StatusForbidden, statusCode)
+				require.Equal(t, appsec.CaptchaRemediation, appsecResponse.Action)
+				require.Equal(t, http.StatusForbidden, appsecResponse.HTTPStatus)
+			},
+		},
+		{
+			name:             "custom user HTTP code",
+			expected_load_ok: true,
+			inband_rules: []appsec_rule.CustomRule{
+				{
+					Name:      "rule42",
+					Zones:     []string{"ARGS"},
+					Variables: []string{"foo"},
+					Match:     appsec_rule.Match{Type: "regex", Value: "^toto"},
+					Transform: []string{"lowercase"},
+				},
+			},
+			input_request: appsec.ParsedRequest{
+				RemoteAddr: "1.2.3.4",
+				Method:     "GET",
+				URI:        "/urllll",
+				Args:       url.Values{"foo": []string{"toto"}},
+			},
+			UserBlockedHTTPCode: 418,
+			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
+				spew.Dump(responses)
+				require.Equal(t, appsec.BanRemediation, responses[0].Action)
+				require.Equal(t, http.StatusForbidden, statusCode)
+				require.Equal(t, appsec.BanRemediation, appsecResponse.Action)
+				require.Equal(t, http.StatusTeapot, appsecResponse.HTTPStatus)
+			},
+		},
+		{
+			name:             "custom remediation + HTTP code",
+			expected_load_ok: true,
+			inband_rules: []appsec_rule.CustomRule{
+				{
+					Name:      "rule42",
+					Zones:     []string{"ARGS"},
+					Variables: []string{"foo"},
+					Match:     appsec_rule.Match{Type: "regex", Value: "^toto"},
+					Transform: []string{"lowercase"},
+				},
+			},
+			input_request: appsec.ParsedRequest{
+				RemoteAddr: "1.2.3.4",
+				Method:     "GET",
+				URI:        "/urllll",
+				Args:       url.Values{"foo": []string{"toto"}},
+			},
+			UserBlockedHTTPCode: 418,
+			DefaultRemediation:  "foobar",
+			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
+				spew.Dump(responses)
+				require.Equal(t, "foobar", responses[0].Action)
+				require.Equal(t, http.StatusForbidden, statusCode)
+				require.Equal(t, "foobar", appsecResponse.Action)
+				require.Equal(t, http.StatusTeapot, appsecResponse.HTTPStatus)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			loadAppSecEngine(test, t)
+		})
+	}
+}
+
 func TestAppsecRuleMatches(t *testing.T) {
 
 	/*

--- a/pkg/acquisition/modules/appsec/appsec_test.go
+++ b/pkg/acquisition/modules/appsec/appsec_test.go
@@ -1216,7 +1216,7 @@ func TestAppsecRuleMatches(t *testing.T) {
 				Args:       url.Values{"foo": []string{"bla"}},
 			},
 			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
-				require.Equal(t, 0, len(events))
+				require.Empty(t, events)
 				require.Equal(t, http.StatusOK, statusCode)
 				require.Equal(t, appsec.AllowRemediation, appsecResponse.Action)
 			},
@@ -1243,7 +1243,7 @@ func TestAppsecRuleMatches(t *testing.T) {
 				Args:       url.Values{"foo": []string{"bla"}},
 			},
 			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
-				require.Equal(t, 0, len(events))
+				require.Empty(t, events)
 				require.Equal(t, http.StatusOK, statusCode)
 				require.Equal(t, appsec.AllowRemediation, appsecResponse.Action)
 			},
@@ -1270,7 +1270,7 @@ func TestAppsecRuleMatches(t *testing.T) {
 				Args:       url.Values{"foo": []string{"bla"}},
 			},
 			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
-				require.Equal(t, 0, len(events))
+				require.Empty(t, events)
 				require.Equal(t, http.StatusOK, statusCode)
 				require.Equal(t, appsec.AllowRemediation, appsecResponse.Action)
 			},

--- a/pkg/appsec/appsec.go
+++ b/pkg/appsec/appsec.go
@@ -31,6 +31,12 @@ const (
 	hookOnMatch
 )
 
+const (
+	BanRemediation     = "ban"
+	CaptchaRemediation = "captcha"
+	AllowRemediation   = "allow"
+)
+
 func (h *Hook) Build(hookStage int) error {
 
 	ctx := map[string]interface{}{}
@@ -210,18 +216,18 @@ func (wc *AppsecConfig) Build() (*AppsecRuntimeConfig, error) {
 		wc.UserPassedHTTPCode = http.StatusOK
 	}
 	if wc.DefaultPassAction == "" {
-		wc.DefaultPassAction = "allow"
+		wc.DefaultPassAction = AllowRemediation
 	}
 	if wc.DefaultRemediation == "" {
-		wc.DefaultRemediation = "ban"
+		wc.DefaultRemediation = BanRemediation
 	}
 
 	//set the defaults
 	switch wc.DefaultRemediation {
-	case "ban", "captcha", "allow":
+	case BanRemediation, CaptchaRemediation, AllowRemediation:
 		//those are the officially supported remediation(s)
 	default:
-		wc.Logger.Warningf("default '%s' remediation of %s is none of [ban,captcha,log] ensure bouncer compatbility!", wc.DefaultRemediation, wc.Name)
+		wc.Logger.Warningf("default '%s' remediation of %s is none of [%s,%s,%s] ensure bouncer compatbility!", wc.DefaultRemediation, wc.Name, BanRemediation, CaptchaRemediation, AllowRemediation)
 	}
 
 	ret.Name = wc.Name
@@ -570,11 +576,11 @@ func (w *AppsecRuntimeConfig) SetAction(action string) error {
 	w.Logger.Debugf("setting action to %s", action)
 	w.Response.Action = action
 	switch action {
-	case "allow":
+	case AllowRemediation:
 		w.Response.BouncerHTTPResponseCode = w.Config.BouncerPassedHTTPCode
 		w.Response.UserHTTPResponseCode = w.Config.UserPassedHTTPCode
 		//@tko how should we handle this ? it seems bouncer only understand bans, but it might be misleading ?
-	case "ban", "captcha":
+	case BanRemediation, CaptchaRemediation:
 		w.Response.BouncerHTTPResponseCode = w.Config.BouncerBlockedHTTPCode
 		w.Response.UserHTTPResponseCode = w.Config.UserBlockedHTTPCode
 	}
@@ -607,10 +613,10 @@ func (w *AppsecRuntimeConfig) GenerateResponse(response AppsecTempResponse, logg
 		resp.Action = w.Config.DefaultRemediation
 	}
 	switch resp.Action {
-	case "allow":
+	case AllowRemediation:
 		resp.HTTPStatus = w.Config.UserPassedHTTPCode
 		http_status = w.Config.BouncerPassedHTTPCode
-	case "ban", "captcha":
+	case BanRemediation, CaptchaRemediation:
 		resp.HTTPStatus = w.Config.UserBlockedHTTPCode
 		http_status = w.Config.BouncerBlockedHTTPCode
 	default:


### PR DESCRIPTION
Fixes #2819 