### PR TITLE
cscli/hub: don't return error if some file can't be recognized

### DIFF
--- a/pkg/cwhub/sync.go
+++ b/pkg/cwhub/sync.go
@@ -1,6 +1,7 @@
 package cwhub
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -99,7 +100,7 @@ func (h *Hub) getItemFileInfo(path string, logger *logrus.Logger) (*itemFileInfo
 
 	if ret.ftype != PARSERS && ret.ftype != POSTOVERFLOWS {
 		if !slices.Contains(ItemTypes, ret.stage) {
-			return nil, fmt.Errorf("unknown configuration type for file '%s'", path)
+			return nil, errors.New("unknown configuration type")
 		}
 
 		ret.ftype = ret.stage
@@ -196,7 +197,8 @@ func (h *Hub) itemVisit(path string, f os.DirEntry, err error) error {
 
 	info, err := h.getItemFileInfo(path, h.logger)
 	if err != nil {
-		return err
+		h.logger.Warningf("Ignoring file %s: %s", path, err)
+		return nil
 	}
 
 	// non symlinks are local user files or hub files

--- a/test/bats/20_hub_items.bats
+++ b/test/bats/20_hub_items.bats
@@ -193,3 +193,10 @@ teardown() {
     rune -0 jq -c '.tainted' <(output)
     assert_output 'false'
 }
+
+@test "skip files if we can't guess their type" {
+    rune -0 mkdir -p "$CONFIG_DIR/scenarios/foo"
+    rune -0 touch "$CONFIG_DIR/scenarios/foo/bar.yaml"
+    rune -0 cscli hub list
+    assert_stderr --partial "Ignoring file $CONFIG_DIR/scenarios/foo/bar.yaml: unknown configuration type"
+}


### PR DESCRIPTION
In k8s there can be extra directories while mounting config maps, which leads to a failure while parsing the hub state. The PR changes these kind of errors to warnings.