### PR TITLE
pkg/database: refactor & rename "soft delete" to "expire"

### DIFF
--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -432,9 +432,9 @@ func (a *apic) HandleDeletedDecisions(deletedDecisions []*models.Decision, delet
 			filter["scopes"] = []string{*decision.Scope}
 		}
 
-		dbCliRet, _, err := a.dbClient.SoftDeleteDecisionsWithFilter(filter)
+		dbCliRet, _, err := a.dbClient.ExpireDecisionsWithFilter(filter)
 		if err != nil {
-			return 0, fmt.Errorf("deleting decisions error: %w", err)
+			return 0, fmt.Errorf("expiring decisions error: %w", err)
 		}
 
 		dbCliDel, err := strconv.Atoi(dbCliRet)
@@ -464,9 +464,9 @@ func (a *apic) HandleDeletedDecisionsV3(deletedDecisions []*modelscapi.GetDecisi
 				filter["scopes"] = []string{*scope}
 			}
 
-			dbCliRet, _, err := a.dbClient.SoftDeleteDecisionsWithFilter(filter)
+			dbCliRet, _, err := a.dbClient.ExpireDecisionsWithFilter(filter)
 			if err != nil {
-				return 0, fmt.Errorf("deleting decisions error: %w", err)
+				return 0, fmt.Errorf("expiring decisions error: %w", err)
 			}
 
 			dbCliDel, err := strconv.Atoi(dbCliRet)

--- a/pkg/apiserver/controllers/v1/decisions.go
+++ b/pkg/apiserver/controllers/v1/decisions.go
@@ -91,7 +91,7 @@ func (c *Controller) DeleteDecisionById(gctx *gin.Context) {
 		return
 	}
 
-	nbDeleted, deletedFromDB, err := c.DBClient.SoftDeleteDecisionByID(decisionID)
+	nbDeleted, deletedFromDB, err := c.DBClient.ExpireDecisionByID(decisionID)
 	if err != nil {
 		c.HandleDBErrors(gctx, err)
 

--- a/pkg/apiserver/controllers/v1/decisions.go
+++ b/pkg/apiserver/controllers/v1/decisions.go
@@ -113,7 +113,7 @@ func (c *Controller) DeleteDecisionById(gctx *gin.Context) {
 }
 
 func (c *Controller) DeleteDecisions(gctx *gin.Context) {
-	nbDeleted, deletedFromDB, err := c.DBClient.SoftDeleteDecisionsWithFilter(gctx.Request.URL.Query())
+	nbDeleted, deletedFromDB, err := c.DBClient.ExpireDecisionsWithFilter(gctx.Request.URL.Query())
 	if err != nil {
 		c.HandleDBErrors(gctx, err)
 

--- a/pkg/apiserver/papi_cmd.go
+++ b/pkg/apiserver/papi_cmd.go
@@ -63,10 +63,10 @@ func DecisionCmd(message *Message, p *Papi, sync bool) error {
 
 		filter := make(map[string][]string)
 		filter["uuid"] = UUIDs
-		_, deletedDecisions, err := p.DBClient.SoftDeleteDecisionsWithFilter(filter)
+		_, deletedDecisions, err := p.DBClient.ExpireDecisionsWithFilter(filter)
 
 		if err != nil {
-			return fmt.Errorf("unable to delete decisions %+v: %w", UUIDs, err)
+			return fmt.Errorf("unable to expire decisions %+v: %w", UUIDs, err)
 		}
 
 		decisions := make([]*models.Decision, 0)
@@ -191,9 +191,9 @@ func ManagementCmd(message *Message, p *Papi, sync bool) error {
 		filter["origin"] = []string{types.ListOrigin}
 		filter["scenario"] = []string{unsubscribeMsg.Name}
 
-		_, deletedDecisions, err := p.DBClient.SoftDeleteDecisionsWithFilter(filter)
+		_, deletedDecisions, err := p.DBClient.ExpireDecisionsWithFilter(filter)
 		if err != nil {
-			return fmt.Errorf("unable to delete decisions for list %s : %w", unsubscribeMsg.Name, err)
+			return fmt.Errorf("unable to expire decisions for list %s : %w", unsubscribeMsg.Name, err)
 		}
 		p.Logger.Infof("deleted %d decisions for list %s", len(deletedDecisions), unsubscribeMsg.Name)
 

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -27,10 +27,10 @@ import (
 )
 
 const (
-	paginationSize = 100 // used to queryAlert to avoid 'too many SQL variable'
-	defaultLimit   = 100 // default limit of element to returns when query alerts
-	bulkSize       = 50  // bulk size when create alerts
-	maxLockRetries = 10  // how many times to retry a bulk operation when sqlite3.ErrBusy is encountered
+	paginationSize      = 100 // used to queryAlert to avoid 'too many SQL variable'
+	defaultLimit        = 100 // default limit of element to returns when query alerts
+	alertCreateBulkSize = 50  // bulk size when create alerts
+	maxLockRetries      = 10  // how many times to retry a bulk operation when sqlite3.ErrBusy is encountered
 )
 
 func formatAlertCN(source models.Source) string {
@@ -796,7 +796,7 @@ func (c *Client) CreateAlert(machineID string, alertList []*models.Alert) ([]str
 
 	c.Log.Debugf("writing %d items", len(alertList))
 
-	alertChunks := slicetools.Chunks(alertList, bulkSize)
+	alertChunks := slicetools.Chunks(alertList, alertCreateBulkSize)
 	alertIDs := []string{}
 
 	for _, alertChunk := range alertChunks {

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -1117,7 +1117,7 @@ func (c *Client) QueryAlertWithFilter(filter map[string][]string) ([]*ent.Alert,
 		if limit == 0 {
 			limit, err = alerts.Count(c.CTX)
 			if err != nil {
-				return nil, fmt.Errorf("unable to count nb alerts: %s", err)
+				return nil, fmt.Errorf("unable to count nb alerts: %w", err)
 			}
 		}
 


### PR DESCRIPTION
In addition to the method split, I propose to replace the term "soft delete" with "expired".  Ideally imho it would be expire/remove instead of soft/hard delete, but it may clash with apiserver or ent generated code.

The decisionID() function can be made generic if needed.