### PR TITLE
Add patterns_dir configuration option

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,6 +14,7 @@ config_paths:
   index_path: /etc/crowdsec/hub/.index.json
   notification_dir: /etc/crowdsec/notifications/
   plugin_dir: /usr/local/lib/crowdsec/plugins/
+  #pattern_dir: /etc/crowdsec/patterns/
 crowdsec_service:
   #console_context_path: /etc/crowdsec/console/context.yaml
   acquisition_path: /etc/crowdsec/acquis.yaml
@@ -27,7 +28,7 @@ db_config:
   type: sqlite
   db_path: /var/lib/crowdsec/data/crowdsec.db
   #max_open_conns: 100
-  #user: 
+  #user:
   #password:
   #db_name:
   #host:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,7 +14,6 @@ config_paths:
   index_path: /etc/crowdsec/hub/.index.json
   notification_dir: /etc/crowdsec/notifications/
   plugin_dir: /usr/local/lib/crowdsec/plugins/
-  #pattern_dir: /etc/crowdsec/patterns/
 crowdsec_service:
   #console_context_path: /etc/crowdsec/console/context.yaml
   acquisition_path: /etc/crowdsec/acquis.yaml
@@ -28,7 +27,7 @@ db_config:
   type: sqlite
   db_path: /var/lib/crowdsec/data/crowdsec.db
   #max_open_conns: 100
-  #user:
+  #user: 
   #password:
   #db_name:
   #host:

--- a/pkg/csconfig/config_paths.go
+++ b/pkg/csconfig/config_paths.go
@@ -13,6 +13,7 @@ type ConfigurationPaths struct {
 	HubDir             string `yaml:"hub_dir,omitempty"`
 	PluginDir          string `yaml:"plugin_dir,omitempty"`
 	NotificationDir    string `yaml:"notification_dir,omitempty"`
+	PatternDir         string `yaml:"pattern_dir,omitempty"`
 }
 
 func (c *Config) loadConfigurationPaths() error {
@@ -33,6 +34,10 @@ func (c *Config) loadConfigurationPaths() error {
 		c.ConfigPaths.HubIndexFile = filepath.Clean(c.ConfigPaths.HubDir + "/.index.json")
 	}
 
+	if c.ConfigPaths.PatternDir == "" {
+		c.ConfigPaths.PatternDir = filepath.Join(c.ConfigPaths.ConfigDir, "patterns/")
+	}
+
 	var configPathsCleanup = []*string{
 		&c.ConfigPaths.HubDir,
 		&c.ConfigPaths.HubIndexFile,
@@ -41,6 +46,7 @@ func (c *Config) loadConfigurationPaths() error {
 		&c.ConfigPaths.SimulationFilePath,
 		&c.ConfigPaths.PluginDir,
 		&c.ConfigPaths.NotificationDir,
+		&c.ConfigPaths.PatternDir,
 	}
 	for _, k := range configPathsCleanup {
 		if *k == "" {

--- a/pkg/parser/unix_parser.go
+++ b/pkg/parser/unix_parser.go
@@ -98,7 +98,7 @@ func NewParsers(hub *cwhub.Hub) *Parsers {
 func LoadParsers(cConfig *csconfig.Config, parsers *Parsers) (*Parsers, error) {
 	var err error
 
-	patternsDir := filepath.Join(cConfig.ConfigPaths.ConfigDir, "patterns/")
+	patternsDir := cConfig.ConfigPaths.PatternDir
 	log.Infof("Loading grok library %s", patternsDir)
 	/* load base regexps for two grok parsers */
 	parsers.Ctx, err = Init(map[string]interface{}{"patterns": patternsDir,


### PR DESCRIPTION
Currently the patterns directory is implicitly set to `/etc/crowdsec/patterns`. This PR make that configurable while keeping the default if not set.