### PR TITLE
enhance: Remove if log check in one instance

### DIFF
--- a/pkg/apiclient/client_http.go
+++ b/pkg/apiclient/client_http.go
@@ -61,9 +61,7 @@ func (c *ApiClient) Do(ctx context.Context, req *http.Request, v interface{}) (*
 		req.Header.Add("User-Agent", c.UserAgent)
 	}
 
-	if log.GetLevel() >= log.DebugLevel {
-		log.Debugf("[URL] %s %s", req.Method, req.URL)
-	}
+	log.Debugf("[URL] %s %s", req.Method, req.URL)
 
 	resp, err := c.client.Do(req)
 	if resp != nil && resp.Body != nil {


### PR DESCRIPTION
We check the log level if we are about to send resource intensive items to the logger, in this case it is not needed.