### PR TITLE
fix: log stack trace while computing metrics

### DIFF
--- a/cmd/crowdsec/metrics.go
+++ b/cmd/crowdsec/metrics.go
@@ -102,6 +102,8 @@ var globalPourHistogram = prometheus.NewHistogramVec(
 
 func computeDynamicMetrics(next http.Handler, dbClient *database.Client) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// catch panics here because they are not handled by servePrometheus
+		defer trace.CatchPanic("crowdsec/computeDynamicMetrics")
 		//update cache metrics (stash)
 		cache.UpdateCacheMetrics()
 		//update cache metrics (regexp)


### PR DESCRIPTION
otherwise they go to stderr in case of panic, with no event in the log