### PR TITLE
docker: fixed hub_update and cli run

### DIFF
--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -80,6 +80,7 @@ is_mounted() {
 }
 
 run_hub_update_if_from_volume() {
+    isfalse "$NO_HUB_UPGRADE" || return 0
     if is_mounted "/etc/crowdsec/hub/.index.json"; then
         echo "Running hub update"
         run_hub_update
@@ -358,6 +359,11 @@ else
 fi
 
 conf_set_if "$PLUGIN_DIR" '.config_paths.plugin_dir = strenv(PLUGIN_DIR)'
+
+if istrue "$DISABLE_LOCAL_API" && istrue "$DISABLE_AGENT"; then
+    echo "Skipping crowdsec run, Local API and Agent are disabled"
+    exit 0
+fi
 
 ## Install hub items
 


### PR DESCRIPTION
1. As [documentation](https://github.com/crowdsecurity/crowdsec/blob/master/docker/README.md) states:
    > NO_HUB_UPGRADE Skip hub update / upgrade when the container starts

    I added check to `hub_update` function.

2. To be able to run onlt CLI from Kubernetes Cron Jobs, I added exit after configuration steps, but before downloading Hub stuff and running `crowdsec`.