### PR TITLE
version: write to stdout, add missing newline

### DIFF
--- a/cmd/crowdsec-cli/support.go
+++ b/cmd/crowdsec-cli/support.go
@@ -123,7 +123,7 @@ func (cli *cliSupport) dumpMetrics(ctx context.Context, zw *zip.Writer) error {
 func (cli *cliSupport) dumpVersion(zw *zip.Writer) {
 	log.Info("Collecting version")
 
-	cli.writeToZip(zw, SUPPORT_VERSION_PATH, time.Now(), strings.NewReader(cwversion.ShowStr()))
+	cli.writeToZip(zw, SUPPORT_VERSION_PATH, time.Now(), strings.NewReader(cwversion.FullString()))
 }
 
 func (cli *cliSupport) dumpFeatures(zw *zip.Writer) {

--- a/cmd/crowdsec-cli/version.go
+++ b/cmd/crowdsec-cli/version.go
@@ -14,14 +14,14 @@ func NewCLIVersion() *cliVersion {
 	return &cliVersion{}
 }
 
-func (cli cliVersion) NewCommand() *cobra.Command {
+func (cliVersion) NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "version",
 		Short:             "Display version",
-		Args:              cobra.ExactArgs(0),
+		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(_ *cobra.Command, _ []string) {
-			os.Stdout.WriteString(cwversion.FullString())
+			_, _ = os.Stdout.WriteString(cwversion.FullString())
 		},
 	}
 

--- a/cmd/crowdsec-cli/version.go
+++ b/cmd/crowdsec-cli/version.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
@@ -19,7 +21,7 @@ func (cli cliVersion) NewCommand() *cobra.Command {
 		Args:              cobra.ExactArgs(0),
 		DisableAutoGenTag: true,
 		Run: func(_ *cobra.Command, _ []string) {
-			cwversion.Show()
+			os.Stdout.WriteString(cwversion.FullString())
 		},
 	}
 

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -369,7 +369,7 @@ func main() {
 	}
 
 	if flags.PrintVersion {
-		cwversion.Show()
+		os.Stdout.WriteString(cwversion.FullString())
 		os.Exit(0)
 	}
 

--- a/pkg/cwversion/version.go
+++ b/pkg/cwversion/version.go
@@ -3,7 +3,6 @@ package cwversion
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"runtime"
 	"strings"
@@ -36,27 +35,19 @@ func versionWithTag() string {
 	return ret
 }
 
-func ShowStr() string {
-	ret := fmt.Sprintf("version: %s", versionWithTag())
+func FullString() string {
+	ret := fmt.Sprintf("version: %s\n", versionWithTag())
 	ret += fmt.Sprintf("Codename: %s\n", Codename)
 	ret += fmt.Sprintf("BuildDate: %s\n", version.BuildDate)
 	ret += fmt.Sprintf("GoVersion: %s\n", version.GoVersion)
 	ret += fmt.Sprintf("Platform: %s\n", System)
+	ret += fmt.Sprintf("libre2: %s\n", Libre2)
+	ret += fmt.Sprintf("Constraint_parser: %s\n", Constraint_parser)
+	ret += fmt.Sprintf("Constraint_scenario: %s\n", Constraint_scenario)
+	ret += fmt.Sprintf("Constraint_api: %s\n", Constraint_api)
+	ret += fmt.Sprintf("Constraint_acquis: %s\n", Constraint_acquis)
 
 	return ret
-}
-
-func Show() {
-	log.Printf("version: %s", versionWithTag())
-	log.Printf("Codename: %s", Codename)
-	log.Printf("BuildDate: %s", version.BuildDate)
-	log.Printf("GoVersion: %s", version.GoVersion)
-	log.Printf("Platform: %s\n", System)
-	log.Printf("libre2: %s\n", Libre2)
-	log.Printf("Constraint_parser: %s", Constraint_parser)
-	log.Printf("Constraint_scenario: %s", Constraint_scenario)
-	log.Printf("Constraint_api: %s", Constraint_api)
-	log.Printf("Constraint_acquis: %s", Constraint_acquis)
 }
 
 func VersionStr() string {

--- a/pkg/cwversion/version.go
+++ b/pkg/cwversion/version.go
@@ -29,7 +29,7 @@ func versionWithTag() string {
 	ret := version.Version
 
 	if !strings.HasSuffix(ret, version.Tag) {
-		ret += fmt.Sprintf("-%s", version.Tag)
+		ret += "-" + version.Tag
 	}
 
 	return ret
@@ -55,10 +55,10 @@ func VersionStr() string {
 }
 
 func VersionStrip() string {
-	version := strings.Split(version.Version, "~")
-	version = strings.Split(version[0], "-")
+	ret := strings.Split(version.Version, "~")
+	ret = strings.Split(ret[0], "-")
 
-	return version[0]
+	return ret[0]
 }
 
 func Satisfies(strvers string, constraint string) (bool, error) {
@@ -81,7 +81,7 @@ func Satisfies(strvers string, constraint string) (bool, error) {
 
 // Latest return latest crowdsec version based on github
 func Latest() (string, error) {
-	latest := make(map[string]interface{})
+	latest := make(map[string]any)
 
 	resp, err := http.Get("https://version.crowdsec.net/latest")
 	if err != nil {

--- a/test/bats/01_crowdsec.bats
+++ b/test/bats/01_crowdsec.bats
@@ -36,6 +36,11 @@ teardown() {
     rune -0 wait-for --err "argument provided but not defined: trololo" "$CROWDSEC" trololo
 }
 
+@test "crowdsec -version" {
+    rune -0 "$CROWDSEC" -version
+    assert_output --partial "version:"
+}
+
 @test "crowdsec (no api and no agent)" {
     rune -0 wait-for \
         --err "you must run at least the API Server or crowdsec" \

--- a/test/bats/01_cscli.bats
+++ b/test/bats/01_cscli.bats
@@ -40,20 +40,20 @@ teardown() {
 
 @test "cscli version" {
     rune -0 cscli version
-    assert_stderr --partial "version:"
-    assert_stderr --partial "Codename:"
-    assert_stderr --partial "BuildDate:"
-    assert_stderr --partial "GoVersion:"
-    assert_stderr --partial "Platform:"
-    assert_stderr --partial "Constraint_parser:"
-    assert_stderr --partial "Constraint_scenario:"
-    assert_stderr --partial "Constraint_api:"
-    assert_stderr --partial "Constraint_acquis:"
+    assert_output --partial "version:"
+    assert_output --partial "Codename:"
+    assert_output --partial "BuildDate:"
+    assert_output --partial "GoVersion:"
+    assert_output --partial "Platform:"
+    assert_output --partial "Constraint_parser:"
+    assert_output --partial "Constraint_scenario:"
+    assert_output --partial "Constraint_api:"
+    assert_output --partial "Constraint_acquis:"
 
     # should work without configuration file
     rm "$CONFIG_YAML"
     rune -0 cscli version
-    assert_stderr --partial "version:"
+    assert_output --partial "version:"
 }
 
 @test "cscli help" {


### PR DESCRIPTION
 - add missing newline between version and codename
 - add more information to "support dump"
 - write "cscli version" and "crowdsec -version" to stdout, not stderr