### PR TITLE
add missing ApiKeyAuthorizer to decisions swagger endpoint

### DIFF
--- a/pkg/models/localapi_swagger.yaml
+++ b/pkg/models/localapi_swagger.yaml
@@ -160,6 +160,8 @@ paths:
           description: "400 response"
           schema:
             $ref: "#/definitions/ErrorResponse"
+      security:
+      - APIKeyAuthorizer: []
     head:
       description: Returns information about existing decisions
       summary: GetDecisions


### PR DESCRIPTION
- add missing ApiKeyAuthorizer to decisions swagger endpoint