### PR TITLE
CI: disable log formatting for consistency

### DIFF
--- a/test/bats/01_crowdsec.bats
+++ b/test/bats/01_crowdsec.bats
@@ -217,7 +217,7 @@ teardown() {
 
     #shellcheck disable=SC2016
     rune -0 wait-for \
-        --err 'datasource '\''journalctl'\'' is not available: exec: "journalctl": executable file not found in ' \
+        --err 'datasource '\''journalctl'\'' is not available: exec: \\"journalctl\\": executable file not found in ' \
         env PATH='' "${CROWDSEC}"
 
     # if all datasources are disabled, crowdsec should exit

--- a/test/bats/01_crowdsec_lapi.bats
+++ b/test/bats/01_crowdsec_lapi.bats
@@ -27,25 +27,25 @@ teardown() {
 
 @test "lapi (.api.server.enable=false)" {
     rune -0 config_set '.api.server.enable=false'
-    rune -1 "${CROWDSEC}" -no-cs
+    rune -1 "$CROWDSEC" -no-cs
     assert_stderr --partial "you must run at least the API Server or crowdsec"
 }
 
 @test "lapi (no .api.server.listen_uri)" {
     rune -0 config_set 'del(.api.server.listen_socket) | del(.api.server.listen_uri)'
-    rune -1 "${CROWDSEC}" -no-cs
+    rune -1 "$CROWDSEC" -no-cs
     assert_stderr --partial "no listen_uri or listen_socket specified"
 }
 
 @test "lapi (bad .api.server.listen_uri)" {
     rune -0 config_set 'del(.api.server.listen_socket) | .api.server.listen_uri="127.0.0.1:-80"'
-    rune -1 "${CROWDSEC}" -no-cs
+    rune -1 "$CROWDSEC" -no-cs
     assert_stderr --partial "local API server stopped with error: listening on 127.0.0.1:-80: listen tcp: address -80: invalid port"
 }
 
 @test "lapi (listen on random port)" {
     config_set '.common.log_media="stdout"'
     rune -0 config_set 'del(.api.server.listen_socket) | .api.server.listen_uri="127.0.0.1:0"'
-    rune -0 wait-for --err "CrowdSec Local API listening on 127.0.0.1:" "${CROWDSEC}" -no-cs
+    rune -0 wait-for --err "CrowdSec Local API listening on 127.0.0.1:" "$CROWDSEC" -no-cs
 }
 

--- a/test/bats/01_cscli.bats
+++ b/test/bats/01_cscli.bats
@@ -51,7 +51,7 @@ teardown() {
     assert_stderr --partial "Constraint_acquis:"
 
     # should work without configuration file
-    rm "${CONFIG_YAML}"
+    rm "$CONFIG_YAML"
     rune -0 cscli version
     assert_stderr --partial "version:"
 }
@@ -62,7 +62,7 @@ teardown() {
     assert_line --regexp ".* help .* Help about any command"
 
     # should work without configuration file
-    rm "${CONFIG_YAML}"
+    rm "$CONFIG_YAML"
     rune -0 cscli help
     assert_line "Available Commands:"
 }
@@ -132,7 +132,7 @@ teardown() {
 
 
 @test "cscli - required configuration paths" {
-    config=$(cat "${CONFIG_YAML}")
+    config=$(cat "$CONFIG_YAML")
     configdir=$(config_get '.config_paths.config_dir')
 
     # required configuration paths with no defaults
@@ -140,12 +140,12 @@ teardown() {
     config_set 'del(.config_paths)'
     rune -1 cscli hub list
     assert_stderr --partial 'no configuration paths provided'
-    echo "$config" > "${CONFIG_YAML}"
+    echo "$config" > "$CONFIG_YAML"
 
     config_set 'del(.config_paths.data_dir)'
     rune -1 cscli hub list
     assert_stderr --partial "please provide a data directory with the 'data_dir' directive in the 'config_paths' section"
-    echo "$config" > "${CONFIG_YAML}"
+    echo "$config" > "$CONFIG_YAML"
 
     # defaults
 
@@ -153,13 +153,13 @@ teardown() {
     rune -0 cscli hub list
     rune -0 cscli config show --key Config.ConfigPaths.HubDir
     assert_output "$configdir/hub"
-    echo "$config" > "${CONFIG_YAML}"
+    echo "$config" > "$CONFIG_YAML"
 
     config_set 'del(.config_paths.index_path)'
     rune -0 cscli hub list
     rune -0 cscli config show --key Config.ConfigPaths.HubIndexFile
     assert_output "$configdir/hub/.index.json"
-    echo "$config" > "${CONFIG_YAML}"
+    echo "$config" > "$CONFIG_YAML"
 }
 
 @test "cscli config show-yaml" {
@@ -182,30 +182,30 @@ teardown() {
     assert_stderr --partial "failed to backup config: while creating /dev/null/blah: mkdir /dev/null/blah: not a directory"
 
     # pick a dirpath
-    backupdir=$(TMPDIR="${BATS_TEST_TMPDIR}" mktemp -u)
+    backupdir=$(TMPDIR="$BATS_TEST_TMPDIR" mktemp -u)
 
     # succeed the first time
-    rune -0 cscli config backup "${backupdir}"
+    rune -0 cscli config backup "$backupdir"
     assert_stderr --partial "Starting configuration backup"
 
     # don't overwrite an existing backup
-    rune -1 cscli config backup "${backupdir}"
+    rune -1 cscli config backup "$backupdir"
     assert_stderr --partial "failed to backup config"
     assert_stderr --partial "file exists"
 
     SIMULATION_YAML="$(config_get '.config_paths.simulation_path')"
 
     # restore
-    rm "${SIMULATION_YAML}"
-    rune -0 cscli config restore "${backupdir}"
-    assert_file_exists "${SIMULATION_YAML}"
+    rm "$SIMULATION_YAML"
+    rune -0 cscli config restore "$backupdir"
+    assert_file_exists "$SIMULATION_YAML"
 
     # cleanup
     rm -rf -- "${backupdir:?}"
 
     # backup: detect missing files
-    rm "${SIMULATION_YAML}"
-    rune -1 cscli config backup "${backupdir}"
+    rm "$SIMULATION_YAML"
+    rune -1 cscli config backup "$backupdir"
     assert_stderr --regexp "failed to backup config: failed copy .* to .*: stat .*: no such file or directory"
     rm -rf -- "${backupdir:?}"
 }
@@ -221,7 +221,7 @@ teardown() {
 
 @test "cscli - missing LAPI credentials file" {
     LOCAL_API_CREDENTIALS=$(config_get '.api.client.credentials_path')
-    rm -f "${LOCAL_API_CREDENTIALS}"
+    rm -f "$LOCAL_API_CREDENTIALS"
     rune -1 cscli lapi status
     assert_stderr --partial "loading api client: while reading yaml file: open ${LOCAL_API_CREDENTIALS}: no such file or directory"
 
@@ -234,7 +234,7 @@ teardown() {
 
 @test "cscli - empty LAPI credentials file" {
     LOCAL_API_CREDENTIALS=$(config_get '.api.client.credentials_path')
-    : > "${LOCAL_API_CREDENTIALS}"
+    : > "$LOCAL_API_CREDENTIALS"
     rune -1 cscli lapi status
     assert_stderr --partial "no credentials or URL found in api client configuration '${LOCAL_API_CREDENTIALS}'"
 
@@ -259,7 +259,7 @@ teardown() {
 
 @test "cscli - malformed LAPI url" {
     LOCAL_API_CREDENTIALS=$(config_get '.api.client.credentials_path')
-    config_set "${LOCAL_API_CREDENTIALS}" '.url="http://127.0.0.1:-80"'
+    config_set "$LOCAL_API_CREDENTIALS" '.url="http://127.0.0.1:-80"'
 
     rune -1 cscli lapi status -o json
     rune -0 jq -r '.msg' <(stderr)
@@ -269,7 +269,7 @@ teardown() {
 @test "cscli - bad LAPI password" {
     rune -0 ./instance-crowdsec start
     LOCAL_API_CREDENTIALS=$(config_get '.api.client.credentials_path')
-    config_set "${LOCAL_API_CREDENTIALS}" '.password="meh"'
+    config_set "$LOCAL_API_CREDENTIALS" '.password="meh"'
 
     rune -1 cscli lapi status -o json
     rune -0 jq -r '.msg' <(stderr)
@@ -286,7 +286,7 @@ teardown() {
     rune -0 cscli completion fish
     assert_output --partial "# fish completion for cscli"
 
-    rm "${CONFIG_YAML}"
+    rm "$CONFIG_YAML"
     rune -0 cscli completion bash
     assert_output --partial "# bash completion for cscli"
 }

--- a/test/bats/02_nolapi.bats
+++ b/test/bats/02_nolapi.bats
@@ -27,12 +27,12 @@ teardown() {
     config_set '.common.log_media="stdout"'
     rune -0 wait-for \
         --err "CrowdSec Local API listening" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "crowdsec should not run without LAPI (-no-api flag)" {
     config_set '.common.log_media="stdout"'
-    rune -1 wait-for "${CROWDSEC}" -no-api
+    rune -1 wait-for "$CROWDSEC" -no-api
 }
 
 @test "crowdsec should not run without LAPI (no api.server in configuration file)" {
@@ -40,7 +40,7 @@ teardown() {
     config_log_stderr
     rune -0 wait-for \
         --err "crowdsec local API is disabled" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "capi status shouldn't be ok without api.server" {
@@ -68,10 +68,10 @@ teardown() {
 
 @test "cscli config backup" {
     config_disable_lapi
-    backupdir=$(TMPDIR="${BATS_TEST_TMPDIR}" mktemp -u)
-    rune -0 cscli config backup "${backupdir}"
+    backupdir=$(TMPDIR="$BATS_TEST_TMPDIR" mktemp -u)
+    rune -0 cscli config backup "$backupdir"
     assert_stderr --partial "Starting configuration backup"
-    rune -1 cscli config backup "${backupdir}"
+    rune -1 cscli config backup "$backupdir"
     rm -rf -- "${backupdir:?}"
 
     assert_stderr --partial "failed to backup config"

--- a/test/bats/03_noagent.bats
+++ b/test/bats/03_noagent.bats
@@ -26,14 +26,14 @@ teardown() {
     config_set '.common.log_media="stdout"'
     rune -0 wait-for \
         --err "Starting processing data" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "no agent: crowdsec LAPI should run (-no-cs flag)" {
     config_set '.common.log_media="stdout"'
     rune -0 wait-for \
         --err "CrowdSec Local API listening" \
-        "${CROWDSEC}" -no-cs
+        "$CROWDSEC" -no-cs
 }
 
 @test "no agent: crowdsec LAPI should run (no crowdsec_service in configuration file)" {
@@ -41,7 +41,7 @@ teardown() {
     config_log_stderr
     rune -0 wait-for \
         --err "crowdsec agent is disabled" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "no agent: cscli config show" {
@@ -62,10 +62,10 @@ teardown() {
 
 @test "no agent: cscli config backup" {
     config_disable_agent
-    backupdir=$(TMPDIR="${BATS_TEST_TMPDIR}" mktemp -u)
-    rune -0 cscli config backup "${backupdir}"
+    backupdir=$(TMPDIR="$BATS_TEST_TMPDIR" mktemp -u)
+    rune -0 cscli config backup "$backupdir"
     assert_stderr --partial "Starting configuration backup"
-    rune -1 cscli config backup "${backupdir}"
+    rune -1 cscli config backup "$backupdir"
 
     assert_stderr --partial "failed to backup config"
     assert_stderr --partial "file exists"

--- a/test/bats/04_nocapi.bats
+++ b/test/bats/04_nocapi.bats
@@ -27,7 +27,7 @@ teardown() {
 
     rune -0 wait-for \
         --err "Communication with CrowdSec Central API disabled from args" \
-        "${CROWDSEC}" -no-capi
+        "$CROWDSEC" -no-capi
 }
 
 @test "without capi: crowdsec LAPI should still work" {
@@ -35,7 +35,7 @@ teardown() {
     config_set '.common.log_media="stdout"'
     rune -0 wait-for \
         --err "push and pull to Central API disabled" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "without capi: cscli capi status -> fail" {
@@ -53,10 +53,10 @@ teardown() {
 
 @test "no agent: cscli config backup" {
     config_disable_capi
-    backupdir=$(TMPDIR="${BATS_TEST_TMPDIR}" mktemp -u)
-    rune -0 cscli config backup "${backupdir}"
+    backupdir=$(TMPDIR="$BATS_TEST_TMPDIR" mktemp -u)
+    rune -0 cscli config backup "$backupdir"
     assert_stderr --partial "Starting configuration backup"
-    rune -1 cscli config backup "${backupdir}"
+    rune -1 cscli config backup "$backupdir"
     assert_stderr --partial "failed to backup config"
     assert_stderr --partial "file exists"
     rm -rf -- "${backupdir:?}"

--- a/test/bats/05_config_yaml_local.bats
+++ b/test/bats/05_config_yaml_local.bats
@@ -21,7 +21,7 @@ setup() {
     load "../lib/setup.sh"
     ./instance-data load
     rune -0 config_get '.api.client.credentials_path'
-    LOCAL_API_CREDENTIALS="${output}"
+    LOCAL_API_CREDENTIALS="$output"
     export LOCAL_API_CREDENTIALS
 }
 
@@ -88,13 +88,13 @@ teardown() {
 @test "simulation.yaml.local" {
     rune -0 config_get '.config_paths.simulation_path'
     refute_output null
-    SIMULATION="${output}"
+    SIMULATION="$output"
 
-    echo "simulation: off" >"${SIMULATION}"
+    echo "simulation: off" >"$SIMULATION"
     rune -0 cscli simulation status -o human
     assert_stderr --partial "global simulation: disabled"
 
-    echo "simulation: on" >"${SIMULATION}"
+    echo "simulation: on" >"$SIMULATION"
     rune -0 cscli simulation status -o human
     assert_stderr --partial "global simulation: enabled"
 
@@ -110,7 +110,7 @@ teardown() {
 @test "profiles.yaml.local" {
     rune -0 config_get '.api.server.profiles_path'
     refute_output null
-    PROFILES="${output}"
+    PROFILES="$output"
 
     cat <<-EOT >"${PROFILES}.local"
 	name: default_ip_remediation
@@ -122,17 +122,17 @@ teardown() {
 	on_success: break
 	EOT
 
-    tmpfile=$(TMPDIR="${BATS_TEST_TMPDIR}" mktemp)
-    touch "${tmpfile}"
+    tmpfile=$(TMPDIR="$BATS_TEST_TMPDIR" mktemp)
+    touch "$tmpfile"
     ACQUIS_YAML=$(config_get '.crowdsec_service.acquisition_path')
-    echo -e "---\nfilename: ${tmpfile}\nlabels:\n  type: syslog\n" >>"${ACQUIS_YAML}"
+    echo -e "---\nfilename: ${tmpfile}\nlabels:\n  type: syslog\n" >>"$ACQUIS_YAML"
 
     rune -0 cscli collections install crowdsecurity/sshd
     rune -0 cscli parsers install crowdsecurity/syslog-logs
 
     ./instance-crowdsec start
     sleep .5
-    fake_log >>"${tmpfile}"
+    fake_log >>"$tmpfile"
 
     # this could be simplified, but some systems are slow and we don't want to
     # wait more than required
@@ -141,6 +141,6 @@ teardown() {
         rune -0 cscli decisions list -o json
         rune -0 jq --exit-status '.[].decisions[0] | [.value,.type] == ["1.1.1.172","captcha"]' <(output) && break
     done
-    rm -f -- "${tmpfile}"
-    [[ "${status}" -eq 0 ]] || fail "captcha not triggered"
+    rm -f -- "$tmpfile"
+    [[ "$status" -eq 0 ]] || fail "captcha not triggered"
 }

--- a/test/bats/11_bouncers_tls.bats
+++ b/test/bats/11_bouncers_tls.bats
@@ -7,7 +7,7 @@ setup_file() {
     load "../lib/setup_file.sh"
     ./instance-data load
 
-    tmpdir="${BATS_FILE_TMPDIR}"
+    tmpdir="$BATS_FILE_TMPDIR"
     export tmpdir
 
     CFDIR="${BATS_TEST_DIRNAME}/testdata/cfssl"

--- a/test/bats/13_capi_whitelists.bats
+++ b/test/bats/13_capi_whitelists.bats
@@ -31,7 +31,7 @@ teardown() {
 @test "capi_whitelists: file missing" {
     rune -0 wait-for \
         --err "while opening capi whitelist file: open $CAPI_WHITELISTS_YAML: no such file or directory" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "capi_whitelists: error on open" {
@@ -40,11 +40,11 @@ teardown() {
     if is_package_testing; then
         rune -0 wait-for \
             --err "while parsing capi whitelist file .*: empty file" \
-            "${CROWDSEC}"
+            "$CROWDSEC"
     else
         rune -0 wait-for \
             --err "while opening capi whitelist file: open $CAPI_WHITELISTS_YAML: permission denied" \
-            "${CROWDSEC}"
+            "$CROWDSEC"
     fi
 }
 
@@ -52,28 +52,28 @@ teardown() {
     echo > "$CAPI_WHITELISTS_YAML"
     rune -0 wait-for \
         --err "while parsing capi whitelist file '$CAPI_WHITELISTS_YAML': empty file" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "capi_whitelists: empty lists" {
     echo '{"ips": [], "cidrs": []}' > "$CAPI_WHITELISTS_YAML"
     rune -0 wait-for \
         --err "Starting processing data" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "capi_whitelists: bad ip" {
     echo '{"ips": ["blahblah"], "cidrs": []}' > "$CAPI_WHITELISTS_YAML"
     rune -0 wait-for \
         --err "while parsing capi whitelist file '$CAPI_WHITELISTS_YAML': invalid IP address: blahblah" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "capi_whitelists: bad cidr" {
     echo '{"ips": [], "cidrs": ["blahblah"]}' > "$CAPI_WHITELISTS_YAML"
     rune -0 wait-for \
         --err "while parsing capi whitelist file '$CAPI_WHITELISTS_YAML': invalid CIDR address: blahblah" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "capi_whitelists: file with ip and cidr values" {

--- a/test/bats/20_hub_collections_dep.bats
+++ b/test/bats/20_hub_collections_dep.bats
@@ -121,6 +121,6 @@ teardown() {
 
     rune -1 cscli hub list
     assert_stderr --partial "circular dependency detected"
-    rune -1 wait-for "${CROWDSEC}"
+    rune -1 wait-for "$CROWDSEC"
     assert_stderr --partial "circular dependency detected"
 }

--- a/test/bats/30_machines_tls.bats
+++ b/test/bats/30_machines_tls.bats
@@ -7,10 +7,10 @@ setup_file() {
     load "../lib/setup_file.sh"
     ./instance-data load
 
-    CONFIG_DIR=$(dirname "${CONFIG_YAML}")
+    CONFIG_DIR=$(dirname "$CONFIG_YAML")
     export CONFIG_DIR
 
-    tmpdir="${BATS_FILE_TMPDIR}"
+    tmpdir="$BATS_FILE_TMPDIR"
     export tmpdir
 
     CFDIR="${BATS_TEST_DIRNAME}/testdata/cfssl"
@@ -80,7 +80,7 @@ teardown() {
 
     rune -0 wait-for \
         --err "missing TLS key file" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "missing cert_file" {
@@ -88,7 +88,7 @@ teardown() {
 
     rune -0 wait-for \
         --err "missing TLS cert file" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "invalid OU for agent" {

--- a/test/bats/40_cold-logs.bats
+++ b/test/bats/40_cold-logs.bats
@@ -32,14 +32,14 @@ setup() {
 #----------
 
 @test "-type and -dsn are required together" {
-    rune -1 "${CROWDSEC}" -no-api -type syslog
+    rune -1 "$CROWDSEC" -no-api -type syslog
     assert_stderr --partial "-type requires a -dsn argument"
-    rune -1 "${CROWDSEC}" -no-api -dsn file:///dev/fd/0
+    rune -1 "$CROWDSEC" -no-api -dsn file:///dev/fd/0
     assert_stderr --partial "-dsn requires a -type argument"
 }
 
 @test "the one-shot mode works" {
-    rune -0 "${CROWDSEC}" -dsn file://<(fake_log) -type syslog -no-api
+    rune -0 "$CROWDSEC" -dsn file://<(fake_log) -type syslog -no-api
     refute_output
     assert_stderr --partial "single file mode : log_media=stdout daemonize=false"
     assert_stderr --regexp "Adding file .* to filelist"

--- a/test/bats/40_live-ban.bats
+++ b/test/bats/40_live-ban.bats
@@ -35,20 +35,20 @@ teardown() {
 #----------
 
 @test "1.1.1.172 has been banned" {
-    tmpfile=$(TMPDIR="${BATS_TEST_TMPDIR}" mktemp)
-    touch "${tmpfile}"
+    tmpfile=$(TMPDIR="$BATS_TEST_TMPDIR" mktemp)
+    touch "$tmpfile"
     ACQUIS_YAML=$(config_get '.crowdsec_service.acquisition_path')
-    echo -e "---\nfilename: ${tmpfile}\nlabels:\n  type: syslog\n" >>"${ACQUIS_YAML}"
+    echo -e "---\nfilename: ${tmpfile}\nlabels:\n  type: syslog\n" >>"$ACQUIS_YAML"
 
     ./instance-crowdsec start
 
     sleep 0.2
 
-    fake_log >>"${tmpfile}"
+    fake_log >>"$tmpfile"
 
     sleep 0.2
 
-    rm -f -- "${tmpfile}"
+    rm -f -- "$tmpfile"
 
     found=0
     # this may take some time in CI
@@ -59,5 +59,5 @@ teardown() {
         fi
         sleep 0.2
     done
-    assert_equal 1 "${found}"
+    assert_equal 1 "$found"
 }

--- a/test/bats/50_simulation.bats
+++ b/test/bats/50_simulation.bats
@@ -33,7 +33,7 @@ setup() {
 
 @test "we have one decision" {
     rune -0 cscli simulation disable --global
-    fake_log | "${CROWDSEC}" -dsn file:///dev/fd/0 -type syslog -no-api
+    fake_log | "$CROWDSEC" -dsn file:///dev/fd/0 -type syslog -no-api
     rune -0 cscli decisions list -o json
     rune -0 jq '. | length' <(output)
     assert_output 1
@@ -41,7 +41,7 @@ setup() {
 
 @test "1.1.1.174 has been banned (exact)" {
     rune -0 cscli simulation disable --global
-    fake_log | "${CROWDSEC}" -dsn file:///dev/fd/0 -type syslog -no-api
+    fake_log | "$CROWDSEC" -dsn file:///dev/fd/0 -type syslog -no-api
     rune -0 cscli decisions list -o json
     rune -0 jq -r '.[].decisions[0].value' <(output)
     assert_output '1.1.1.174'
@@ -49,7 +49,7 @@ setup() {
 
 @test "decision has simulated == false (exact)" {
     rune -0 cscli simulation disable --global
-    fake_log | "${CROWDSEC}" -dsn file:///dev/fd/0 -type syslog -no-api
+    fake_log | "$CROWDSEC" -dsn file:///dev/fd/0 -type syslog -no-api
     rune -0 cscli decisions list -o json
     rune -0 jq '.[].decisions[0].simulated' <(output)
     assert_output 'false'
@@ -57,7 +57,7 @@ setup() {
 
 @test "simulated scenario, listing non-simulated: expect no decision" {
     rune -0 cscli simulation enable crowdsecurity/ssh-bf
-    fake_log | "${CROWDSEC}" -dsn file:///dev/fd/0 -type syslog -no-api
+    fake_log | "$CROWDSEC" -dsn file:///dev/fd/0 -type syslog -no-api
     rune -0 cscli decisions list --no-simu -o json
     assert_json '[]'
 }
@@ -65,7 +65,7 @@ setup() {
 @test "global simulation, listing non-simulated: expect no decision" {
     rune -0 cscli simulation disable crowdsecurity/ssh-bf
     rune -0 cscli simulation enable --global
-    fake_log | "${CROWDSEC}" -dsn file:///dev/fd/0 -type syslog -no-api
+    fake_log | "$CROWDSEC" -dsn file:///dev/fd/0 -type syslog -no-api
     rune -0 cscli decisions list --no-simu -o json
     assert_json '[]'
 }

--- a/test/bats/70_plugin_http.bats
+++ b/test/bats/70_plugin_http.bats
@@ -15,7 +15,7 @@ setup_file() {
     export MOCK_URL
     PLUGIN_DIR=$(config_get '.config_paths.plugin_dir')
     # could have a trailing slash
-    PLUGIN_DIR=$(realpath "${PLUGIN_DIR}")
+    PLUGIN_DIR=$(realpath "$PLUGIN_DIR")
     export PLUGIN_DIR
 
     # https://mikefarah.gitbook.io/yq/operators/env-variable-operators
@@ -35,10 +35,10 @@ setup_file() {
         .plugin_config.group=""
     '
 
-    rm -f -- "${MOCK_OUT}"
+    rm -f -- "$MOCK_OUT"
 
     ./instance-crowdsec start
-    ./instance-mock-http start "${MOCK_PORT}"
+    ./instance-mock-http start "$MOCK_PORT"
 }
 
 teardown_file() {
@@ -63,24 +63,24 @@ setup() {
 }
 
 @test "expected 1 log line from http server" {
-    rune -0 wc -l <"${MOCK_OUT}"
+    rune -0 wc -l <"$MOCK_OUT"
     # wc can pad with spaces on some platforms
     rune -0 tr -d ' ' < <(output)
     assert_output 1
 }
 
 @test "expected to receive 2 alerts in the request body from plugin" {
-    rune -0 jq -r '.request_body' <"${MOCK_OUT}"
+    rune -0 jq -r '.request_body' <"$MOCK_OUT"
     rune -0 jq -r 'length' <(output)
     assert_output 2
 }
 
 @test "expected to receive IP 1.2.3.4 as value of first decision" {
-    rune -0 jq -r '.request_body[0].decisions[0].value' <"${MOCK_OUT}"
+    rune -0 jq -r '.request_body[0].decisions[0].value' <"$MOCK_OUT"
     assert_output 1.2.3.4
 }
 
 @test "expected to receive IP 1.2.3.5 as value of second decision" {
-    rune -0 jq -r '.request_body[1].decisions[0].value' <"${MOCK_OUT}"
+    rune -0 jq -r '.request_body[1].decisions[0].value' <"$MOCK_OUT"
     assert_output 1.2.3.5
 }

--- a/test/bats/71_plugin_dummy.bats
+++ b/test/bats/71_plugin_dummy.bats
@@ -9,15 +9,15 @@ setup_file() {
 
     ./instance-data load
 
-    tempfile=$(TMPDIR="${BATS_FILE_TMPDIR}" mktemp)
+    tempfile=$(TMPDIR="$BATS_FILE_TMPDIR" mktemp)
     export tempfile
 
-    tempfile2=$(TMPDIR="${BATS_FILE_TMPDIR}" mktemp)
+    tempfile2=$(TMPDIR="$BATS_FILE_TMPDIR" mktemp)
     export tempfile2
 
     DUMMY_YAML="$(config_get '.config_paths.notification_dir')/dummy.yaml"
 
-    config_set "${DUMMY_YAML}" '
+    config_set "$DUMMY_YAML" '
        .group_wait="5s" |
        .group_threshold=2 |
        .output_file=strenv(tempfile) |
@@ -67,12 +67,12 @@ setup() {
 }
 
 @test "expected 1 notification" {
-    rune -0 cat "${tempfile}"
+    rune -0 cat "$tempfile"
     assert_output --partial 1.2.3.4
     assert_output --partial 1.2.3.5
 }
 
 @test "second notification works too" {
-    rune -0 cat "${tempfile2}"
+    rune -0 cat "$tempfile2"
     assert_output --partial secondfile
 }

--- a/test/bats/72_plugin_badconfig.bats
+++ b/test/bats/72_plugin_badconfig.bats
@@ -8,7 +8,7 @@ setup_file() {
 
     PLUGIN_DIR=$(config_get '.config_paths.plugin_dir')
     # could have a trailing slash
-    PLUGIN_DIR=$(realpath "${PLUGIN_DIR}")
+    PLUGIN_DIR=$(realpath "$PLUGIN_DIR")
     export PLUGIN_DIR
 
     PROFILES_PATH=$(config_get '.api.server.profiles_path')
@@ -26,50 +26,50 @@ setup() {
 
 teardown() {
     ./instance-crowdsec stop
-    rm -f "${PLUGIN_DIR}"/badname
-    chmod go-w "${PLUGIN_DIR}"/notification-http || true
+    rm -f "$PLUGIN_DIR"/badname
+    chmod go-w "$PLUGIN_DIR"/notification-http || true
 }
 
 #----------
 
 @test "misconfigured plugin, only user is empty" {
     config_set '.plugin_config.user="" | .plugin_config.group="nogroup"'
-    config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
+    config_set "$PROFILES_PATH" '.notifications=["http_default"]'
     rune -0 wait-for \
         --err "api server init: unable to run plugin broker: while loading plugin: while getting process attributes: both plugin user and group must be set" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "misconfigured plugin, only group is empty" {
     config_set '(.plugin_config.user="nobody") | (.plugin_config.group="")'
-    config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
+    config_set "$PROFILES_PATH" '.notifications=["http_default"]'
     rune -0 wait-for \
         --err "api server init: unable to run plugin broker: while loading plugin: while getting process attributes: both plugin user and group must be set" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "misconfigured plugin, user does not exist" {
     config_set '(.plugin_config.user="userdoesnotexist") | (.plugin_config.group="groupdoesnotexist")'
-    config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
+    config_set "$PROFILES_PATH" '.notifications=["http_default"]'
     rune -0 wait-for \
         --err "api server init: unable to run plugin broker: while loading plugin: while getting process attributes: user: unknown user userdoesnotexist" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "misconfigured plugin, group does not exist" {
     config_set '(.plugin_config.user=strenv(USER)) | (.plugin_config.group="groupdoesnotexist")'
-    config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
+    config_set "$PROFILES_PATH" '.notifications=["http_default"]'
     rune -0 wait-for \
         --err "api server init: unable to run plugin broker: while loading plugin: while getting process attributes: group: unknown group groupdoesnotexist" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "bad plugin name" {
-    config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
-    cp "${PLUGIN_DIR}"/notification-http "${PLUGIN_DIR}"/badname
+    config_set "$PROFILES_PATH" '.notifications=["http_default"]'
+    cp "$PLUGIN_DIR"/notification-http "$PLUGIN_DIR"/badname
     rune -0 wait-for \
         --err "api server init: unable to run plugin broker: while loading plugin: plugin name ${PLUGIN_DIR}/badname is invalid. Name should be like {type-name}" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "duplicate notification config" {
@@ -77,58 +77,58 @@ teardown() {
     # email_default has two configurations
     rune -0 yq -i '.name="email_default"' "$CONFIG_DIR/notifications/http.yaml"
     # enable a notification, otherwise plugins are ignored
-    config_set "${PROFILES_PATH}" '.notifications=["slack_default"]'
+    config_set "$PROFILES_PATH" '.notifications=["slack_default"]'
     # the slack plugin may fail or not, but we just need the logs
     config_set '.common.log_media="stdout"'
     rune wait-for \
         --err "notification 'email_default' is defined multiple times" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "bad plugin permission (group writable)" {
-    config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
-    chmod g+w "${PLUGIN_DIR}"/notification-http
+    config_set "$PROFILES_PATH" '.notifications=["http_default"]'
+    chmod g+w "$PLUGIN_DIR"/notification-http
     rune -0 wait-for \
         --err "api server init: unable to run plugin broker: while loading plugin: plugin at ${PLUGIN_DIR}/notification-http is group writable, group writable plugins are invalid" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "bad plugin permission (world writable)" {
-    config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
-    chmod o+w "${PLUGIN_DIR}"/notification-http
+    config_set "$PROFILES_PATH" '.notifications=["http_default"]'
+    chmod o+w "$PLUGIN_DIR"/notification-http
     rune -0 wait-for \
         --err "api server init: unable to run plugin broker: while loading plugin: plugin at ${PLUGIN_DIR}/notification-http is world writable, world writable plugins are invalid" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "config.yaml: missing .plugin_config section" {
     config_set 'del(.plugin_config)'
-    config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
+    config_set "$PROFILES_PATH" '.notifications=["http_default"]'
     rune -0 wait-for \
         --err "api server init: plugins are enabled, but the plugin_config section is missing in the configuration" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "config.yaml: missing config_paths.notification_dir" {
     config_set 'del(.config_paths.notification_dir)'
-    config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
+    config_set "$PROFILES_PATH" '.notifications=["http_default"]'
     rune -0 wait-for \
         --err "api server init: plugins are enabled, but config_paths.notification_dir is not defined" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "config.yaml: missing config_paths.plugin_dir" {
     config_set 'del(.config_paths.plugin_dir)'
-    config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
+    config_set "$PROFILES_PATH" '.notifications=["http_default"]'
     rune -0 wait-for \
         --err "api server init: plugins are enabled, but config_paths.plugin_dir is not defined" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }
 
 @test "unable to run plugin broker: while reading plugin config" {
     config_set '.config_paths.notification_dir="/this/path/does/not/exist"'
-    config_set "${PROFILES_PATH}" '.notifications=["http_default"]'
+    config_set "$PROFILES_PATH" '.notifications=["http_default"]'
     rune -0 wait-for \
         --err "api server init: unable to run plugin broker: while loading plugin config: open /this/path/does/not/exist: no such file or directory" \
-        "${CROWDSEC}"
+        "$CROWDSEC"
 }

--- a/test/bats/73_plugin_formatting.bats
+++ b/test/bats/73_plugin_formatting.bats
@@ -9,7 +9,7 @@ setup_file() {
 
     ./instance-data load
 
-    tempfile=$(TMPDIR="${BATS_FILE_TMPDIR}" mktemp)
+    tempfile=$(TMPDIR="$BATS_FILE_TMPDIR" mktemp)
     export tempfile
 
     DUMMY_YAML="$(config_get '.config_paths.notification_dir')/dummy.yaml"
@@ -17,7 +17,7 @@ setup_file() {
     # we test the template that is suggested in the email notification
     # the $alert is not a shell variable
     # shellcheck disable=SC2016
-    config_set "${DUMMY_YAML}" '
+    config_set "$DUMMY_YAML" '
        .group_wait="5s" |
        .group_threshold=2 |
        .output_file=strenv(tempfile) |
@@ -58,7 +58,7 @@ setup() {
 }
 
 @test "expected 1 notification" {
-    rune -0 cat "${tempfile}"
+    rune -0 cat "$tempfile"
     assert_output - <<-EOT
 	<html><body> <p><a href="https://www.whois.com/whois/1.2.3.4">1.2.3.4</a> will get <b>ban</b> for next <b>30s</b> for triggering <b>manual 'ban' from 'githubciXXXXXXXXXXXXXXXXXXXXXXXX'</b> on machine <b>githubciXXXXXXXXXXXXXXXXXXXXXXXX</b>.</p> <p><a href="https://app.crowdsec.net/cti/1.2.3.4">CrowdSec CTI</a></p> <p><a href="https://www.whois.com/whois/1.2.3.5">1.2.3.5</a> will get <b>ban</b> for next <b>30s</b> for triggering <b>manual 'ban' from 'githubciXXXXXXXXXXXXXXXXXXXXXXXX'</b> on machine <b>githubciXXXXXXXXXXXXXXXXXXXXXXXX</b>.</p> <p><a href="https://app.crowdsec.net/cti/1.2.3.5">CrowdSec CTI</a></p> </body></html>
 	EOT

--- a/test/bats/80_alerts.bats
+++ b/test/bats/80_alerts.bats
@@ -73,9 +73,9 @@ teardown() {
     rune -0 cscli alerts list -o raw <(output)
     rune -0 grep 10.20.30.40 <(output)
     rune -0 cut -d, -f1 <(output)
-    ALERT_ID="${output}"
+    ALERT_ID="$output"
 
-    rune -0 cscli alerts inspect "${ALERT_ID}" -o human
+    rune -0 cscli alerts inspect "$ALERT_ID" -o human
     rune -0 plaintext < <(output)
     assert_line --regexp '^#+$'
     assert_line --regexp "^ - ID *: ${ALERT_ID}$"
@@ -93,10 +93,10 @@ teardown() {
     assert_line --regexp "^.* ID .* scope:value .* action .* expiration .* created_at .*$"
     assert_line --regexp "^.* Ip:10.20.30.40 .* ban .*$"
 
-    rune -0 cscli alerts inspect "${ALERT_ID}" -o human --details
+    rune -0 cscli alerts inspect "$ALERT_ID" -o human --details
     # XXX can we have something here?
 
-    rune -0 cscli alerts inspect "${ALERT_ID}" -o raw
+    rune -0 cscli alerts inspect "$ALERT_ID" -o raw
     assert_line --regexp "^ *capacity: 0$"
     assert_line --regexp "^ *id: ${ALERT_ID}$"
     assert_line --regexp "^ *origin: cscli$"
@@ -106,11 +106,11 @@ teardown() {
     assert_line --regexp "^ *type: ban$"
     assert_line --regexp "^ *value: 10.20.30.40$"
 
-    rune -0 cscli alerts inspect "${ALERT_ID}" -o json
+    rune -0 cscli alerts inspect "$ALERT_ID" -o json
     alert=${output}
-    rune jq -c '.decisions[] | [.origin,.scenario,.scope,.simulated,.type,.value]' <<<"${alert}"
+    rune jq -c '.decisions[] | [.origin,.scenario,.scope,.simulated,.type,.value]' <<<"$alert"
     assert_output --regexp "\[\"cscli\",\"manual 'ban' from 'githubciXXXXXXXXXXXXXXXXXXXXXXXX.*'\",\"Ip\",false,\"ban\",\"10.20.30.40\"\]"
-    rune jq -c '.source' <<<"${alert}"
+    rune jq -c '.source' <<<"$alert"
     assert_json '{ip:"10.20.30.40",scope:"Ip",value:"10.20.30.40"}'
 }
 
@@ -188,7 +188,7 @@ teardown() {
     rune -0 cscli decisions add -i 10.20.30.40 -t ban
     rune -9 cscli decisions list --ip 10.20.30.40 -o json
     rune -9 jq -r '.[].decisions[].id' <(output)
-    DECISION_ID="${output}"
+    DECISION_ID="$output"
 
     ./instance-crowdsec stop
     rune -0 ./instance-db exec_sql "UPDATE decisions SET ... WHERE id=${DECISION_ID}"

--- a/test/bats/81_alert_context.bats
+++ b/test/bats/81_alert_context.bats
@@ -32,8 +32,8 @@ teardown() {
 #----------
 
 @test "$FILE 1.1.1.172 has context" {
-    tmpfile=$(TMPDIR="${BATS_TEST_TMPDIR}" mktemp)
-    touch "${tmpfile}"
+    tmpfile=$(TMPDIR="$BATS_TEST_TMPDIR" mktemp)
+    touch "$tmpfile"
 
     ACQUIS_YAML=$(config_get '.crowdsec_service.acquisition_path')
 
@@ -61,9 +61,9 @@ teardown() {
 
     ./instance-crowdsec start
     sleep 2
-    fake_log >>"${tmpfile}"
+    fake_log >>"$tmpfile"
     sleep 2
-    rm -f -- "${tmpfile}"
+    rm -f -- "$tmpfile"
 
     rune -0 cscli alerts list -o json
     rune -0 jq '.[0].id' <(output)

--- a/test/bats/90_decisions.bats
+++ b/test/bats/90_decisions.bats
@@ -166,7 +166,7 @@ teardown() {
     # silently discarding (but logging) invalid decisions
 
     rune -0 cscli alerts delete --all
-    truncate -s 0 "${LOGFILE}"
+    truncate -s 0 "$LOGFILE"
 
     rune -0 cscli decisions import -i - --format values <<-EOT
 	whatever
@@ -182,7 +182,7 @@ teardown() {
 
 
     rune -0 cscli alerts delete --all
-    truncate -s 0 "${LOGFILE}"
+    truncate -s 0 "$LOGFILE"
 
     rune -0 cscli decisions import -i - --format values <<-EOT
         1.2.3.4

--- a/test/lib/config/config-local
+++ b/test/lib/config/config-local
@@ -80,7 +80,6 @@ config_generate() {
     .common.daemonize=true |
     del(.common.pid_dir) |
     .common.log_level="info" |
-    .common.force_color_logs=true |
     .common.log_dir=strenv(LOG_DIR) |
     .config_paths.config_dir=strenv(CONFIG_DIR) |
     .config_paths.data_dir=strenv(DATA_DIR) |


### PR DESCRIPTION
log files won't be formatted/colored during CI tests because they are not in production or during package testing