### PR TITLE
Fix REQUEST_URI behavior + fix #2891

### DIFF
--- a/pkg/acquisition/modules/appsec/appsec_others_test.go
+++ b/pkg/acquisition/modules/appsec/appsec_others_test.go
@@ -1,0 +1,74 @@
+//go:build !windows
+// +build !windows
+
+package appsecacquisition
+
+import (
+	"testing"
+
+	"github.com/crowdsecurity/crowdsec/pkg/appsec"
+	"github.com/crowdsecurity/crowdsec/pkg/appsec/appsec_rule"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppsecRuleTransformsOthers(t *testing.T) {
+
+	log.SetLevel(log.TraceLevel)
+	tests := []appsecRuleTest{
+		{
+			name:             "normalizepath",
+			expected_load_ok: true,
+			inband_rules: []appsec_rule.CustomRule{
+				{
+					Name:      "rule1",
+					Zones:     []string{"ARGS"},
+					Variables: []string{"foo"},
+					Match:     appsec_rule.Match{Type: "equals", Value: "b/c"},
+					Transform: []string{"normalizepath"},
+				},
+			},
+			input_request: appsec.ParsedRequest{
+				RemoteAddr: "1.2.3.4",
+				Method:     "GET",
+				URI:        "/?foo=a/../b/c",
+			},
+			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
+				require.Len(t, events, 2)
+				require.Equal(t, types.APPSEC, events[0].Type)
+				require.Equal(t, types.LOG, events[1].Type)
+				require.Equal(t, "rule1", events[1].Appsec.MatchedRules[0]["msg"])
+			},
+		},
+		{
+			name:             "normalizepath #2",
+			expected_load_ok: true,
+			inband_rules: []appsec_rule.CustomRule{
+				{
+					Name:      "rule1",
+					Zones:     []string{"ARGS"},
+					Variables: []string{"foo"},
+					Match:     appsec_rule.Match{Type: "equals", Value: "b/c/"},
+					Transform: []string{"normalizepath"},
+				},
+			},
+			input_request: appsec.ParsedRequest{
+				RemoteAddr: "1.2.3.4",
+				Method:     "GET",
+				URI:        "/?foo=a/../b/c/////././././",
+			},
+			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
+				require.Len(t, events, 2)
+				require.Equal(t, types.APPSEC, events[0].Type)
+				require.Equal(t, types.LOG, events[1].Type)
+				require.Equal(t, "rule1", events[1].Appsec.MatchedRules[0]["msg"])
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			loadAppSecEngine(test, t)
+		})
+	}
+}

--- a/pkg/acquisition/modules/appsec/appsec_test.go
+++ b/pkg/acquisition/modules/appsec/appsec_test.go
@@ -1476,54 +1476,6 @@ func TestAppsecRuleTransforms(t *testing.T) {
 				require.Equal(t, "rule1", events[1].Appsec.MatchedRules[0]["msg"])
 			},
 		},
-		{
-			name:             "normalizepath",
-			expected_load_ok: true,
-			inband_rules: []appsec_rule.CustomRule{
-				{
-					Name:      "rule1",
-					Zones:     []string{"ARGS"},
-					Variables: []string{"foo"},
-					Match:     appsec_rule.Match{Type: "equals", Value: "b/c"},
-					Transform: []string{"normalizepath"},
-				},
-			},
-			input_request: appsec.ParsedRequest{
-				RemoteAddr: "1.2.3.4",
-				Method:     "GET",
-				URI:        "/?foo=a/../b/c",
-			},
-			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
-				require.Len(t, events, 2)
-				require.Equal(t, types.APPSEC, events[0].Type)
-				require.Equal(t, types.LOG, events[1].Type)
-				require.Equal(t, "rule1", events[1].Appsec.MatchedRules[0]["msg"])
-			},
-		},
-		{
-			name:             "normalizepath #2",
-			expected_load_ok: true,
-			inband_rules: []appsec_rule.CustomRule{
-				{
-					Name:      "rule1",
-					Zones:     []string{"ARGS"},
-					Variables: []string{"foo"},
-					Match:     appsec_rule.Match{Type: "equals", Value: "b/c/"},
-					Transform: []string{"normalizepath"},
-				},
-			},
-			input_request: appsec.ParsedRequest{
-				RemoteAddr: "1.2.3.4",
-				Method:     "GET",
-				URI:        "/?foo=a/../b/c/////././././",
-			},
-			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
-				require.Len(t, events, 2)
-				require.Equal(t, types.APPSEC, events[0].Type)
-				require.Equal(t, types.LOG, events[1].Type)
-				require.Equal(t, "rule1", events[1].Appsec.MatchedRules[0]["msg"])
-			},
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/acquisition/modules/appsec/appsec_win_test.go
+++ b/pkg/acquisition/modules/appsec/appsec_win_test.go
@@ -6,41 +6,37 @@ package appsecacquisition
 import (
 	"testing"
 
-	"github.com/crowdsecurity/crowdsec/pkg/appsec"
-	"github.com/crowdsecurity/crowdsec/pkg/appsec/appsec_rule"
-	"github.com/crowdsecurity/crowdsec/pkg/types"
 	log "github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAppsecRuleTransformsWindows(t *testing.T) {
 
 	log.SetLevel(log.TraceLevel)
 	tests := []appsecRuleTest{
-		{
-			name:             "normalizepath",
-			expected_load_ok: true,
-			inband_rules: []appsec_rule.CustomRule{
-				{
-					Name:      "rule1",
-					Zones:     []string{"ARGS"},
-					Variables: []string{"foo"},
-					Match:     appsec_rule.Match{Type: "equals", Value: "b/c"},
-					Transform: []string{"normalizepath"},
-				},
-			},
-			input_request: appsec.ParsedRequest{
-				RemoteAddr: "1.2.3.4",
-				Method:     "GET",
-				URI:        "/?foo=a/../b/c",
-			},
-			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
-				require.Len(t, events, 2)
-				require.Equal(t, types.APPSEC, events[0].Type)
-				require.Equal(t, types.LOG, events[1].Type)
-				require.Equal(t, "rule1", events[1].Appsec.MatchedRules[0]["msg"])
-			},
-		},
+		// {
+		// 	name:             "normalizepath",
+		// 	expected_load_ok: true,
+		// 	inband_rules: []appsec_rule.CustomRule{
+		// 		{
+		// 			Name:      "rule1",
+		// 			Zones:     []string{"ARGS"},
+		// 			Variables: []string{"foo"},
+		// 			Match:     appsec_rule.Match{Type: "equals", Value: "b/c"},
+		// 			Transform: []string{"normalizepath"},
+		// 		},
+		// 	},
+		// 	input_request: appsec.ParsedRequest{
+		// 		RemoteAddr: "1.2.3.4",
+		// 		Method:     "GET",
+		// 		URI:        "/?foo=a/../b/c",
+		// 	},
+		// 	output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
+		// 		require.Len(t, events, 2)
+		// 		require.Equal(t, types.APPSEC, events[0].Type)
+		// 		require.Equal(t, types.LOG, events[1].Type)
+		// 		require.Equal(t, "rule1", events[1].Appsec.MatchedRules[0]["msg"])
+		// 	},
+		// },
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/acquisition/modules/appsec/appsec_win_test.go
+++ b/pkg/acquisition/modules/appsec/appsec_win_test.go
@@ -1,0 +1,50 @@
+//go:build windows
+// +build windows
+
+package appsecacquisition
+
+import (
+	"testing"
+
+	"github.com/crowdsecurity/crowdsec/pkg/appsec"
+	"github.com/crowdsecurity/crowdsec/pkg/appsec/appsec_rule"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppsecRuleTransformsWindows(t *testing.T) {
+
+	log.SetLevel(log.TraceLevel)
+	tests := []appsecRuleTest{
+		{
+			name:             "normalizepath",
+			expected_load_ok: true,
+			inband_rules: []appsec_rule.CustomRule{
+				{
+					Name:      "rule1",
+					Zones:     []string{"ARGS"},
+					Variables: []string{"foo"},
+					Match:     appsec_rule.Match{Type: "equals", Value: "b/c"},
+					Transform: []string{"normalizepath"},
+				},
+			},
+			input_request: appsec.ParsedRequest{
+				RemoteAddr: "1.2.3.4",
+				Method:     "GET",
+				URI:        "/?foo=a/../b/c",
+			},
+			output_asserts: func(events []types.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
+				require.Len(t, events, 2)
+				require.Equal(t, types.APPSEC, events[0].Type)
+				require.Equal(t, types.LOG, events[1].Type)
+				require.Equal(t, "rule1", events[1].Appsec.MatchedRules[0]["msg"])
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			loadAppSecEngine(test, t)
+		})
+	}
+}

--- a/pkg/appsec/appsec_rule/modsecurity.go
+++ b/pkg/appsec/appsec_rule/modsecurity.go
@@ -29,8 +29,14 @@ var transformMap map[string]string = map[string]string{
 	"lowercase": "t:lowercase",
 	"uppercase": "t:uppercase",
 	"b64decode": "t:base64Decode",
-	"hexdecode": "t:hexDecode",
-	"length":    "t:length",
+	//"hexdecode":          "t:hexDecode", -> not supported by coraza
+	"length":             "t:length",
+	"urldecode":          "t:urlDecode",
+	"trim":               "t:trim",
+	"normalize_path":     "t:normalizePath",
+	"normalizepath":      "t:normalizePath",
+	"htmlentitydecode":   "t:htmlEntityDecode",
+	"html_entity_decode": "t:htmlEntityDecode",
 }
 
 var matchMap map[string]string = map[string]string{

--- a/pkg/appsec/appsec_rule/modsecurity.go
+++ b/pkg/appsec/appsec_rule/modsecurity.go
@@ -19,7 +19,8 @@ var zonesMap map[string]string = map[string]string{
 	"HEADERS":         "REQUEST_HEADERS",
 	"METHOD":          "REQUEST_METHOD",
 	"PROTOCOL":        "REQUEST_PROTOCOL",
-	"URI":             "REQUEST_URI",
+	"URI":             "REQUEST_FILENAME",
+	"URI_FULL":        "REQUEST_URI",
 	"RAW_BODY":        "REQUEST_BODY",
 	"FILENAMES":       "FILES",
 }

--- a/pkg/appsec/request.go
+++ b/pkg/appsec/request.go
@@ -30,6 +30,7 @@ type ParsedRequest struct {
 	Host                 string                  `json:"host,omitempty"`
 	ClientIP             string                  `json:"client_ip,omitempty"`
 	URI                  string                  `json:"uri,omitempty"`
+	Path                 string                  `json:"path,omitempty"`
 	Args                 url.Values              `json:"args,omitempty"`
 	ClientHost           string                  `json:"client_host,omitempty"`
 	Headers              http.Header             `json:"headers,omitempty"`
@@ -365,11 +366,12 @@ func NewParsedRequestFromRequest(r *http.Request, logger *logrus.Entry) (ParsedR
 		UUID:                 uuid.New().String(),
 		ClientHost:           clientHost,
 		ClientIP:             clientIP,
-		URI:                  parsedURL.Path,
+		URI:                  clientURI,
+		Path:                 parsedURL.Path,
 		Method:               clientMethod,
-		Host:                 r.Host,
+		Host:                 clientHost,
 		Headers:              r.Header,
-		URL:                  r.URL,
+		URL:                  parsedURL,
 		Proto:                r.Proto,
 		Body:                 body,
 		Args:                 ParseQuery(parsedURL.RawQuery),

--- a/pkg/appsec/request.go
+++ b/pkg/appsec/request.go
@@ -30,7 +30,6 @@ type ParsedRequest struct {
 	Host                 string                  `json:"host,omitempty"`
 	ClientIP             string                  `json:"client_ip,omitempty"`
 	URI                  string                  `json:"uri,omitempty"`
-	Path                 string                  `json:"path,omitempty"`
 	Args                 url.Values              `json:"args,omitempty"`
 	ClientHost           string                  `json:"client_host,omitempty"`
 	Headers              http.Header             `json:"headers,omitempty"`
@@ -367,7 +366,6 @@ func NewParsedRequestFromRequest(r *http.Request, logger *logrus.Entry) (ParsedR
 		ClientHost:           clientHost,
 		ClientIP:             clientIP,
 		URI:                  clientURI,
-		Path:                 parsedURL.Path,
 		Method:               clientMethod,
 		Host:                 clientHost,
 		Headers:              r.Header,


### PR DESCRIPTION
 - [x] Checked that it doesn't break existing vpatch rules (`cscli hubtest run --appsec --all`)
 - [x] Add the new helpers in the doc (`normalizepath`, `trim`, `urldecode`, `htmlentitydecode`)
 - [x] Fix some documentation (`contain` -> `contains`. Remove `hexdecode` that doesn't exist)
