### PR TITLE
cscli: fix deprecation message for "context delete"

### DIFF
--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -464,9 +464,8 @@ func (cli *cliLapi) newContextDeleteCmd() *cobra.Command {
 			if filePath == "" {
 				filePath = "the context file"
 			}
-			fmt.Printf("Command 'delete' is deprecated, please manually edit %s.", filePath)
 
-			return nil
+			return fmt.Errorf("command 'delete' has been removed, please manually edit %s", filePath)
 		},
 	}
 

--- a/test/bats/09_context.bats
+++ b/test/bats/09_context.bats
@@ -65,6 +65,11 @@ teardown() {
     assert_stderr --partial "while checking console_context_path: stat $CONTEXT_YAML: no such file or directory"
 }
 
+@test "csli lapi context delete" {
+    rune -1 cscli lapi context delete
+    assert_stderr --partial "command 'delete' has been removed, please manually edit the context file"
+}
+
 @test "context file is bad" {
     echo "bad yaml" > "$CONTEXT_YAML"
     rune -1 "$CROWDSEC" -t


### PR DESCRIPTION
missing newline, proper return code, same msg as dashboard, test