### PR TITLE
cscli: avoid global vars

### DIFF
--- a/cmd/crowdsec-cli/hub.go
+++ b/cmd/crowdsec-cli/hub.go
@@ -47,7 +47,9 @@ cscli hub upgrade`,
 }
 
 func (cli *cliHub) list(all bool) error {
-	hub, err := require.Hub(cli.cfg(), nil, log.StandardLogger())
+	cfg := cli.cfg()
+
+	hub, err := require.Hub(cfg, nil, log.StandardLogger())
 	if err != nil {
 		return err
 	}
@@ -69,7 +71,7 @@ func (cli *cliHub) list(all bool) error {
 		}
 	}
 
-	err = listItems(color.Output, cwhub.ItemTypes, items, true)
+	err = listItems(color.Output, cwhub.ItemTypes, items, true, cfg.Cscli.Output)
 	if err != nil {
 		return err
 	}

--- a/cmd/crowdsec-cli/hubappsec.go
+++ b/cmd/crowdsec-cli/hubappsec.go
@@ -50,7 +50,7 @@ cscli appsec-configs list crowdsecurity/vpatch`,
 func NewCLIAppsecRule(cfg configGetter) *cliItem {
 	inspectDetail := func(item *cwhub.Item) error {
 		// Only show the converted rules in human mode
-		if csConfig.Cscli.Output != "human" {
+		if cfg().Cscli.Output != "human" {
 			return nil
 		}
 

--- a/cmd/crowdsec-cli/item_metrics.go
+++ b/cmd/crowdsec-cli/item_metrics.go
@@ -18,22 +18,22 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 )
 
-func ShowMetrics(hubItem *cwhub.Item) error {
+func ShowMetrics(prometheusURL string, hubItem *cwhub.Item) error {
 	switch hubItem.Type {
 	case cwhub.PARSERS:
-		metrics := GetParserMetric(csConfig.Cscli.PrometheusUrl, hubItem.Name)
+		metrics := GetParserMetric(prometheusURL, hubItem.Name)
 		parserMetricsTable(color.Output, hubItem.Name, metrics)
 	case cwhub.SCENARIOS:
-		metrics := GetScenarioMetric(csConfig.Cscli.PrometheusUrl, hubItem.Name)
+		metrics := GetScenarioMetric(prometheusURL, hubItem.Name)
 		scenarioMetricsTable(color.Output, hubItem.Name, metrics)
 	case cwhub.COLLECTIONS:
 		for _, sub := range hubItem.SubItems() {
-			if err := ShowMetrics(sub); err != nil {
+			if err := ShowMetrics(prometheusURL, sub); err != nil {
 				return err
 			}
 		}
 	case cwhub.APPSEC_RULES:
-		metrics := GetAppsecRuleMetric(csConfig.Cscli.PrometheusUrl, hubItem.Name)
+		metrics := GetAppsecRuleMetric(prometheusURL, hubItem.Name)
 		appsecMetricsTable(color.Output, hubItem.Name, metrics)
 	default: // no metrics for this item type
 	}

--- a/cmd/crowdsec-cli/item_suggest.go
+++ b/cmd/crowdsec-cli/item_suggest.go
@@ -36,8 +36,8 @@ func suggestNearestMessage(hub *cwhub.Hub, itemType string, itemName string) str
 	return msg
 }
 
-func compAllItems(itemType string, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	hub, err := require.Hub(csConfig, nil, nil)
+func compAllItems(itemType string, args []string, toComplete string, cfg configGetter) ([]string, cobra.ShellCompDirective) {
+	hub, err := require.Hub(cfg(), nil, nil)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveDefault
 	}
@@ -55,8 +55,8 @@ func compAllItems(itemType string, args []string, toComplete string) ([]string, 
 	return comp, cobra.ShellCompDirectiveNoFileComp
 }
 
-func compInstalledItems(itemType string, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	hub, err := require.Hub(csConfig, nil, nil)
+func compInstalledItems(itemType string, args []string, toComplete string, cfg configGetter) ([]string, cobra.ShellCompDirective) {
+	hub, err := require.Hub(cfg(), nil, nil)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveDefault
 	}

--- a/cmd/crowdsec-cli/itemcli.go
+++ b/cmd/crowdsec-cli/itemcli.go
@@ -112,7 +112,7 @@ func (cli cliItem) newInstallCmd() *cobra.Command {
 		Args:              cobra.MinimumNArgs(1),
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return compAllItems(cli.name, args, toComplete)
+			return compAllItems(cli.name, args, toComplete, cli.cfg)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			return cli.install(args, downloadOnly, force, ignoreError)
@@ -238,7 +238,7 @@ func (cli cliItem) newRemoveCmd() *cobra.Command {
 		Aliases:           []string{"delete"},
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return compInstalledItems(cli.name, args, toComplete)
+			return compInstalledItems(cli.name, args, toComplete, cli.cfg)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			return cli.remove(args, purge, force, all)
@@ -333,7 +333,7 @@ func (cli cliItem) newUpgradeCmd() *cobra.Command {
 		Example:           cli.upgradeHelp.example,
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return compInstalledItems(cli.name, args, toComplete)
+			return compInstalledItems(cli.name, args, toComplete, cli.cfg)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			return cli.upgrade(args, force, all)
@@ -381,7 +381,7 @@ func (cli cliItem) inspect(args []string, url string, diff bool, rev bool, noMet
 			continue
 		}
 
-		if err = inspectItem(item, !noMetrics); err != nil {
+		if err = inspectItem(item, !noMetrics, cfg.Cscli.Output, cfg.Cscli.PrometheusUrl); err != nil {
 			return err
 		}
 
@@ -411,7 +411,7 @@ func (cli cliItem) newInspectCmd() *cobra.Command {
 		Args:              cobra.MinimumNArgs(1),
 		DisableAutoGenTag: true,
 		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return compInstalledItems(cli.name, args, toComplete)
+			return compInstalledItems(cli.name, args, toComplete, cli.cfg)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			return cli.inspect(args, url, diff, rev, noMetrics)
@@ -428,6 +428,8 @@ func (cli cliItem) newInspectCmd() *cobra.Command {
 }
 
 func (cli cliItem) list(args []string, all bool) error {
+	cfg := cli.cfg()
+
 	hub, err := require.Hub(cli.cfg(), nil, log.StandardLogger())
 	if err != nil {
 		return err
@@ -440,7 +442,7 @@ func (cli cliItem) list(args []string, all bool) error {
 		return err
 	}
 
-	if err = listItems(color.Output, []string{cli.name}, items, false); err != nil {
+	if err = listItems(color.Output, []string{cli.name}, items, false, cfg.Cscli.Output); err != nil {
 		return err
 	}
 

--- a/cmd/crowdsec-cli/items.go
+++ b/cmd/crowdsec-cli/items.go
@@ -54,8 +54,8 @@ func selectItems(hub *cwhub.Hub, itemType string, args []string, installedOnly b
 	return items, nil
 }
 
-func listItems(out io.Writer, itemTypes []string, items map[string][]*cwhub.Item, omitIfEmpty bool) error {
-	switch csConfig.Cscli.Output {
+func listItems(out io.Writer, itemTypes []string, items map[string][]*cwhub.Item, omitIfEmpty bool, output string) error {
+	switch output {
 	case "human":
 		nothingToDisplay := true
 
@@ -143,8 +143,8 @@ func listItems(out io.Writer, itemTypes []string, items map[string][]*cwhub.Item
 	return nil
 }
 
-func inspectItem(item *cwhub.Item, showMetrics bool) error {
-	switch csConfig.Cscli.Output {
+func inspectItem(item *cwhub.Item, showMetrics bool, output string, prometheusURL string) error {
+	switch output {
 	case "human", "raw":
 		enc := yaml.NewEncoder(os.Stdout)
 		enc.SetIndent(2)
@@ -161,7 +161,7 @@ func inspectItem(item *cwhub.Item, showMetrics bool) error {
 		fmt.Print(string(b))
 	}
 
-	if csConfig.Cscli.Output != "human" {
+	if output != "human" {
 		return nil
 	}
 
@@ -174,7 +174,7 @@ func inspectItem(item *cwhub.Item, showMetrics bool) error {
 	if showMetrics {
 		fmt.Printf("\nCurrent metrics: \n")
 
-		if err := ShowMetrics(item); err != nil {
+		if err := ShowMetrics(prometheusURL, item); err != nil {
 			return err
 		}
 	}

--- a/cmd/crowdsec-cli/support.go
+++ b/cmd/crowdsec-cli/support.go
@@ -154,7 +154,7 @@ func collectHubItems(hub *cwhub.Hub, itemType string) []byte {
 		log.Warnf("could not collect %s list: %s", itemType, err)
 	}
 
-	if err := listItems(out, []string{itemType}, items, false); err != nil {
+	if err := listItems(out, []string{itemType}, items, false, "human"); err != nil {
 		log.Warnf("could not collect %s list: %s", itemType, err)
 	}
 

--- a/pkg/acquisition/acquisition_test.go
+++ b/pkg/acquisition/acquisition_test.go
@@ -1,6 +1,7 @@
 package acquisition
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -50,7 +51,7 @@ func (f *MockSource) Configure(cfg []byte, logger *log.Entry, metricsLevel int) 
 	}
 
 	if f.Toto == "" {
-		return fmt.Errorf("expect non-empty toto")
+		return errors.New("expect non-empty toto")
 	}
 
 	return nil
@@ -64,7 +65,7 @@ func (f *MockSource) GetAggregMetrics() []prometheus.Collector                { 
 func (f *MockSource) Dump() interface{}                                       { return f }
 func (f *MockSource) GetName() string                                         { return "mock" }
 func (f *MockSource) ConfigureByDSN(string, map[string]string, *log.Entry, string) error {
-	return fmt.Errorf("not supported")
+	return errors.New("not supported")
 }
 func (f *MockSource) GetUuid() string { return "" }
 
@@ -73,7 +74,7 @@ type MockSourceCantRun struct {
 	MockSource
 }
 
-func (f *MockSourceCantRun) CanRun() error   { return fmt.Errorf("can't run bro") }
+func (f *MockSourceCantRun) CanRun() error   { return errors.New("can't run bro") }
 func (f *MockSourceCantRun) GetName() string { return "mock_cant_run" }
 
 // appendMockSource is only used to add mock source for tests
@@ -331,14 +332,14 @@ func (f *MockCat) OneShotAcquisition(out chan types.Event, tomb *tomb.Tomb) erro
 	return nil
 }
 func (f *MockCat) StreamingAcquisition(chan types.Event, *tomb.Tomb) error {
-	return fmt.Errorf("can't run in tail")
+	return errors.New("can't run in tail")
 }
 func (f *MockCat) CanRun() error                            { return nil }
 func (f *MockCat) GetMetrics() []prometheus.Collector       { return nil }
 func (f *MockCat) GetAggregMetrics() []prometheus.Collector { return nil }
 func (f *MockCat) Dump() interface{}                        { return f }
 func (f *MockCat) ConfigureByDSN(string, map[string]string, *log.Entry, string) error {
-	return fmt.Errorf("not supported")
+	return errors.New("not supported")
 }
 func (f *MockCat) GetUuid() string { return "" }
 
@@ -366,7 +367,7 @@ func (f *MockTail) UnmarshalConfig(cfg []byte) error { return nil }
 func (f *MockTail) GetName() string                  { return "mock_tail" }
 func (f *MockTail) GetMode() string                  { return "tail" }
 func (f *MockTail) OneShotAcquisition(out chan types.Event, tomb *tomb.Tomb) error {
-	return fmt.Errorf("can't run in cat mode")
+	return errors.New("can't run in cat mode")
 }
 func (f *MockTail) StreamingAcquisition(out chan types.Event, t *tomb.Tomb) error {
 	for i := 0; i < 10; i++ {
@@ -383,7 +384,7 @@ func (f *MockTail) GetMetrics() []prometheus.Collector       { return nil }
 func (f *MockTail) GetAggregMetrics() []prometheus.Collector { return nil }
 func (f *MockTail) Dump() interface{}                        { return f }
 func (f *MockTail) ConfigureByDSN(string, map[string]string, *log.Entry, string) error {
-	return fmt.Errorf("not supported")
+	return errors.New("not supported")
 }
 func (f *MockTail) GetUuid() string { return "" }
 
@@ -457,9 +458,9 @@ func (f *MockTailError) StreamingAcquisition(out chan types.Event, t *tomb.Tomb)
 		evt.Line.Src = "test"
 		out <- evt
 	}
-	t.Kill(fmt.Errorf("got error (tomb)"))
+	t.Kill(errors.New("got error (tomb)"))
 
-	return fmt.Errorf("got error")
+	return errors.New("got error")
 }
 
 func TestStartAcquisitionTailError(t *testing.T) {
@@ -512,7 +513,7 @@ func (f *MockSourceByDSN) GetName() string                                      
 func (f *MockSourceByDSN) ConfigureByDSN(dsn string, labels map[string]string, logger *log.Entry, uuid string) error {
 	dsn = strings.TrimPrefix(dsn, "mockdsn://")
 	if dsn != "test_expect" {
-		return fmt.Errorf("unexpected value")
+		return errors.New("unexpected value")
 	}
 
 	return nil

--- a/pkg/acquisition/modules/cloudwatch/cloudwatch_test.go
+++ b/pkg/acquisition/modules/cloudwatch/cloudwatch_test.go
@@ -1,6 +1,7 @@
 package cloudwatchacquisition
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -43,7 +44,7 @@ func deleteAllLogGroups(t *testing.T, cw *CloudwatchSource) {
 func checkForLocalStackAvailability() error {
 	v := os.Getenv("AWS_ENDPOINT_FORCE")
 	if v == "" {
-		return fmt.Errorf("missing aws endpoint for tests : AWS_ENDPOINT_FORCE")
+		return errors.New("missing aws endpoint for tests : AWS_ENDPOINT_FORCE")
 	}
 
 	v = strings.TrimPrefix(v, "http://")

--- a/pkg/csconfig/config_paths.go
+++ b/pkg/csconfig/config_paths.go
@@ -1,6 +1,7 @@
 package csconfig
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 )
@@ -19,11 +20,11 @@ type ConfigurationPaths struct {
 func (c *Config) loadConfigurationPaths() error {
 	var err error
 	if c.ConfigPaths == nil {
-		return fmt.Errorf("no configuration paths provided")
+		return errors.New("no configuration paths provided")
 	}
 
 	if c.ConfigPaths.DataDir == "" {
-		return fmt.Errorf("please provide a data directory with the 'data_dir' directive in the 'config_paths' section")
+		return errors.New("please provide a data directory with the 'data_dir' directive in the 'config_paths' section")
 	}
 
 	if c.ConfigPaths.HubDir == "" {

--- a/pkg/longpollclient/client.go
+++ b/pkg/longpollclient/client.go
@@ -46,7 +46,7 @@ type pollResponse struct {
 	ErrorMessage string `json:"error"`
 }
 
-var errUnauthorized = fmt.Errorf("user is not authorized to use PAPI")
+var errUnauthorized = errors.New("user is not authorized to use PAPI")
 
 const timeoutMessage = "no events before timeout"
 
@@ -225,7 +225,7 @@ func (c *LongPollClient) PullOnce(since time.Time) ([]Event, error) {
 func NewLongPollClient(config LongPollClientConfig) (*LongPollClient, error) {
 	var logger *log.Entry
 	if config.Url == (url.URL{}) {
-		return nil, fmt.Errorf("url is required")
+		return nil, errors.New("url is required")
 	}
 	if config.Logger == nil {
 		logger = log.WithField("component", "longpollclient")

--- a/pkg/parser/parsing_test.go
+++ b/pkg/parser/parsing_test.go
@@ -131,7 +131,7 @@ func testOneParser(pctx *UnixParserCtx, ectx EnricherCtx, dir string, b *testing
 	}
 	for n := 0; n < count; n++ {
 		if testFile(tests, *pctx, pnodes) != true {
-			return fmt.Errorf("test failed !")
+			return errors.New("test failed !")
 		}
 	}
 	return nil
@@ -296,7 +296,7 @@ func testSubSet(testSet TestFile, pctx UnixParserCtx, nodes []Node) (bool, error
 	*/
 	if len(testSet.Results) == 0 && len(results) == 0 {
 		log.Fatal("No results, no tests, abort.")
-		return false, fmt.Errorf("no tests, no results")
+		return false, errors.New("no tests, no results")
 	}
 
 reCheck:


### PR DESCRIPTION
This is required to make it possible to split the package