### PR TITLE
backport: return an error if cscli dashboard is run within a container

### DIFF
--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -70,6 +70,10 @@ cscli dashboard stop
 cscli dashboard remove
 `,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			if version.System == "docker" {
+				return errors.New("cscli dashboard is not supported whilst running CrowdSec within a container please see: https://github.com/crowdsecurity/example-docker-compose/tree/main/basic")
+			}
+
 			cfg := cli.cfg()
 			if err := require.LAPI(cfg); err != nil {
 				return err
@@ -102,10 +106,6 @@ cscli dashboard remove
 			}
 
 			log.Warn("cscli dashboard will be deprecated in version 1.7.0, read more at https://docs.crowdsec.net/blog/cscli_dashboard_deprecation/")
-
-			if version.System == "docker" {
-				return errors.New("cscli dashboard is not supported whilst running CrowdSec within a container please see: https://github.com/crowdsecurity/example-docker-compose/tree/main/basic")
-			}
 
 			return nil
 		},

--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/require"
 	"github.com/crowdsecurity/crowdsec/pkg/metabase"
+	"github.com/crowdsecurity/go-cs-lib/version"
 )
 
 var (
@@ -101,6 +102,10 @@ cscli dashboard remove
 			}
 
 			log.Warn("cscli dashboard will be deprecated in version 1.7.0, read more at https://docs.crowdsec.net/blog/cscli_dashboard_deprecation/")
+
+			if version.System == "docker" {
+				return errors.New("cscli dashboard is not supported whilst running CrowdSec within a container please see: https://github.com/crowdsecurity/example-docker-compose/tree/main/basic")
+			}
 
 			return nil
 		},


### PR DESCRIPTION
To prevent users from running cscli dashboard within a container it should detect the system and return an error.