### PR TITLE
building cross-platform AMD64 and ARM64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ BUILD_REQUIRE_GO_MINOR ?= 21
 
 GO = go
 GOTEST = $(GO) test
-
+GOARCH = $(dpkg --print-architecture)
 BUILD_CODENAME ?= alphaga
 
 CROWDSEC_FOLDER = ./cmd/crowdsec


### PR DESCRIPTION
I came across this tutorial to run on arm and I found it unnecessary it can be handled if we use command dpkg --print-architecture in linux.

![image](https://github.com/crowdsecurity/crowdsec/assets/41409442/5fec4b2d-7e41-4184-9a57-525bb133b3f2)
