### PR TITLE
fix #1742 : Allow QueryCAPIStatus to return as well enrollment status

### DIFF
--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -210,10 +210,6 @@ func QueryCAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 		return false, false, err
 	}
 
-	if err = client.GetClient().Transport.(*apiclient.JWTTransport).Expiration.UnmarshalText([]byte(authResp.Expire)); err != nil {
-		return true, false, err
-	}
-
 	client.GetClient().Transport.(*apiclient.JWTTransport).Token = authResp.Token
 
 	if client.IsEnrolled() {

--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -239,7 +239,7 @@ func (cli *cliCapi) status() error {
 	auth, enrolled, err := QueryCAPIStatus(hub, cred.URL, cred.Login, cred.Password)
 
 	if err != nil {
-		log.Errorf("CAPI: failed to authenticate to Central API (CAPI): %s", err)
+		return fmt.Errorf("CAPI: failed to authenticate to Central API (CAPI): %s", err)
 	}
 	if auth {
 		log.Info("You can successfully interact with Central API (CAPI)")

--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -239,7 +239,7 @@ func (cli *cliCapi) status() error {
 	auth, enrolled, err := QueryCAPIStatus(hub, cred.URL, cred.Login, cred.Password)
 
 	if err != nil {
-		log.Errorf("CAPI: failed to authenticate to Central API (CAPI): %w", err)
+		log.Errorf("CAPI: failed to authenticate to Central API (CAPI): %s", err)
 	}
 	if auth {
 		log.Info("You can successfully interact with Central API (CAPI)")

--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -177,7 +177,7 @@ func QueryCAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 		//PapiURL:       papiURL,
 		VersionPrefix: "v3",
 		UpdateScenario: func() ([]string, error) {
-			scenarios, err := hub.GetInstalledNamesByType(cwhub.SCENARIOS)
+			l_scenarios, err := hub.GetInstalledNamesByType(cwhub.SCENARIOS)
 			if err != nil {
 				return nil, err
 			}
@@ -185,8 +185,8 @@ func QueryCAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 			if err != nil {
 				return nil, err
 			}
-			ret := make([]string, 0, len(scenarios)+len(appsecRules))
-			ret = append(ret, scenarios...)
+			ret := make([]string, 0, len(l_scenarios)+len(appsecRules))
+			ret = append(ret, l_scenarios...)
 			ret = append(ret, appsecRules...)
 
 			return ret, nil

--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -218,9 +218,9 @@ func QueryCAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 
 	if client.IsEnrolled() {
 		return true, true, nil
-	} else {
-		return true, false, nil
 	}
+	return true, false, nil
+
 }
 
 func (cli *cliCapi) status() error {

--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -148,28 +148,53 @@ func (cli *cliCapi) newRegisterCmd() *cobra.Command {
 	return cmd
 }
 
-// QueryCAPIStatus checks if the Local API is reachable, and if the credentials are correct
-func QueryCAPIStatus(hub *cwhub.Hub, credURL string, login string, password string) error {
+// QueryCAPIStatus checks if the Local API is reachable, and if the credentials are correct. It then checks if the instance is enrolle in the console.
+func QueryCAPIStatus(hub *cwhub.Hub, credURL string, login string, password string) (bool, bool, error) {
+
 	apiURL, err := url.Parse(credURL)
 	if err != nil {
-		return fmt.Errorf("parsing api url: %w", err)
+		return false, false, fmt.Errorf("parsing api url: %w", err)
 	}
 
 	scenarios, err := hub.GetInstalledNamesByType(cwhub.SCENARIOS)
 	if err != nil {
-		return fmt.Errorf("failed to get scenarios: %w", err)
+		return false, false, fmt.Errorf("failed to get scenarios: %w", err)
 	}
 
 	if len(scenarios) == 0 {
-		return errors.New("no scenarios installed, abort")
+		return false, false, errors.New("no scenarios installed, abort")
 	}
 
-	client, err := apiclient.NewDefaultClient(apiURL,
-		CAPIURLPrefix,
-		cwversion.UserAgent(),
-		nil)
+	passwd := strfmt.Password(password)
+
+	client, err := apiclient.NewClient(&apiclient.Config{
+		MachineID: login,
+		Password:  passwd,
+		Scenarios: scenarios,
+		UserAgent: cwversion.UserAgent(),
+		URL:       apiURL,
+		//I don't believe papi is neede to check enrollement
+		//PapiURL:       papiURL,
+		VersionPrefix: "v3",
+		UpdateScenario: func() ([]string, error) {
+			scenarios, err := hub.GetInstalledNamesByType(cwhub.SCENARIOS)
+			if err != nil {
+				return nil, err
+			}
+			appsecRules, err := hub.GetInstalledNamesByType(cwhub.APPSEC_RULES)
+			if err != nil {
+				return nil, err
+			}
+			ret := make([]string, 0, len(scenarios)+len(appsecRules))
+			ret = append(ret, scenarios...)
+			ret = append(ret, appsecRules...)
+
+			return ret, nil
+		},
+	})
+
 	if err != nil {
-		return fmt.Errorf("init default client: %w", err)
+		return false, false, fmt.Errorf("new client api: %w", err)
 	}
 
 	pw := strfmt.Password(password)
@@ -180,12 +205,22 @@ func QueryCAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 		Scenarios: scenarios,
 	}
 
-	_, _, err = client.Auth.AuthenticateWatcher(context.Background(), t)
+	authResp, _, err := client.Auth.AuthenticateWatcher(context.Background(), t)
 	if err != nil {
-		return err
+		return false, false, err
 	}
 
-	return nil
+	if err = client.GetClient().Transport.(*apiclient.JWTTransport).Expiration.UnmarshalText([]byte(authResp.Expire)); err != nil {
+		return true, false, err
+	}
+
+	client.GetClient().Transport.(*apiclient.JWTTransport).Token = authResp.Token
+
+	if client.IsEnrolled() {
+		return true, true, nil
+	} else {
+		return true, false, nil
+	}
 }
 
 func (cli *cliCapi) status() error {
@@ -205,12 +240,17 @@ func (cli *cliCapi) status() error {
 	log.Infof("Loaded credentials from %s", cfg.API.Server.OnlineClient.CredentialsFilePath)
 	log.Infof("Trying to authenticate with username %s on %s", cred.Login, cred.URL)
 
-	if err := QueryCAPIStatus(hub, cred.URL, cred.Login, cred.Password); err != nil {
-		return fmt.Errorf("failed to authenticate to Central API (CAPI): %w", err)
+	auth, enrolled, err := QueryCAPIStatus(hub, cred.URL, cred.Login, cred.Password)
+
+	if err != nil {
+		log.Errorf("CAPI: failed to authenticate to Central API (CAPI): %w", err)
 	}
-
-	log.Info("You can successfully interact with Central API (CAPI)")
-
+	if auth {
+		log.Info("You can successfully interact with Central API (CAPI)")
+	}
+	if enrolled {
+		log.Info("Your instance is enrolled in the console")
+	}
 	return nil
 }
 

--- a/cmd/crowdsec-cli/support.go
+++ b/cmd/crowdsec-cli/support.go
@@ -260,11 +260,17 @@ func (cli *cliSupport) dumpCAPIStatus(zw *zip.Writer, hub *cwhub.Hub) error {
 	fmt.Fprintf(out, "CAPI URL: %s\n", cred.URL)
 	fmt.Fprintf(out, "CAPI username: %s\n", cred.Login)
 
-	if err := QueryCAPIStatus(hub, cred.URL, cred.Login, cred.Password); err != nil {
+	auth, enrolled, err := QueryCAPIStatus(hub, cred.URL, cred.Login, cred.Password)
+	if err != nil {
 		return fmt.Errorf("could not authenticate to Central API (CAPI): %w", err)
 	}
+	if auth {
+		fmt.Fprintln(out, "You can successfully interact with Central API (CAPI)")
+	}
 
-	fmt.Fprintln(out, "You can successfully interact with Central API (CAPI)")
+	if enrolled {
+		fmt.Fprintln(out, "Your instance is enrolled in the console")
+	}
 
 	cli.writeToZip(zw, SUPPORT_CAPI_STATUS_PATH, time.Now(), out)
 


### PR DESCRIPTION
`cscli capi status` now as well tells if we're enrolled