### PR TITLE
Enhancement: force hub index file update if hub data upgrade is forced

### DIFF
--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -55,8 +55,8 @@ cscli() {
 
 run_hub_update() {
     index_modification_time=$(stat -c %Y /etc/crowdsec/hub/.index.json 2>/dev/null)
-    # Run cscli hub update if no date or if the index file is older than 24h
-    if [ -z "$index_modification_time" ] || [ $(( $(date +%s) - index_modification_time )) -gt 86400 ]; then
+    # Run cscli hub update if forced to upgrade hub data, if no date or if the index file is older than 24h
+    if istrue "$DO_HUB_UPGRADE" || [ -z "$index_modification_time" ] || [ $(( $(date +%s) - index_modification_time )) -gt 86400 ]; then
         cscli hub update
     else
         echo "Skipping hub update, index file is recent"


### PR DESCRIPTION
I ran into an issue by having a hub-index file younger than 24h within the docker container and needed to restart it while the hub holds newer data.
So this results in conflicting hashes for parsers loaded by a collection.

Setting the environment var `DO_HUB_UPGRADE` to `true` it just forces the already (old) indexed collections to upgrade, but not upgrading the index file.
I think if someone forcing to get the newest data from the hub, than the local index should be as fresh as possible.

With this PR setting `DO_HUB_UPGRADE` to `true` also forces the local hub index to get updated on starting the docker container.