### PR TITLE
update user agent with version and platform information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ LD_OPTS_VARS= \
 -X '$(GO_MODULE_NAME)/pkg/csconfig.defaultDataDir=$(DEFAULT_DATADIR)'
 
 ifneq (,$(DOCKER_BUILD))
-LD_OPTS_VARS += -X '$(GO_MODULE_NAME)/pkg/cwversion.System=docker'
+LD_OPTS_VARS += -X 'github.com/crowdsecurity/go-cs-lib/version.System=docker'
 endif
 
 GO_TAGS := netgo,osusergo,sqlite_omit_load_extension

--- a/cmd/crowdsec-cli/alerts.go
+++ b/cmd/crowdsec-cli/alerts.go
@@ -19,10 +19,9 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/crowdsecurity/go-cs-lib/version"
-
 	"github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/require"
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/database"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
@@ -209,7 +208,7 @@ func (cli *cliAlerts) NewCommand() *cobra.Command {
 			cli.client, err = apiclient.NewClient(&apiclient.Config{
 				MachineID:     cfg.API.Client.Credentials.Login,
 				Password:      strfmt.Password(cfg.API.Client.Credentials.Password),
-				UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+				UserAgent:     cwversion.UserAgent(),
 				URL:           apiURL,
 				VersionPrefix: "v1",
 			})

--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -12,12 +12,11 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/crowdsecurity/go-cs-lib/version"
-
 	"github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/require"
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
@@ -81,7 +80,7 @@ func (cli *cliCapi) register(capiUserPrefix string, outputFile string) error {
 	_, err = apiclient.RegisterClient(&apiclient.Config{
 		MachineID:     capiUser,
 		Password:      password,
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiurl,
 		VersionPrefix: CAPIURLPrefix,
 	}, nil)
@@ -173,7 +172,7 @@ func QueryCAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 
 	Client, err = apiclient.NewDefaultClient(apiURL,
 		CAPIURLPrefix,
-		fmt.Sprintf("crowdsec/%s", version.String()),
+		cwversion.UserAgent(),
 		nil)
 	if err != nil {
 		return fmt.Errorf("init default client: %w", err)

--- a/cmd/crowdsec-cli/console.go
+++ b/cmd/crowdsec-cli/console.go
@@ -18,12 +18,12 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/crowdsecurity/go-cs-lib/ptr"
-	"github.com/crowdsecurity/go-cs-lib/version"
 
 	"github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/require"
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
@@ -147,7 +147,7 @@ After running this command your will need to validate the enrollment in the weba
 				MachineID:     cli.cfg().API.Server.OnlineClient.Credentials.Login,
 				Password:      password,
 				Scenarios:     scenarios,
-				UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+				UserAgent:     cwversion.UserAgent(),
 				URL:           apiURL,
 				VersionPrefix: "v3",
 			})

--- a/cmd/crowdsec-cli/decisions.go
+++ b/cmd/crowdsec-cli/decisions.go
@@ -17,9 +17,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/crowdsecurity/go-cs-lib/version"
-
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
@@ -150,7 +149,7 @@ func (cli *cliDecisions) NewCommand() *cobra.Command {
 			Client, err = apiclient.NewClient(&apiclient.Config{
 				MachineID:     cfg.API.Client.Credentials.Login,
 				Password:      password,
-				UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+				UserAgent:     cwversion.UserAgent(),
 				URL:           apiurl,
 				VersionPrefix: "v1",
 			})

--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -15,13 +15,12 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/crowdsecurity/go-cs-lib/version"
-
 	"github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/require"
 	"github.com/crowdsecurity/crowdsec/pkg/alertcontext"
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/exprhelpers"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/crowdsecurity/crowdsec/pkg/parser"
@@ -53,7 +52,7 @@ func QueryLAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 
 	Client, err = apiclient.NewDefaultClient(apiURL,
 		LAPIURLPrefix,
-		fmt.Sprintf("crowdsec/%s", version.String()),
+		cwversion.UserAgent(),
 		nil)
 	if err != nil {
 		return fmt.Errorf("init default client: %w", err)
@@ -120,7 +119,7 @@ func (cli *cliLapi) register(apiURL string, outputFile string, machine string) e
 	_, err = apiclient.RegisterClient(&apiclient.Config{
 		MachineID:     lapiUser,
 		Password:      password,
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiurl,
 		VersionPrefix: LAPIURLPrefix,
 	}, nil)

--- a/cmd/crowdsec-cli/notifications.go
+++ b/cmd/crowdsec-cli/notifications.go
@@ -23,13 +23,13 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/crowdsecurity/go-cs-lib/ptr"
-	"github.com/crowdsecurity/go-cs-lib/version"
 
 	"github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/require"
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/csplugin"
 	"github.com/crowdsecurity/crowdsec/pkg/csprofiles"
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
@@ -462,7 +462,7 @@ func (cli *cliNotifications) fetchAlertFromArgString(toParse string) (*models.Al
 	client, err := apiclient.NewClient(&apiclient.Config{
 		MachineID:     cfg.API.Client.Credentials.Login,
 		Password:      strfmt.Password(cfg.API.Client.Credentials.Password),
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	})

--- a/cmd/crowdsec/lapiclient.go
+++ b/cmd/crowdsec/lapiclient.go
@@ -8,10 +8,9 @@ import (
 
 	"github.com/go-openapi/strfmt"
 
-	"github.com/crowdsecurity/go-cs-lib/version"
-
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 )
@@ -47,7 +46,7 @@ func AuthenticatedLAPIClient(credentials csconfig.ApiCredentialsCfg, hub *cwhub.
 		MachineID:     credentials.Login,
 		Password:      password,
 		Scenarios:     installedScenariosAndAppsecRules,
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		PapiURL:       papiURL,
 		VersionPrefix: "v1",

--- a/pkg/acquisition/modules/loki/internal/lokiclient/loki_client.go
+++ b/pkg/acquisition/modules/loki/internal/lokiclient/loki_client.go
@@ -321,6 +321,6 @@ func NewLokiClient(config Config) *LokiClient {
 	if config.Username != "" || config.Password != "" {
 		headers["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(config.Username+":"+config.Password))
 	}
-	headers["User-Agent"] = "Crowdsec " + cwversion.VersionStr()
+	headers["User-Agent"] = cwversion.UserAgent()
 	return &LokiClient{Logger: log.WithField("component", "lokiclient"), config: config, requestHeaders: headers}
 }

--- a/pkg/apiclient/alerts_service_test.go
+++ b/pkg/apiclient/alerts_service_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/crowdsecurity/go-cs-lib/cstest"
 	"github.com/crowdsecurity/go-cs-lib/ptr"
-	"github.com/crowdsecurity/go-cs-lib/version"
 
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 )
 
@@ -35,7 +35,7 @@ func TestAlertsListAsMachine(t *testing.T) {
 	client, err := NewClient(&Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	})
@@ -214,7 +214,7 @@ func TestAlertsGetAsMachine(t *testing.T) {
 	client, err := NewClient(&Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	})
@@ -388,7 +388,7 @@ func TestAlertsCreateAsMachine(t *testing.T) {
 	client, err := NewClient(&Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	})
@@ -430,7 +430,7 @@ func TestAlertsDeleteAsMachine(t *testing.T) {
 	client, err := NewClient(&Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	})

--- a/pkg/apiclient/auth_service_test.go
+++ b/pkg/apiclient/auth_service_test.go
@@ -14,8 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/crowdsecurity/go-cs-lib/version"
-
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 )
 
@@ -88,7 +87,7 @@ func TestWatcherRegister(t *testing.T) {
 	clientconfig := Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	}
@@ -126,7 +125,7 @@ func TestWatcherAuth(t *testing.T) {
 	clientConfig := &Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 		Scenarios:     []string{"crowdsecurity/test"},
@@ -207,7 +206,7 @@ func TestWatcherUnregister(t *testing.T) {
 	mycfg := &Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 		Scenarios:     []string{"crowdsecurity/test"},
@@ -261,7 +260,7 @@ func TestWatcherEnroll(t *testing.T) {
 	mycfg := &Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 		Scenarios:     []string{"crowdsecurity/test"},

--- a/pkg/apiclient/client_http_test.go
+++ b/pkg/apiclient/client_http_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/crowdsecurity/go-cs-lib/cstest"
-	"github.com/crowdsecurity/go-cs-lib/version"
+
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 )
 
 func TestNewRequestInvalid(t *testing.T) {
@@ -25,7 +26,7 @@ func TestNewRequestInvalid(t *testing.T) {
 	client, err := NewClient(&Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	})
@@ -57,7 +58,7 @@ func TestNewRequestTimeout(t *testing.T) {
 	client, err := NewClient(&Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	})

--- a/pkg/apiclient/client_http_test.go
+++ b/pkg/apiclient/client_http_test.go
@@ -2,7 +2,6 @@ package apiclient
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 	"testing"

--- a/pkg/apiclient/client_test.go
+++ b/pkg/apiclient/client_test.go
@@ -17,7 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/crowdsecurity/go-cs-lib/cstest"
-	"github.com/crowdsecurity/go-cs-lib/version"
+
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 )
 
 /*this is a ripoff of google/go-github approach :
@@ -96,7 +97,7 @@ func TestNewClientOk(t *testing.T) {
 	client, err := NewClient(&Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	})
@@ -133,7 +134,7 @@ func TestNewClientOk_UnixSocket(t *testing.T) {
 	client, err := NewClient(&Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	})
@@ -171,7 +172,7 @@ func TestNewClientKo(t *testing.T) {
 	client, err := NewClient(&Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	})
@@ -249,7 +250,7 @@ func TestNewClientRegisterKO(t *testing.T) {
 	_, err = RegisterClient(&Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	}, &http.Client{})
@@ -280,7 +281,7 @@ func TestNewClientRegisterOK(t *testing.T) {
 	client, err := RegisterClient(&Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	}, &http.Client{})
@@ -313,7 +314,7 @@ func TestNewClientRegisterOK_UnixSocket(t *testing.T) {
 	client, err := RegisterClient(&Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	}, &http.Client{})
@@ -343,7 +344,7 @@ func TestNewClientBadAnswer(t *testing.T) {
 	_, err = RegisterClient(&Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	}, &http.Client{})

--- a/pkg/apiclient/decisions_service_test.go
+++ b/pkg/apiclient/decisions_service_test.go
@@ -2,7 +2,6 @@ package apiclient
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -13,8 +12,8 @@ import (
 
 	"github.com/crowdsecurity/go-cs-lib/cstest"
 	"github.com/crowdsecurity/go-cs-lib/ptr"
-	"github.com/crowdsecurity/go-cs-lib/version"
 
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/crowdsecurity/crowdsec/pkg/modelscapi"
 )
@@ -403,7 +402,7 @@ func TestDeleteDecisions(t *testing.T) {
 	client, err := NewClient(&Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
-		UserAgent:     fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v1",
 	})
@@ -504,7 +503,7 @@ func TestDecisionsStreamOpts_addQueryParamsToURL(t *testing.T) {
 // 	client, err := NewClient(&Config{
 // 		MachineID:     "test_login",
 // 		Password:      "test_password",
-// 		UserAgent:     fmt.Sprintf("crowdsec/%s", cwversion.VersionStr()),
+// 		UserAgent:     cwversion.UserAgent(),
 // 		URL:           apiURL,
 // 		VersionPrefix: "v1",
 // 	})

--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/crowdsecurity/go-cs-lib/ptr"
 	"github.com/crowdsecurity/go-cs-lib/trace"
-	"github.com/crowdsecurity/go-cs-lib/version"
 
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/database"
 	"github.com/crowdsecurity/crowdsec/pkg/database/ent"
 	"github.com/crowdsecurity/crowdsec/pkg/database/ent/alert"
@@ -215,7 +215,7 @@ func NewAPIC(config *csconfig.OnlineApiClientCfg, dbClient *database.Client, con
 	ret.apiClient, err = apiclient.NewClient(&apiclient.Config{
 		MachineID:      config.Credentials.Login,
 		Password:       password,
-		UserAgent:      fmt.Sprintf("crowdsec/%s", version.String()),
+		UserAgent:      cwversion.UserAgent(),
 		URL:            apiURL,
 		PapiURL:        papiURL,
 		VersionPrefix:  "v3",

--- a/pkg/apiserver/apic_metrics_test.go
+++ b/pkg/apiserver/apic_metrics_test.go
@@ -2,7 +2,6 @@ package apiserver
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"testing"
 	"time"
@@ -11,9 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/crowdsecurity/go-cs-lib/version"
-
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 )
 
 func TestAPICSendMetrics(t *testing.T) {
@@ -73,7 +71,7 @@ func TestAPICSendMetrics(t *testing.T) {
 			apiClient, err := apiclient.NewDefaultClient(
 				url,
 				"/api",
-				fmt.Sprintf("crowdsec/%s", version.String()),
+				cwversion.UserAgent(),
 				nil,
 			)
 			require.NoError(t, err)

--- a/pkg/apiserver/apic_test.go
+++ b/pkg/apiserver/apic_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/database"
 	"github.com/crowdsecurity/crowdsec/pkg/database/ent/decision"
 	"github.com/crowdsecurity/crowdsec/pkg/database/ent/machine"
@@ -675,7 +676,7 @@ func TestAPICWhitelists(t *testing.T) {
 	apic, err := apiclient.NewDefaultClient(
 		url,
 		"/api",
-		fmt.Sprintf("crowdsec/%s", version.String()),
+		cwversion.UserAgent(),
 		nil,
 	)
 	require.NoError(t, err)
@@ -816,7 +817,7 @@ func TestAPICPullTop(t *testing.T) {
 	apic, err := apiclient.NewDefaultClient(
 		url,
 		"/api",
-		fmt.Sprintf("crowdsec/%s", version.String()),
+		cwversion.UserAgent(),
 		nil,
 	)
 	require.NoError(t, err)
@@ -904,7 +905,7 @@ func TestAPICPullTopBLCacheFirstCall(t *testing.T) {
 	apic, err := apiclient.NewDefaultClient(
 		url,
 		"/api",
-		fmt.Sprintf("crowdsec/%s", version.String()),
+		cwversion.UserAgent(),
 		nil,
 	)
 	require.NoError(t, err)
@@ -996,7 +997,7 @@ func TestAPICPullTopBLCacheForceCall(t *testing.T) {
 	apic, err := apiclient.NewDefaultClient(
 		url,
 		"/api",
-		fmt.Sprintf("crowdsec/%s", version.String()),
+		cwversion.UserAgent(),
 		nil,
 	)
 	require.NoError(t, err)
@@ -1023,7 +1024,7 @@ func TestAPICPullBlocklistCall(t *testing.T) {
 	apic, err := apiclient.NewDefaultClient(
 		url,
 		"/api",
-		fmt.Sprintf("crowdsec/%s", version.String()),
+		cwversion.UserAgent(),
 		nil,
 	)
 	require.NoError(t, err)
@@ -1105,7 +1106,7 @@ func TestAPICPush(t *testing.T) {
 			apic, err := apiclient.NewDefaultClient(
 				url,
 				"/api",
-				fmt.Sprintf("crowdsec/%s", version.String()),
+				cwversion.UserAgent(),
 				nil,
 			)
 			require.NoError(t, err)
@@ -1164,7 +1165,7 @@ func TestAPICPull(t *testing.T) {
 			apic, err := apiclient.NewDefaultClient(
 				url,
 				"/api",
-				fmt.Sprintf("crowdsec/%s", version.String()),
+				cwversion.UserAgent(),
 				nil,
 			)
 			require.NoError(t, err)

--- a/pkg/cwhub/cwhub.go
+++ b/pkg/cwhub/cwhub.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/crowdsecurity/go-cs-lib/version"
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 )
 
 // hubTransport wraps a Transport to set a custom User-Agent.
@@ -17,7 +17,7 @@ type hubTransport struct {
 }
 
 func (t *hubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("User-Agent", "crowdsec/"+version.String())
+	req.Header.Set("User-Agent", cwversion.UserAgent())
 	return t.RoundTripper.RoundTrip(req)
 }
 

--- a/pkg/cwversion/version.go
+++ b/pkg/cwversion/version.go
@@ -27,7 +27,7 @@ func versionWithTag() string {
 	// if the version number already contains the tag, don't duplicate it
 	ret := version.Version
 
-	if !strings.HasSuffix(ret, version.Tag) {
+	if !strings.HasSuffix(ret, version.Tag) && !strings.HasSuffix(ret, "g" + version.Tag + "-dirty") {
 		ret += "-" + version.Tag
 	}
 
@@ -41,6 +41,7 @@ func FullString() string {
 	ret += fmt.Sprintf("GoVersion: %s\n", version.GoVersion)
 	ret += fmt.Sprintf("Platform: %s\n", version.System)
 	ret += fmt.Sprintf("libre2: %s\n", Libre2)
+	ret += fmt.Sprintf("User-Agent: %s\n", UserAgent())
 	ret += fmt.Sprintf("Constraint_parser: %s\n", Constraint_parser)
 	ret += fmt.Sprintf("Constraint_scenario: %s\n", Constraint_scenario)
 	ret += fmt.Sprintf("Constraint_api: %s\n", Constraint_api)

--- a/pkg/cwversion/version.go
+++ b/pkg/cwversion/version.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"runtime"
 	"strings"
 
 	goversion "github.com/hashicorp/go-version"
@@ -14,7 +13,6 @@ import (
 
 var (
 	Codename string         // = "SoumSoum"
-	System   = runtime.GOOS // = "linux"
 	Libre2   = "WebAssembly"
 )
 
@@ -26,6 +24,7 @@ const (
 )
 
 func versionWithTag() string {
+	// if the version number already contains the tag, don't duplicate it
 	ret := version.Version
 
 	if !strings.HasSuffix(ret, version.Tag) {
@@ -40,7 +39,7 @@ func FullString() string {
 	ret += fmt.Sprintf("Codename: %s\n", Codename)
 	ret += fmt.Sprintf("BuildDate: %s\n", version.BuildDate)
 	ret += fmt.Sprintf("GoVersion: %s\n", version.GoVersion)
-	ret += fmt.Sprintf("Platform: %s\n", System)
+	ret += fmt.Sprintf("Platform: %s\n", version.System)
 	ret += fmt.Sprintf("libre2: %s\n", Libre2)
 	ret += fmt.Sprintf("Constraint_parser: %s\n", Constraint_parser)
 	ret += fmt.Sprintf("Constraint_scenario: %s\n", Constraint_scenario)
@@ -50,10 +49,11 @@ func FullString() string {
 	return ret
 }
 
-func VersionStr() string {
-	return fmt.Sprintf("%s-%s-%s", version.Version, System, version.Tag)
+func UserAgent() string {
+	return "crowdsec/" + versionWithTag() + "-" + version.System
 }
 
+// VersionStrip remove the tag from the version string, used to match with a hub branch
 func VersionStrip() string {
 	ret := strings.Split(version.Version, "~")
 	ret = strings.Split(ret[0], "-")

--- a/pkg/metabase/api.go
+++ b/pkg/metabase/api.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/crowdsecurity/go-cs-lib/version"
-
 	"github.com/dghubble/sling"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 )
 
 type MBClient struct {
@@ -38,7 +38,7 @@ var (
 func NewMBClient(url string) (*MBClient, error) {
 	httpClient := &http.Client{Timeout: 20 * time.Second}
 	return &MBClient{
-		CTX:    sling.New().Client(httpClient).Base(url).Set("User-Agent", fmt.Sprintf("crowdsec/%s", version.String())),
+		CTX:    sling.New().Client(httpClient).Base(url).Set("User-Agent", cwversion.UserAgent()),
 		Client: httpClient,
 	}, nil
 }


### PR DESCRIPTION
The System variable has been moved to go-cs-lib so it can be used by bouncers.

Also added User-Agent to `cscli version`.

the output is for example
User-Agent: crowdsec/v1.6.3-070a51af2-linux
if there is a tag, and
User-Agent: crowdsec/v1.6.2-rc3-3-g070a51af2-linux
if it's built from master