### PR TITLE
lint/revive: check tags on non-exported struct fields

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -213,6 +213,7 @@ linters:
     #
     - execinquery
     - exportloopref
+    - gomnd
 
     #
     # Redundant
@@ -227,69 +228,6 @@ linters:
     # Disabled atm
 
     - intrange              # intrange is a linter to find places where for loops could make use of an integer range.
-
-    #
-    # Enabled
-    #
-
-    # - asasalint           # check for pass []any as any in variadic func(...any)
-    # - asciicheck          # checks that all code identifiers does not have non-ASCII symbols in the name
-    # - bidichk             # Checks for dangerous unicode character sequences
-    # - bodyclose           # checks whether HTTP response body is closed successfully
-    # - copyloopvar         # copyloopvar is a linter detects places where loop variables are copied
-    # - decorder            # check declaration order and count of types, constants, variables and functions
-    # - depguard            # Go linter that checks if package imports are in a list of acceptable packages
-    # - dupword             # checks for duplicate words in the source code
-    # - durationcheck       # check for two durations multiplied together
-    # - errcheck            # errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases
-    # - errorlint           # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    # - ginkgolinter        # enforces standards of using ginkgo and gomega
-    # - gocheckcompilerdirectives # Checks that go compiler directive comments (//go:) are valid.
-    # - gochecknoinits      # Checks that no init functions are present in Go code
-    # - gochecksumtype      # Run exhaustiveness checks on Go "sum types"
-    # - gocritic            # Provides diagnostics that check for bugs, performance and style issues.
-    # - goheader            # Checks is file header matches to pattern
-    # - gomoddirectives     # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
-    # - gomodguard          # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
-    # - goprintffuncname    # Checks that printf-like functions are named with `f` at the end
-    # - gosimple            # (megacheck): Linter for Go source code that specializes in simplifying code
-    # - gosmopolitan        # Report certain i18n/l10n anti-patterns in your Go codebase
-    # - govet               # (vet, vetshadow): Vet examines Go source code and reports suspicious constructs. It is roughly the same as 'go vet' and uses its passes.
-    # - grouper             # Analyze expression groups.
-    # - importas            # Enforces consistent import aliases
-    # - ineffassign         # Detects when assignments to existing variables are not used
-    # - interfacebloat      # A linter that checks the number of methods inside an interface.
-    # - loggercheck         # (logrlint): Checks key value pairs for common logger libraries (kitlog,klog,logr,zap).
-    # - logrlint            # Check logr arguments.
-    # - maintidx            # maintidx measures the maintainability index of each function.
-    # - makezero            # Finds slice declarations with non-zero initial length
-    # - mirror              # reports wrong mirror patterns of bytes/strings usage
-    # - misspell            # Finds commonly misspelled English words
-    # - nakedret            # Checks that functions with naked returns are not longer than a maximum size (can be zero).
-    # - nestif              # Reports deeply nested if statements
-    # - nilerr              # Finds the code that returns nil even if it checks that the error is not nil.
-    # - nolintlint          # Reports ill-formed or insufficient nolint directives
-    # - nonamedreturns      # Reports all named returns
-    # - nosprintfhostport   # Checks for misuse of Sprintf to construct a host with port in a URL.
-    # - perfsprint          # Checks that fmt.Sprintf can be replaced with a faster alternative.
-    # - predeclared         # find code that shadows one of Go's predeclared identifiers
-    # - reassign            # Checks that package variables are not reassigned
-    # - revive              # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
-    # - rowserrcheck        # checks whether Rows.Err of rows is checked successfully
-    # - sloglint            # ensure consistent code style when using log/slog
-    # - spancheck           # Checks for mistakes with OpenTelemetry/Census spans.
-    # - sqlclosecheck       # Checks that sql.Rows, sql.Stmt, sqlx.NamedStmt, pgx.Query are closed.
-    # - staticcheck         # (megacheck): It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint.
-    # - stylecheck          # Stylecheck is a replacement for golint
-    # - tenv                # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
-    # - testableexamples    # linter checks if examples are testable (have an expected output)
-    # - testifylint         # Checks usage of github.com/stretchr/testify.
-    # - tparallel           # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
-    # - unconvert           # Remove unnecessary type conversions
-    # - unused              # (megacheck): Checks Go code for unused constants, variables, functions and types
-    # - usestdlibvars       # A linter that detect the possibility to use variables/constants from the Go standard library.
-    # - wastedassign        # Finds wasted assignment statements
-    # - zerologlint         # Detects the wrong usage of `zerolog` that a user forgets to dispatch with `Send` or `Msg`
 
     #
     # Recommended? (easy)
@@ -318,7 +256,6 @@ linters:
     - containedctx          # containedctx is a linter that detects struct contained context.Context field
     - contextcheck          # check whether the function uses a non-inherited context
     - errname               # Checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`.
-    - gomnd                 # An analyzer to detect magic numbers.
     - ireturn               # Accept Interfaces, Return Concrete Types
     - mnd                   # An analyzer to detect magic numbers.
     - nilnil                # Checks that there is no simultaneous return of `nil` error and an invalid value.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -135,13 +135,9 @@ linters-settings:
         arguments: [7]
       - name: max-public-structs
         disabled: true
-      - name: optimize-operands-order
-        disabled: true
       - name: nested-structs
         disabled: true
       - name: package-comments
-        disabled: true
-      - name: struct-tag
         disabled: true
       - name: redundant-import-alias
         disabled: true

--- a/cmd/crowdsec-cli/climetrics/show.go
+++ b/cmd/crowdsec-cli/climetrics/show.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/fatih/color"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/require"

--- a/cmd/crowdsec-cli/dashboard.go
+++ b/cmd/crowdsec-cli/dashboard.go
@@ -20,10 +20,11 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/crowdsecurity/go-cs-lib/version"
+
 	"github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/idgen"
 	"github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/require"
 	"github.com/crowdsecurity/crowdsec/pkg/metabase"
-	"github.com/crowdsecurity/go-cs-lib/version"
 )
 
 var (

--- a/pkg/appsec/appsec_rules_collection.go
+++ b/pkg/appsec/appsec_rules_collection.go
@@ -29,9 +29,9 @@ type AppsecCollectionConfig struct {
 	SecLangRules      []string                 `yaml:"seclang_rules"`
 	Rules             []appsec_rule.CustomRule `yaml:"rules"`
 
-	Labels map[string]interface{} `yaml:"labels"` //Labels is K:V list aiming at providing context the overflow
+	Labels map[string]interface{} `yaml:"labels"` // Labels is K:V list aiming at providing context the overflow
 
-	Data    interface{} `yaml:"data"` //Ignore it
+	Data    interface{} `yaml:"data"` // Ignore it
 	hash    string
 	version string
 }
@@ -108,7 +108,7 @@ func LoadCollection(pattern string, logger *log.Entry) ([]AppsecCollection, erro
 				logger.Debugf("Adding rule %s", strRule)
 				appsecCol.Rules = append(appsecCol.Rules, strRule)
 
-				//We only take the first id, as it's the one of the "main" rule
+				// We only take the first id, as it's the one of the "main" rule
 				if _, ok := AppsecRulesDetails[int(rulesId[0])]; !ok {
 					AppsecRulesDetails[int(rulesId[0])] = RulesDetails{
 						LogLevel: log.InfoLevel,

--- a/pkg/appsec/appsec_rules_collection.go
+++ b/pkg/appsec/appsec_rules_collection.go
@@ -32,8 +32,8 @@ type AppsecCollectionConfig struct {
 	Labels map[string]interface{} `yaml:"labels"` //Labels is K:V list aiming at providing context the overflow
 
 	Data    interface{} `yaml:"data"` //Ignore it
-	hash    string      `yaml:"-"`
-	version string      `yaml:"-"`
+	hash    string
+	version string
 }
 
 type RulesDetails struct {

--- a/pkg/leakybucket/manager_load.go
+++ b/pkg/leakybucket/manager_load.go
@@ -45,7 +45,7 @@ type BucketFactory struct {
 	Debug               bool                   `yaml:"debug"`               // Debug, when set to true, will enable debugging for _this_ scenario specifically
 	Labels              map[string]interface{} `yaml:"labels"`              // Labels is K:V list aiming at providing context the overflow
 	Blackhole           string                 `yaml:"blackhole,omitempty"` // Blackhole is a duration that, if present, will prevent same bucket partition to overflow more often than $duration
-	logger              *log.Entry             `yaml:"-"`                   // logger is bucket-specific logger (used by Debug as well)
+	logger              *log.Entry                                          // logger is bucket-specific logger (used by Debug as well)
 	Reprocess           bool                   `yaml:"reprocess"`           // Reprocess, if true, will for the bucket to be re-injected into processing chain
 	CacheSize           int                    `yaml:"cache_size"`          // CacheSize, if > 0, limits the size of in-memory cache of the bucket
 	Profiling           bool                   `yaml:"profiling"`           // Profiling, if true, will make the bucket record pours/overflows/etc.
@@ -68,11 +68,11 @@ type BucketFactory struct {
 	processors          []Processor            // processors is the list of hooks for pour/overflow/create (cf. uniq, blackhole etc.)
 	output              bool                   // ??
 	ScenarioVersion     string                 `yaml:"version,omitempty"`
-	hash                string                 `yaml:"-"`
+	hash                string
 	Simulated           bool                   `yaml:"simulated"` // Set to true if the scenario instantiating the bucket was in the exclusion list
-	tomb                *tomb.Tomb             `yaml:"-"`
-	wgPour              *sync.WaitGroup        `yaml:"-"`
-	wgDumpState         *sync.WaitGroup        `yaml:"-"`
+	tomb                *tomb.Tomb
+	wgPour              *sync.WaitGroup
+	wgDumpState         *sync.WaitGroup
 	orderEvent          bool
 }
 

--- a/pkg/leakybucket/manager_load.go
+++ b/pkg/leakybucket/manager_load.go
@@ -45,12 +45,12 @@ type BucketFactory struct {
 	Debug               bool                   `yaml:"debug"`               // Debug, when set to true, will enable debugging for _this_ scenario specifically
 	Labels              map[string]interface{} `yaml:"labels"`              // Labels is K:V list aiming at providing context the overflow
 	Blackhole           string                 `yaml:"blackhole,omitempty"` // Blackhole is a duration that, if present, will prevent same bucket partition to overflow more often than $duration
-	logger              *log.Entry                                          // logger is bucket-specific logger (used by Debug as well)
-	Reprocess           bool                   `yaml:"reprocess"`           // Reprocess, if true, will for the bucket to be re-injected into processing chain
-	CacheSize           int                    `yaml:"cache_size"`          // CacheSize, if > 0, limits the size of in-memory cache of the bucket
-	Profiling           bool                   `yaml:"profiling"`           // Profiling, if true, will make the bucket record pours/overflows/etc.
-	OverflowFilter      string                 `yaml:"overflow_filter"`     // OverflowFilter if present, is a filter that must return true for the overflow to go through
-	ConditionalOverflow string                 `yaml:"condition"`           // condition if present, is an expression that must return true for the bucket to overflow
+	logger              *log.Entry             // logger is bucket-specific logger (used by Debug as well)
+	Reprocess           bool                   `yaml:"reprocess"`       // Reprocess, if true, will for the bucket to be re-injected into processing chain
+	CacheSize           int                    `yaml:"cache_size"`      // CacheSize, if > 0, limits the size of in-memory cache of the bucket
+	Profiling           bool                   `yaml:"profiling"`       // Profiling, if true, will make the bucket record pours/overflows/etc.
+	OverflowFilter      string                 `yaml:"overflow_filter"` // OverflowFilter if present, is a filter that must return true for the overflow to go through
+	ConditionalOverflow string                 `yaml:"condition"`       // condition if present, is an expression that must return true for the bucket to overflow
 	BayesianPrior       float32                `yaml:"bayesian_prior"`
 	BayesianThreshold   float32                `yaml:"bayesian_threshold"`
 	BayesianConditions  []RawBayesianCondition `yaml:"bayesian_conditions"` // conditions for the bayesian bucket
@@ -69,7 +69,7 @@ type BucketFactory struct {
 	output              bool                   // ??
 	ScenarioVersion     string                 `yaml:"version,omitempty"`
 	hash                string
-	Simulated           bool                   `yaml:"simulated"` // Set to true if the scenario instantiating the bucket was in the exclusion list
+	Simulated           bool `yaml:"simulated"` // Set to true if the scenario instantiating the bucket was in the exclusion list
 	tomb                *tomb.Tomb
 	wgPour              *sync.WaitGroup
 	wgDumpState         *sync.WaitGroup


### PR DESCRIPTION
this prevents forgetting to export a tagged field