### PR TITLE
CI/lint: enable some "revive" rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -118,10 +118,6 @@ linters-settings:
     rules:
       - name: add-constant
         disabled: true
-      - name: argument-limit
-        disabled: true
-      - name: bare-return
-        disabled: true
       - name: blank-imports
         disabled: true
       - name: bool-literal-in-expr
@@ -132,15 +128,11 @@ linters-settings:
         disabled: true
       - name: confusing-results
         disabled: true
-      - name: context-as-argument
-        disabled: true
       - name: cyclomatic
         disabled: true
       - name: deep-exit
         disabled: true
       - name: defer
-        disabled: true
-      - name: duplicated-imports
         disabled: true
       - name: early-return
         disabled: true
@@ -176,15 +168,11 @@ linters-settings:
         disabled: true
       - name: max-public-structs
         disabled: true
-      - name: modifies-parameter
-        disabled: true
       - name: optimize-operands-order
         disabled: true
       - name: nested-structs
         disabled: true
       - name: package-comments
-        disabled: true
-      - name: redundant-import-alias
         disabled: true
       - name: struct-tag
         disabled: true
@@ -211,8 +199,6 @@ linters-settings:
           - "fmt.Printf"
           - "fmt.Println"
       - name: unnecessary-stmt
-        disabled: true
-      - name: unreachable-code
         disabled: true
       - name: unused-parameter
         disabled: true
@@ -505,4 +491,12 @@ issues:
         - revive
       path: pkg/acquisition/modules/loki/internal/lokiclient/loki_client.go
       text: "confusing-naming: Method 'QueryRange' differs only by capitalization to method 'queryRange' in the same source file"
+
+    - linters:
+        - revive
+      path: pkg/metabase/metabase.go
+
+    - linters:
+        - revive
+      path: cmd/crowdsec-cli/copyfile.go
 

--- a/cmd/crowdsec/metrics.go
+++ b/cmd/crowdsec/metrics.go
@@ -12,7 +12,7 @@ import (
 	"github.com/crowdsecurity/go-cs-lib/version"
 
 	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
-	v1 "github.com/crowdsecurity/crowdsec/pkg/apiserver/controllers/v1"
+	"github.com/crowdsecurity/crowdsec/pkg/apiserver/controllers/v1"
 	"github.com/crowdsecurity/crowdsec/pkg/cache"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/database"

--- a/pkg/acquisition/modules/file/file_test.go
+++ b/pkg/acquisition/modules/file/file_test.go
@@ -416,8 +416,8 @@ force_inotify: true`, testPattern),
 				for i := 0; i < 5; i++ {
 					_, err = fmt.Fprintf(fd, "%d\n", i)
 					if err != nil {
-						t.Fatalf("could not write test file : %s", err)
 						os.Remove("test_files/stream.log")
+						t.Fatalf("could not write test file : %s", err)
 					}
 				}
 

--- a/pkg/acquisition/modules/loki/internal/lokiclient/loki_client.go
+++ b/pkg/acquisition/modules/loki/internal/lokiclient/loki_client.go
@@ -106,7 +106,7 @@ func (lc *LokiClient) decreaseTicker(ticker *time.Ticker) {
 	}
 }
 
-func (lc *LokiClient) queryRange(uri string, ctx context.Context, c chan *LokiQueryRangeResponse, infinite bool) error {
+func (lc *LokiClient) queryRange(ctx context.Context, uri string, c chan *LokiQueryRangeResponse, infinite bool) error {
 	lc.currentTickerInterval = 100 * time.Millisecond
 	ticker := time.NewTicker(lc.currentTickerInterval)
 	defer ticker.Stop()
@@ -296,7 +296,7 @@ func (lc *LokiClient) QueryRange(ctx context.Context, infinite bool) chan *LokiQ
 
 	lc.Logger.Infof("Connecting to %s", url)
 	lc.t.Go(func() error {
-		return lc.queryRange(url, ctx, c, infinite)
+		return lc.queryRange(ctx, url, c, infinite)
 	})
 	return c
 }

--- a/pkg/acquisition/modules/loki/loki.go
+++ b/pkg/acquisition/modules/loki/loki.go
@@ -19,7 +19,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
-	lokiclient "github.com/crowdsecurity/crowdsec/pkg/acquisition/modules/loki/internal/lokiclient"
+	"github.com/crowdsecurity/crowdsec/pkg/acquisition/modules/loki/internal/lokiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -21,7 +21,7 @@ import (
 	"github.com/crowdsecurity/go-cs-lib/trace"
 
 	"github.com/crowdsecurity/crowdsec/pkg/apiserver/controllers"
-	v1 "github.com/crowdsecurity/crowdsec/pkg/apiserver/middlewares/v1"
+	"github.com/crowdsecurity/crowdsec/pkg/apiserver/middlewares/v1"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/csplugin"
 	"github.com/crowdsecurity/crowdsec/pkg/database"

--- a/pkg/apiserver/controllers/controller.go
+++ b/pkg/apiserver/controllers/controller.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 
-	v1 "github.com/crowdsecurity/crowdsec/pkg/apiserver/controllers/v1"
+	"github.com/crowdsecurity/crowdsec/pkg/apiserver/controllers/v1"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/csplugin"
 	"github.com/crowdsecurity/crowdsec/pkg/database"

--- a/pkg/appsec/request.go
+++ b/pkg/appsec/request.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 
 	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -276,7 +275,7 @@ func (r *ReqDumpFilter) ToJSON() error {
 }
 
 // Generate a ParsedRequest from a http.Request. ParsedRequest can be consumed by the App security Engine
-func NewParsedRequestFromRequest(r *http.Request, logger *logrus.Entry) (ParsedRequest, error) {
+func NewParsedRequestFromRequest(r *http.Request, logger *log.Entry) (ParsedRequest, error) {
 	var err error
 	contentLength := r.ContentLength
 	if contentLength < 0 {

--- a/pkg/csplugin/hclog_adapter.go
+++ b/pkg/csplugin/hclog_adapter.go
@@ -230,5 +230,5 @@ func safeString(str fmt.Stringer) (s string) {
 	}()
 
 	s = str.String()
-	return
+	return //nolint:revive // bare return for the defer
 }


### PR DESCRIPTION
argument-limit
Warns when a function receives more parameters than the maximum set by the rule's configuration.

bare-return
Warns on bare (a.k.a. naked) returns

context-as-argument
By convention, context.Context should be the first parameter of a function.

duplicated-imports
It is possible to unintentionally import the same package twice.

modifies-parameter
A function that modifies its parameters can be hard to understand. It can also be misleading if the arguments are passed by value by the caller.

redundant-import-alias
This rule warns on redundant import aliases.

unreachable-code
This rule spots and proposes to remove unreachable code.