### PR TITLE
revert "db: round created, updated... timestamps to 1 second"

### DIFF
--- a/pkg/types/utils.go
+++ b/pkg/types/utils.go
@@ -66,7 +66,7 @@ func ConfigureLogger(clog *log.Logger) error {
 }
 
 func UtcNow() time.Time {
-	return time.Now().UTC().Round(time.Second)
+	return time.Now().UTC()
 }
 
 func IsNetworkFS(path string) (bool, string, error) {


### PR DESCRIPTION
this fixes functional tests with decision stream startup=true (due to bouncer lastpull), still something we may want to do for other data