### PR TITLE
pkg/cwhub: simpler accessor methods

### DIFF
--- a/cmd/crowdsec-cli/capi.go
+++ b/cmd/crowdsec-cli/capi.go
@@ -145,7 +145,6 @@ func (cli *cliCapi) newRegisterCmd() *cobra.Command {
 
 // QueryCAPIStatus checks if the Local API is reachable, and if the credentials are correct. It then checks if the instance is enrolle in the console.
 func QueryCAPIStatus(hub *cwhub.Hub, credURL string, login string, password string) (bool, bool, error) {
-
 	apiURL, err := url.Parse(credURL)
 	if err != nil {
 		return false, false, fmt.Errorf("parsing api url: %w", err)
@@ -165,14 +164,13 @@ func QueryCAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 		Scenarios: itemsForAPI,
 		UserAgent: cwversion.UserAgent(),
 		URL:       apiURL,
-		//I don't believe papi is neede to check enrollement
-		//PapiURL:       papiURL,
+		// I don't believe papi is neede to check enrollement
+		// PapiURL:       papiURL,
 		VersionPrefix: "v3",
 		UpdateScenario: func() ([]string, error) {
 			return itemsForAPI, nil
 		},
 	})
-
 	if err != nil {
 		return false, false, fmt.Errorf("new client api: %w", err)
 	}
@@ -196,7 +194,6 @@ func QueryCAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 		return true, true, nil
 	}
 	return true, false, nil
-
 }
 
 func (cli *cliCapi) status() error {
@@ -217,7 +214,6 @@ func (cli *cliCapi) status() error {
 	log.Infof("Trying to authenticate with username %s on %s", cred.Login, cred.URL)
 
 	auth, enrolled, err := QueryCAPIStatus(hub, cred.URL, cred.Login, cred.Password)
-
 	if err != nil {
 		return fmt.Errorf("CAPI: failed to authenticate to Central API (CAPI): %s", err)
 	}

--- a/cmd/crowdsec-cli/cliconsole/console.go
+++ b/cmd/crowdsec-cli/cliconsole/console.go
@@ -23,7 +23,6 @@ import (
 	"github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/require"
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
-	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
@@ -78,20 +77,6 @@ func (cli *cliConsole) enroll(key string, name string, overwrite bool, tags []st
 		return fmt.Errorf("could not parse CAPI URL: %w", err)
 	}
 
-	hub, err := require.Hub(cfg, nil, nil)
-	if err != nil {
-		return err
-	}
-
-	scenarios, err := hub.GetInstalledNamesByType(cwhub.SCENARIOS)
-	if err != nil {
-		return fmt.Errorf("failed to get installed scenarios: %w", err)
-	}
-
-	if len(scenarios) == 0 {
-		scenarios = make([]string, 0)
-	}
-
 	enableOpts := []string{csconfig.SEND_MANUAL_SCENARIOS, csconfig.SEND_TAINTED_SCENARIOS}
 
 	if len(opts) != 0 {
@@ -129,10 +114,15 @@ func (cli *cliConsole) enroll(key string, name string, overwrite bool, tags []st
 		}
 	}
 
+	hub, err := require.Hub(cfg, nil, nil)
+	if err != nil {
+		return err
+	}
+
 	c, _ := apiclient.NewClient(&apiclient.Config{
 		MachineID:     cli.cfg().API.Server.OnlineClient.Credentials.Login,
 		Password:      password,
-		Scenarios:     scenarios,
+		Scenarios:     hub.GetInstalledListForAPI(),
 		UserAgent:     cwversion.UserAgent(),
 		URL:           apiURL,
 		VersionPrefix: "v3",

--- a/cmd/crowdsec-cli/hub.go
+++ b/cmd/crowdsec-cli/hub.go
@@ -148,16 +148,11 @@ func (cli *cliHub) upgrade(ctx context.Context, force bool) error {
 	}
 
 	for _, itemType := range cwhub.ItemTypes {
-		items, err := hub.GetInstalledItemsByType(itemType)
-		if err != nil {
-			return err
-		}
-
 		updated := 0
 
 		log.Infof("Upgrading %s", itemType)
 
-		for _, item := range items {
+		for _, item := range hub.GetInstalledByType(itemType, true) {
 			didUpdate, err := item.Upgrade(ctx, force)
 			if err != nil {
 				return err

--- a/cmd/crowdsec-cli/item_suggest.go
+++ b/cmd/crowdsec-cli/item_suggest.go
@@ -19,7 +19,7 @@ func suggestNearestMessage(hub *cwhub.Hub, itemType string, itemName string) str
 	score := 100
 	nearest := ""
 
-	for _, item := range hub.GetItemMap(itemType) {
+	for _, item := range hub.GetItemsByType(itemType, false) {
 		d := levenshtein.Distance(itemName, item.Name, nil)
 		if d < score {
 			score = d
@@ -44,7 +44,7 @@ func compAllItems(itemType string, args []string, toComplete string, cfg configG
 
 	comp := make([]string, 0)
 
-	for _, item := range hub.GetItemMap(itemType) {
+	for _, item := range hub.GetItemsByType(itemType, false) {
 		if !slices.Contains(args, item.Name) && strings.Contains(item.Name, toComplete) {
 			comp = append(comp, item.Name)
 		}
@@ -61,22 +61,14 @@ func compInstalledItems(itemType string, args []string, toComplete string, cfg c
 		return nil, cobra.ShellCompDirectiveDefault
 	}
 
-	items, err := hub.GetInstalledNamesByType(itemType)
-	if err != nil {
-		cobra.CompDebugln(fmt.Sprintf("list installed %s err: %s", itemType, err), true)
-		return nil, cobra.ShellCompDirectiveDefault
-	}
+	items := hub.GetInstalledByType(itemType, true)
 
 	comp := make([]string, 0)
 
-	if toComplete != "" {
-		for _, item := range items {
-			if strings.Contains(item, toComplete) {
-				comp = append(comp, item)
-			}
+	for _, item := range items {
+		if strings.Contains(item.Name, toComplete) {
+			comp = append(comp, item.Name)
 		}
-	} else {
-		comp = items
 	}
 
 	cobra.CompDebugln(fmt.Sprintf("%s: %+v", itemType, comp), true)

--- a/cmd/crowdsec-cli/itemcli.go
+++ b/cmd/crowdsec-cli/itemcli.go
@@ -147,19 +147,14 @@ func (cli cliItem) remove(args []string, purge bool, force bool, all bool) error
 	}
 
 	if all {
-		getter := hub.GetInstalledItemsByType
+		itemGetter := hub.GetInstalledByType
 		if purge {
-			getter = hub.GetItemsByType
-		}
-
-		items, err := getter(cli.name)
-		if err != nil {
-			return err
+			itemGetter = hub.GetItemsByType
 		}
 
 		removed := 0
 
-		for _, item := range items {
+		for _, item := range itemGetter(cli.name, true) {
 			didRemove, err := item.Remove(purge, force)
 			if err != nil {
 				return err
@@ -262,14 +257,9 @@ func (cli cliItem) upgrade(ctx context.Context, args []string, force bool, all b
 	}
 
 	if all {
-		items, err := hub.GetInstalledItemsByType(cli.name)
-		if err != nil {
-			return err
-		}
-
 		updated := 0
 
-		for _, item := range items {
+		for _, item := range hub.GetInstalledByType(cli.name, true) {
 			didUpdate, err := item.Upgrade(ctx, force)
 			if err != nil {
 				return err

--- a/cmd/crowdsec-cli/items.go
+++ b/cmd/crowdsec-cli/items.go
@@ -17,7 +17,12 @@ import (
 
 // selectItems returns a slice of items of a given type, selected by name and sorted by case-insensitive name
 func selectItems(hub *cwhub.Hub, itemType string, args []string, installedOnly bool) ([]*cwhub.Item, error) {
-	itemNames := hub.GetNamesByType(itemType)
+	allItems := hub.GetItemsByType(itemType, true)
+
+	itemNames := make([]string, len(allItems))
+	for idx, item := range allItems {
+		itemNames[idx] = item.Name
+	}
 
 	notExist := []string{}
 
@@ -38,7 +43,7 @@ func selectItems(hub *cwhub.Hub, itemType string, args []string, installedOnly b
 		installedOnly = false
 	}
 
-	items := make([]*cwhub.Item, 0, len(itemNames))
+	wantedItems := make([]*cwhub.Item, 0, len(itemNames))
 
 	for _, itemName := range itemNames {
 		item := hub.GetItem(itemType, itemName)
@@ -46,12 +51,10 @@ func selectItems(hub *cwhub.Hub, itemType string, args []string, installedOnly b
 			continue
 		}
 
-		items = append(items, item)
+		wantedItems = append(wantedItems, item)
 	}
 
-	cwhub.SortItemSlice(items)
-
-	return items, nil
+	return wantedItems, nil
 }
 
 func listItems(out io.Writer, wantColor string, itemTypes []string, items map[string][]*cwhub.Item, omitIfEmpty bool, output string) error {

--- a/cmd/crowdsec-cli/lapi.go
+++ b/cmd/crowdsec-cli/lapi.go
@@ -45,11 +45,6 @@ func QueryLAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 		return fmt.Errorf("parsing api url: %w", err)
 	}
 
-	scenarios, err := hub.GetInstalledNamesByType(cwhub.SCENARIOS)
-	if err != nil {
-		return fmt.Errorf("failed to get scenarios: %w", err)
-	}
-
 	client, err := apiclient.NewDefaultClient(apiURL,
 		LAPIURLPrefix,
 		cwversion.UserAgent(),
@@ -60,10 +55,12 @@ func QueryLAPIStatus(hub *cwhub.Hub, credURL string, login string, password stri
 
 	pw := strfmt.Password(password)
 
+	itemsForAPI := hub.GetInstalledListForAPI()
+
 	t := models.WatcherAuthRequest{
 		MachineID: &login,
 		Password:  &pw,
-		Scenarios: scenarios,
+		Scenarios: itemsForAPI,
 	}
 
 	_, _, err = client.Auth.AuthenticateWatcher(context.Background(), t)

--- a/cmd/crowdsec/lpmetrics.go
+++ b/cmd/crowdsec/lpmetrics.go
@@ -46,10 +46,8 @@ func getHubState(hub *cwhub.Hub) models.HubItems {
 
 	for _, itemType := range cwhub.ItemTypes {
 		ret[itemType] = []models.HubItem{}
-		items, _ := hub.GetInstalledItemsByType(itemType)
-		cwhub.SortItemSlice(items)
 
-		for _, item := range items {
+		for _, item := range hub.GetInstalledByType(itemType, true) {
 			status := "official"
 			if item.State.IsLocal() {
 				status = "custom"

--- a/cmd/crowdsec/lpmetrics.go
+++ b/cmd/crowdsec/lpmetrics.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-
 	"gopkg.in/tomb.v2"
 
 	"github.com/crowdsecurity/go-cs-lib/ptr"
@@ -88,7 +87,8 @@ func newStaticMetrics(consoleOptions []string, datasources []acquisition.DataSou
 }
 
 func NewMetricsProvider(apic *apiclient.ApiClient, interval time.Duration, logger *logrus.Entry,
-	consoleOptions []string, datasources []acquisition.DataSource, hub *cwhub.Hub) *MetricsProvider {
+	consoleOptions []string, datasources []acquisition.DataSource, hub *cwhub.Hub,
+) *MetricsProvider {
 	return &MetricsProvider{
 		apic:     apic,
 		interval: interval,

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -91,10 +91,8 @@ func LoadBuckets(cConfig *csconfig.Config, hub *cwhub.Hub) error {
 		files []string
 	)
 
-	for _, hubScenarioItem := range hub.GetItemMap(cwhub.SCENARIOS) {
-		if hubScenarioItem.State.Installed {
-			files = append(files, hubScenarioItem.State.LocalPath)
-		}
+	for _, hubScenarioItem := range hub.GetInstalledByType(cwhub.SCENARIOS, false) {
+		files = append(files, hubScenarioItem.State.LocalPath)
 	}
 
 	buckets = leakybucket.NewBuckets()

--- a/pkg/alertcontext/config.go
+++ b/pkg/alertcontext/config.go
@@ -104,14 +104,9 @@ func LoadConsoleContext(c *csconfig.Config, hub *cwhub.Hub) error {
 	c.Crowdsec.ContextToSend = make(map[string][]string, 0)
 
 	if hub != nil {
-		items, err := hub.GetInstalledItemsByType(cwhub.CONTEXTS)
-		if err != nil {
-			return err
-		}
-
-		for _, item := range items {
+		for _, item := range hub.GetInstalledByType(cwhub.CONTEXTS, true) {
 			// context in item files goes under the key 'context'
-			if err = addContextFromItem(c.Crowdsec.ContextToSend, item); err != nil {
+			if err := addContextFromItem(c.Crowdsec.ContextToSend, item); err != nil {
 				return err
 			}
 		}

--- a/pkg/alertcontext/config.go
+++ b/pkg/alertcontext/config.go
@@ -98,7 +98,6 @@ func addContextFromFile(toSend map[string][]string, filePath string) error {
 	return nil
 }
 
-
 // LoadConsoleContext loads the context from the hub (if provided) and the file console_context_path.
 func LoadConsoleContext(c *csconfig.Config, hub *cwhub.Hub) error {
 	c.Crowdsec.ContextToSend = make(map[string][]string, 0)

--- a/pkg/appsec/appsec.go
+++ b/pkg/appsec/appsec.go
@@ -177,19 +177,13 @@ func (wc *AppsecConfig) LoadByPath(file string) error {
 }
 
 func (wc *AppsecConfig) Load(configName string) error {
-	appsecConfigs := hub.GetItemMap(cwhub.APPSEC_CONFIGS)
+	item := hub.GetItem(cwhub.APPSEC_CONFIGS, configName)
 
-	for _, hubAppsecConfigItem := range appsecConfigs {
-		if !hubAppsecConfigItem.State.Installed {
-			continue
-		}
-		if hubAppsecConfigItem.Name != configName {
-			continue
-		}
-		wc.Logger.Infof("loading %s", hubAppsecConfigItem.State.LocalPath)
-		err := wc.LoadByPath(hubAppsecConfigItem.State.LocalPath)
+	if item != nil && item.State.Installed {
+		wc.Logger.Infof("loading %s", item.State.LocalPath)
+		err := wc.LoadByPath(item.State.LocalPath)
 		if err != nil {
-			return fmt.Errorf("unable to load appsec-config %s : %s", hubAppsecConfigItem.State.LocalPath, err)
+			return fmt.Errorf("unable to load appsec-config %s : %s", item.State.LocalPath, err)
 		}
 		return nil
 	}

--- a/pkg/appsec/appsec.go
+++ b/pkg/appsec/appsec.go
@@ -40,7 +40,6 @@ const (
 )
 
 func (h *Hook) Build(hookStage int) error {
-
 	ctx := map[string]interface{}{}
 	switch hookStage {
 	case hookOnLoad:
@@ -54,7 +53,7 @@ func (h *Hook) Build(hookStage int) error {
 	}
 	opts := exprhelpers.GetExprOptions(ctx)
 	if h.Filter != "" {
-		program, err := expr.Compile(h.Filter, opts...) //FIXME: opts
+		program, err := expr.Compile(h.Filter, opts...) // FIXME: opts
 		if err != nil {
 			return fmt.Errorf("unable to compile filter %s : %w", h.Filter, err)
 		}
@@ -73,11 +72,11 @@ func (h *Hook) Build(hookStage int) error {
 type AppsecTempResponse struct {
 	InBandInterrupt         bool
 	OutOfBandInterrupt      bool
-	Action                  string //allow, deny, captcha, log
-	UserHTTPResponseCode    int    //The response code to send to the user
-	BouncerHTTPResponseCode int    //The response code to send to the remediation component
-	SendEvent               bool   //do we send an internal event on rule match
-	SendAlert               bool   //do we send an alert on rule match
+	Action                  string // allow, deny, captcha, log
+	UserHTTPResponseCode    int    // The response code to send to the user
+	BouncerHTTPResponseCode int    // The response code to send to the remediation component
+	SendEvent               bool   // do we send an internal event on rule match
+	SendAlert               bool   // do we send an alert on rule match
 }
 
 type AppsecSubEngineOpts struct {
@@ -93,7 +92,7 @@ type AppsecRuntimeConfig struct {
 	InBandRules []AppsecCollection
 
 	DefaultRemediation        string
-	RemediationByTag          map[string]string //Also used for ByName, as the name (for modsec rules) is a tag crowdsec-NAME
+	RemediationByTag          map[string]string // Also used for ByName, as the name (for modsec rules) is a tag crowdsec-NAME
 	RemediationById           map[int]string
 	CompiledOnLoad            []Hook
 	CompiledPreEval           []Hook
@@ -101,22 +100,22 @@ type AppsecRuntimeConfig struct {
 	CompiledOnMatch           []Hook
 	CompiledVariablesTracking []*regexp.Regexp
 	Config                    *AppsecConfig
-	//CorazaLogger              debuglog.Logger
+	// CorazaLogger              debuglog.Logger
 
-	//those are ephemeral, created/destroyed with every req
-	OutOfBandTx ExtendedTransaction //is it a good idea ?
-	InBandTx    ExtendedTransaction //is it a good idea ?
+	// those are ephemeral, created/destroyed with every req
+	OutOfBandTx ExtendedTransaction // is it a good idea ?
+	InBandTx    ExtendedTransaction // is it a good idea ?
 	Response    AppsecTempResponse
-	//should we store matched rules here ?
+	// should we store matched rules here ?
 
 	Logger *log.Entry
 
-	//Set by on_load to ignore some rules on loading
+	// Set by on_load to ignore some rules on loading
 	DisabledInBandRuleIds   []int
-	DisabledInBandRulesTags []string //Also used for ByName, as the name (for modsec rules) is a tag crowdsec-NAME
+	DisabledInBandRulesTags []string // Also used for ByName, as the name (for modsec rules) is a tag crowdsec-NAME
 
 	DisabledOutOfBandRuleIds   []int
-	DisabledOutOfBandRulesTags []string //Also used for ByName, as the name (for modsec rules) is a tag crowdsec-NAME
+	DisabledOutOfBandRulesTags []string // Also used for ByName, as the name (for modsec rules) is a tag crowdsec-NAME
 }
 
 type AppsecConfig struct {
@@ -125,10 +124,10 @@ type AppsecConfig struct {
 	InBandRules            []string `yaml:"inband_rules"`
 	DefaultRemediation     string   `yaml:"default_remediation"`
 	DefaultPassAction      string   `yaml:"default_pass_action"`
-	BouncerBlockedHTTPCode int      `yaml:"blocked_http_code"`      //returned to the bouncer
-	BouncerPassedHTTPCode  int      `yaml:"passed_http_code"`       //returned to the bouncer
-	UserBlockedHTTPCode    int      `yaml:"user_blocked_http_code"` //returned to the user
-	UserPassedHTTPCode     int      `yaml:"user_passed_http_code"`  //returned to the user
+	BouncerBlockedHTTPCode int      `yaml:"blocked_http_code"`      // returned to the bouncer
+	BouncerPassedHTTPCode  int      `yaml:"passed_http_code"`       // returned to the bouncer
+	UserBlockedHTTPCode    int      `yaml:"user_blocked_http_code"` // returned to the user
+	UserPassedHTTPCode     int      `yaml:"user_passed_http_code"`  // returned to the user
 
 	OnLoad            []Hook              `yaml:"on_load"`
 	PreEval           []Hook              `yaml:"pre_eval"`
@@ -152,7 +151,6 @@ func (w *AppsecRuntimeConfig) ClearResponse() {
 }
 
 func (wc *AppsecConfig) LoadByPath(file string) error {
-
 	wc.Logger.Debugf("loading config %s", file)
 
 	yamlFile, err := os.ReadFile(file)
@@ -218,10 +216,10 @@ func (wc *AppsecConfig) Build() (*AppsecRuntimeConfig, error) {
 		wc.DefaultRemediation = BanRemediation
 	}
 
-	//set the defaults
+	// set the defaults
 	switch wc.DefaultRemediation {
 	case BanRemediation, CaptchaRemediation, AllowRemediation:
-		//those are the officially supported remediation(s)
+		// those are the officially supported remediation(s)
 	default:
 		wc.Logger.Warningf("default '%s' remediation of %s is none of [%s,%s,%s] ensure bouncer compatbility!", wc.DefaultRemediation, wc.Name, BanRemediation, CaptchaRemediation, AllowRemediation)
 	}
@@ -231,7 +229,7 @@ func (wc *AppsecConfig) Build() (*AppsecRuntimeConfig, error) {
 	ret.DefaultRemediation = wc.DefaultRemediation
 
 	wc.Logger.Tracef("Loading config %+v", wc)
-	//load rules
+	// load rules
 	for _, rule := range wc.OutOfBandRules {
 		wc.Logger.Infof("loading outofband rule %s", rule)
 		collections, err := LoadCollection(rule, wc.Logger.WithField("component", "appsec_collection_loader"))
@@ -253,7 +251,7 @@ func (wc *AppsecConfig) Build() (*AppsecRuntimeConfig, error) {
 
 	wc.Logger.Infof("Loaded %d inband rules", len(ret.InBandRules))
 
-	//load hooks
+	// load hooks
 	for _, hook := range wc.OnLoad {
 		if hook.OnSuccess != "" && hook.OnSuccess != "continue" && hook.OnSuccess != "break" {
 			return nil, fmt.Errorf("invalid 'on_success' for on_load hook : %s", hook.OnSuccess)
@@ -298,7 +296,7 @@ func (wc *AppsecConfig) Build() (*AppsecRuntimeConfig, error) {
 		ret.CompiledOnMatch = append(ret.CompiledOnMatch, hook)
 	}
 
-	//variable tracking
+	// variable tracking
 	for _, variable := range wc.VariablesTracking {
 		compiledVariableRule, err := regexp.Compile(variable)
 		if err != nil {
@@ -454,7 +452,6 @@ func (w *AppsecRuntimeConfig) ProcessPostEvalRules(request *ParsedRequest) error
 		// here means there is no filter or the filter matched
 		for _, applyExpr := range rule.ApplyExpr {
 			o, err := exprhelpers.Run(applyExpr, GetPostEvalEnv(w, request), w.Logger, w.Logger.Level >= log.DebugLevel)
-
 			if err != nil {
 				w.Logger.Errorf("unable to apply appsec post_eval expr: %s", err)
 				continue
@@ -598,7 +595,7 @@ func (w *AppsecRuntimeConfig) SetActionByName(name string, action string) error 
 }
 
 func (w *AppsecRuntimeConfig) SetAction(action string) error {
-	//log.Infof("setting to %s", action)
+	// log.Infof("setting to %s", action)
 	w.Logger.Debugf("setting action to %s", action)
 	w.Response.Action = action
 	return nil
@@ -622,7 +619,7 @@ func (w *AppsecRuntimeConfig) GenerateResponse(response AppsecTempResponse, logg
 	if response.Action == AllowRemediation {
 		resp.HTTPStatus = w.Config.UserPassedHTTPCode
 		bouncerStatusCode = w.Config.BouncerPassedHTTPCode
-	} else { //ban, captcha and anything else
+	} else { // ban, captcha and anything else
 		resp.HTTPStatus = response.UserHTTPResponseCode
 		if resp.HTTPStatus == 0 {
 			resp.HTTPStatus = w.Config.UserBlockedHTTPCode

--- a/pkg/appsec/loader.go
+++ b/pkg/appsec/loader.go
@@ -17,11 +17,7 @@ func LoadAppsecRules(hubInstance *cwhub.Hub) error {
 	hub = hubInstance
 	appsecRules = make(map[string]AppsecCollectionConfig)
 
-	for _, hubAppsecRuleItem := range hub.GetItemMap(cwhub.APPSEC_RULES) {
-		if !hubAppsecRuleItem.State.Installed {
-			continue
-		}
-
+	for _, hubAppsecRuleItem := range hub.GetInstalledByType(cwhub.APPSEC_RULES, false) {
 		content, err := os.ReadFile(hubAppsecRuleItem.State.LocalPath)
 		if err != nil {
 			log.Warnf("unable to read file %s : %s", hubAppsecRuleItem.State.LocalPath, err)

--- a/pkg/appsec/loader.go
+++ b/pkg/appsec/loader.go
@@ -9,9 +9,9 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
 )
 
-var appsecRules = make(map[string]AppsecCollectionConfig) //FIXME: would probably be better to have a struct for this
+var appsecRules = make(map[string]AppsecCollectionConfig) // FIXME: would probably be better to have a struct for this
 
-var hub *cwhub.Hub //FIXME: this is a temporary hack to make the hub available in the package
+var hub *cwhub.Hub // FIXME: this is a temporary hack to make the hub available in the package
 
 func LoadAppsecRules(hubInstance *cwhub.Hub) error {
 	hub = hubInstance

--- a/pkg/cwhub/cwhub.go
+++ b/pkg/cwhub/cwhub.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -44,11 +43,4 @@ func safePath(dir, filePath string) (string, error) {
 	}
 
 	return absFilePath, nil
-}
-
-// SortItemSlice sorts a slice of items by name, case insensitive.
-func SortItemSlice(items []*Item) {
-	sort.Slice(items, func(i, j int) bool {
-		return strings.ToLower(items[i].Name) < strings.ToLower(items[j].Name)
-	})
 }

--- a/pkg/cwhub/doc.go
+++ b/pkg/cwhub/doc.go
@@ -74,7 +74,7 @@
 // Now you can use the hub object to access the existing items:
 //
 //	// list all the parsers
-//	for _, parser := range hub.GetItemMap(cwhub.PARSERS) {
+//	for _, parser := range hub.GetItemsByType(cwhub.PARSERS, false) {
 //		fmt.Printf("parser: %s\n", parser.Name)
 //	}
 //

--- a/pkg/cwhub/hub.go
+++ b/pkg/cwhub/hub.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/crowdsecurity/go-cs-lib/maptools"
+
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 )
 

--- a/pkg/hubtest/hubtest_item.go
+++ b/pkg/hubtest/hubtest_item.go
@@ -223,39 +223,30 @@ func (t *HubTestItem) InstallHub() error {
 	ctx := context.Background()
 
 	// install data for parsers if needed
-	ret := hub.GetItemMap(cwhub.PARSERS)
-	for parserName, item := range ret {
-		if item.State.Installed {
-			if err := item.DownloadDataIfNeeded(ctx, true); err != nil {
-				return fmt.Errorf("unable to download data for parser '%s': %+v", parserName, err)
-			}
-
-			log.Debugf("parser '%s' installed successfully in runtime environment", parserName)
+	for _, item := range hub.GetInstalledByType(cwhub.PARSERS, true) {
+		if err := item.DownloadDataIfNeeded(ctx, true); err != nil {
+			return fmt.Errorf("unable to download data for parser '%s': %+v", item.Name, err)
 		}
+
+		log.Debugf("parser '%s' installed successfully in runtime environment", item.Name)
 	}
 
 	// install data for scenarios if needed
-	ret = hub.GetItemMap(cwhub.SCENARIOS)
-	for scenarioName, item := range ret {
-		if item.State.Installed {
-			if err := item.DownloadDataIfNeeded(ctx, true); err != nil {
-				return fmt.Errorf("unable to download data for parser '%s': %+v", scenarioName, err)
-			}
-
-			log.Debugf("scenario '%s' installed successfully in runtime environment", scenarioName)
+	for _, item := range hub.GetInstalledByType(cwhub.SCENARIOS, true) {
+		if err := item.DownloadDataIfNeeded(ctx, true); err != nil {
+			return fmt.Errorf("unable to download data for parser '%s': %+v", item.Name, err)
 		}
+
+		log.Debugf("scenario '%s' installed successfully in runtime environment", item.Name)
 	}
 
 	// install data for postoverflows if needed
-	ret = hub.GetItemMap(cwhub.POSTOVERFLOWS)
-	for postoverflowName, item := range ret {
-		if item.State.Installed {
-			if err := item.DownloadDataIfNeeded(ctx, true); err != nil {
-				return fmt.Errorf("unable to download data for parser '%s': %+v", postoverflowName, err)
-			}
-
-			log.Debugf("postoverflow '%s' installed successfully in runtime environment", postoverflowName)
+	for _, item := range hub.GetInstalledByType(cwhub.POSTOVERFLOWS, true) {
+		if err := item.DownloadDataIfNeeded(ctx, true); err != nil {
+			return fmt.Errorf("unable to download data for parser '%s': %+v", item.Name, err)
 		}
+
+		log.Debugf("postoverflow '%s' installed successfully in runtime environment", item.Name)
 	}
 
 	return nil

--- a/pkg/parser/unix_parser.go
+++ b/pkg/parser/unix_parser.go
@@ -66,21 +66,20 @@ func NewParsers(hub *cwhub.Hub) *Parsers {
 	}
 
 	for _, itemType := range []string{cwhub.PARSERS, cwhub.POSTOVERFLOWS} {
-		for _, hubParserItem := range hub.GetItemMap(itemType) {
-			if hubParserItem.State.Installed {
-				stagefile := Stagefile{
-					Filename: hubParserItem.State.LocalPath,
-					Stage:    hubParserItem.Stage,
-				}
-				if itemType == cwhub.PARSERS {
-					parsers.StageFiles = append(parsers.StageFiles, stagefile)
-				}
-				if itemType == cwhub.POSTOVERFLOWS {
-					parsers.PovfwStageFiles = append(parsers.PovfwStageFiles, stagefile)
-				}
+		for _, hubParserItem := range hub.GetInstalledByType(itemType, false) {
+			stagefile := Stagefile{
+				Filename: hubParserItem.State.LocalPath,
+				Stage:    hubParserItem.Stage,
+			}
+			if itemType == cwhub.PARSERS {
+				parsers.StageFiles = append(parsers.StageFiles, stagefile)
+			}
+			if itemType == cwhub.POSTOVERFLOWS {
+				parsers.PovfwStageFiles = append(parsers.PovfwStageFiles, stagefile)
 			}
 		}
 	}
+
 	if parsers.StageFiles != nil {
 		sort.Slice(parsers.StageFiles, func(i, j int) bool {
 			return parsers.StageFiles[i].Filename < parsers.StageFiles[j].Filename

--- a/pkg/parser/unix_parser.go
+++ b/pkg/parser/unix_parser.go
@@ -100,13 +100,17 @@ func LoadParsers(cConfig *csconfig.Config, parsers *Parsers) (*Parsers, error) {
 	patternsDir := cConfig.ConfigPaths.PatternDir
 	log.Infof("Loading grok library %s", patternsDir)
 	/* load base regexps for two grok parsers */
-	parsers.Ctx, err = Init(map[string]interface{}{"patterns": patternsDir,
-		"data": cConfig.ConfigPaths.DataDir})
+	parsers.Ctx, err = Init(map[string]interface{}{
+		"patterns": patternsDir,
+		"data":     cConfig.ConfigPaths.DataDir,
+	})
 	if err != nil {
 		return parsers, fmt.Errorf("failed to load parser patterns : %v", err)
 	}
-	parsers.Povfwctx, err = Init(map[string]interface{}{"patterns": patternsDir,
-		"data": cConfig.ConfigPaths.DataDir})
+	parsers.Povfwctx, err = Init(map[string]interface{}{
+		"patterns": patternsDir,
+		"data":     cConfig.ConfigPaths.DataDir,
+	})
 	if err != nil {
 		return parsers, fmt.Errorf("failed to load postovflw parser patterns : %v", err)
 	}

--- a/test/bats/04_capi.bats
+++ b/test/bats/04_capi.bats
@@ -51,7 +51,7 @@ setup() {
     config_enable_capi
     rune -0 cscli capi register --schmilblick githubciXXXXXXXXXXXXXXXXXXXXXXXX
     rune -1 cscli capi status
-    assert_stderr --partial "no scenarios installed, abort"
+    assert_stderr --partial "no scenarios or appsec-rules installed, abort"
 
     rune -0 cscli scenarios install crowdsecurity/ssh-bf
     rune -0 cscli capi status


### PR DESCRIPTION
 - prefer higher level GetItemsByType, GetInstalledByType over GetItemMap
 - always send both appsec-rules and scenarios to api
 - explicit parameter for (case insensitive) sorted list of items
 - shorter code
 - assume itemType parameter makes sense, don't error