### PR TITLE
hub update: reload crowdsec if only data files have changed

### DIFF
--- a/pkg/cwhub/dataset.go
+++ b/pkg/cwhub/dataset.go
@@ -32,6 +32,9 @@ func downloadFile(url string, destPath string) error {
 		return fmt.Errorf("bad http code %d for %s", resp.StatusCode, url)
 	}
 
+	// Download to a temporary location to avoid corrupting files
+	// that are currently in use or memory mapped.
+
 	tmpFile, err := os.CreateTemp(filepath.Dir(destPath), filepath.Base(destPath)+".*.tmp")
 	if err != nil {
 		return err

--- a/pkg/cwhub/dataset.go
+++ b/pkg/cwhub/dataset.go
@@ -43,11 +43,6 @@ func downloadFile(url string, destPath string) error {
 		os.Remove(tmpFileName)
 	}()
 
-	// a check on stdout is used while scripting to know if the hub has been upgraded
-	// and a configuration reload is required
-	// TODO: use a better way to communicate this
-	fmt.Printf("updated %s\n", filepath.Base(destPath))
-
 	// avoid reading the whole file in memory
 	_, err = io.Copy(tmpFile, resp.Body)
 	if err != nil {
@@ -61,6 +56,11 @@ func downloadFile(url string, destPath string) error {
 	if err = tmpFile.Close(); err != nil {
 		return err
 	}
+
+	// a check on stdout is used while scripting to know if the hub has been upgraded
+	// and a configuration reload is required
+	// TODO: use a better way to communicate this
+	fmt.Printf("updated %s\n", filepath.Base(destPath))
 
 	if err = os.Rename(tmpFileName, destPath); err != nil {
 		return err

--- a/pkg/cwhub/dataset.go
+++ b/pkg/cwhub/dataset.go
@@ -43,6 +43,11 @@ func downloadFile(url string, destPath string) error {
 		os.Remove(tmpFileName)
 	}()
 
+	// a check on stdout is used while scripting to know if the hub has been upgraded
+	// and a configuration reload is required
+	// TODO: use a better way to communicate this
+	fmt.Printf("updated %s\n", filepath.Base(destPath))
+
 	// avoid reading the whole file in memory
 	_, err = io.Copy(tmpFile, resp.Body)
 	if err != nil {


### PR DESCRIPTION
From the cron scripts in both linux and freebsd:

```
upgraded=$(/usr/bin/cscli --error hub upgrade)
if [ -n "$upgraded" ]; then
    [...] reload crowdsec
fi
```