### PR TITLE
cscli: fixed some inconsistency in returning errors

### DIFF
--- a/cmd/crowdsec-cli/alerts.go
+++ b/cmd/crowdsec-cli/alerts.go
@@ -540,7 +540,7 @@ func (cli *cliAlerts) NewInspectCmd() *cobra.Command {
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				printHelp(cmd)
+				_ = cmd.Help()
 				return errors.New("missing alert_id")
 			}
 			return cli.inspect(details, args...)

--- a/cmd/crowdsec-cli/hubtest.go
+++ b/cmd/crowdsec-cli/hubtest.go
@@ -251,7 +251,7 @@ func (cli *cliHubTest) NewRunCmd() *cobra.Command {
 			cfg := cli.cfg()
 
 			if !runAll && len(args) == 0 {
-				printHelp(cmd)
+				_ = cmd.Help()
 				return errors.New("please provide test to run or --all flag")
 			}
 			hubPtr.NucleiTargetHost = NucleiTargetHost
@@ -305,8 +305,7 @@ func (cli *cliHubTest) NewRunCmd() *cobra.Command {
 							return fmt.Errorf("unable to clean test '%s' env: %w", test.Name, err)
 						}
 					}
-					fmt.Printf("\nPlease fill your assert file(s) for test '%s', exiting\n", test.Name)
-					os.Exit(1)
+					return fmt.Errorf("please fill your assert file(s) for test '%s', exiting", test.Name)
 				}
 				testResult[test.Name] = test.Success
 				if test.Success {
@@ -389,7 +388,7 @@ func (cli *cliHubTest) NewRunCmd() *cobra.Command {
 			}
 
 			if !success {
-				os.Exit(1)
+				return errors.New("some tests failed")
 			}
 
 			return nil
@@ -580,7 +579,7 @@ func (cli *cliHubTest) NewCoverageCmd() *cobra.Command {
 				case showAppsecCov:
 					fmt.Printf("appsec_rules=%d%%", appsecRuleCoveragePercent)
 				}
-				os.Exit(0)
+				return nil
 			}
 
 			switch cfg.Cscli.Output {

--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -376,8 +376,8 @@ cscli lapi context detect crowdsecurity/sshd-logs
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := cli.cfg()
 			if !detectAll && len(args) == 0 {
-				log.Infof("Please provide parsers to detect or --all flag.")
-				printHelp(cmd)
+				_ = cmd.Help()
+				return errors.New("please provide parsers to detect or --all flag")
 			}
 
 			// to avoid all the log.Info from the loaders functions
@@ -490,9 +490,6 @@ func (cli *cliLapi) newContextCmd() *cobra.Command {
 			}
 
 			return nil
-		},
-		Run: func(cmd *cobra.Command, _ []string) {
-			printHelp(cmd)
 		},
 	}
 

--- a/cmd/crowdsec-cli/simulation.go
+++ b/cmd/crowdsec-cli/simulation.go
@@ -107,7 +107,7 @@ func (cli *cliSimulation) NewEnableCmd() *cobra.Command {
 					return fmt.Errorf("unable to enable global simulation mode: %w", err)
 				}
 			} else {
-				printHelp(cmd)
+				_ = cmd.Help()
 			}
 
 			return nil
@@ -154,7 +154,7 @@ func (cli *cliSimulation) NewDisableCmd() *cobra.Command {
 					return fmt.Errorf("unable to disable global simulation mode: %w", err)
 				}
 			} else {
-				printHelp(cmd)
+				_ = cmd.Help()
 			}
 
 			return nil

--- a/cmd/crowdsec-cli/utils.go
+++ b/cmd/crowdsec-cli/utils.go
@@ -5,17 +5,8 @@ import (
 	"net"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
-
-func printHelp(cmd *cobra.Command) {
-	if err := cmd.Help(); err != nil {
-		log.Fatalf("unable to print help(): %s", err)
-	}
-}
 
 func manageCliDecisionAlerts(ip *string, ipRange *string, scope *string, value *string) error {
 	/*if a range is provided, change the scope*/


### PR DESCRIPTION
note: cmd.Help() never fails if it's not customized with HelpFunc()