### PR TITLE
loki: add no_ready_check option

### DIFF
--- a/pkg/acquisition/modules/loki/loki.go
+++ b/pkg/acquisition/modules/loki/loki.go
@@ -283,19 +283,18 @@ func (l *LokiSource) OneShotAcquisition(ctx context.Context, out chan types.Even
 		}
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	c := l.Client.QueryRange(ctx, false)
+	lokiCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c := l.Client.QueryRange(lokiCtx, false)
 
 	for {
 		select {
 		case <-t.Dying():
 			l.logger.Debug("Loki one shot acquisition stopped")
-			cancel()
 			return nil
 		case resp, ok := <-c:
 			if !ok {
 				l.logger.Info("Loki acquisition done, chan closed")
-				cancel()
 				return nil
 			}
 			for _, stream := range resp.Data.Result {

--- a/pkg/acquisition/modules/loki/loki.go
+++ b/pkg/acquisition/modules/loki/loki.go
@@ -324,8 +324,6 @@ func (l *LokiSource) readOneEntry(entry lokiclient.Entry, labels map[string]stri
 }
 
 func (l *LokiSource) StreamingAcquisition(ctx context.Context, out chan types.Event, t *tomb.Tomb) error {
-	var err error
-
 	l.Client.SetTomb(t)
 
 	if !l.Config.NoReadyCheck {
@@ -341,16 +339,12 @@ func (l *LokiSource) StreamingAcquisition(ctx context.Context, out chan types.Ev
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		respChan := l.Client.QueryRange(ctx, true)
-		if err != nil {
-			ll.Errorf("could not start loki tail: %s", err)
-			return fmt.Errorf("while starting loki tail: %w", err)
-		}
 		for {
 			select {
 			case resp, ok := <-respChan:
 				if !ok {
 					ll.Warnf("loki channel closed")
-					return err
+					return fmt.Errorf("loki channel closed")
 				}
 				for _, stream := range resp.Data.Result {
 					for _, entry := range stream.Entries {

--- a/pkg/acquisition/modules/loki/loki.go
+++ b/pkg/acquisition/modules/loki/loki.go
@@ -344,7 +344,7 @@ func (l *LokiSource) StreamingAcquisition(ctx context.Context, out chan types.Ev
 			case resp, ok := <-respChan:
 				if !ok {
 					ll.Warnf("loki channel closed")
-					return fmt.Errorf("loki channel closed")
+					return errors.New("loki channel closed")
 				}
 				for _, stream := range resp.Data.Result {
 					for _, entry := range stream.Entries {

--- a/pkg/acquisition/modules/loki/loki_test.go
+++ b/pkg/acquisition/modules/loki/loki_test.go
@@ -34,6 +34,7 @@ func TestConfiguration(t *testing.T) {
 		password     string
 		waitForReady time.Duration
 		delayFor     time.Duration
+		noReadyCheck bool
 		testName     string
 	}{
 		{
@@ -99,6 +100,19 @@ query: >
 mode: tail
 source: loki
 url: http://localhost:3100/
+no_ready_check: true
+query: >
+        {server="demo"}
+`,
+			expectedErr:  "",
+			testName:     "Correct config with no_ready_check",
+			noReadyCheck: true,
+		},
+		{
+			config: `
+mode: tail
+source: loki
+url: http://localhost:3100/
 auth:
   username: foo
   password: bar
@@ -148,6 +162,8 @@ query: >
 					t.Fatalf("Wrong DelayFor %v != %v", lokiSource.Config.DelayFor, test.delayFor)
 				}
 			}
+
+			assert.Equal(t, test.noReadyCheck, lokiSource.Config.NoReadyCheck)
 		})
 	}
 }
@@ -164,6 +180,7 @@ func TestConfigureDSN(t *testing.T) {
 		scheme       string
 		waitForReady time.Duration
 		delayFor     time.Duration
+		noReadyCheck bool
 	}{
 		{
 			name:        "Wrong scheme",
@@ -202,10 +219,11 @@ func TestConfigureDSN(t *testing.T) {
 		},
 		{
 			name:         "Correct DSN",
-			dsn:          `loki://localhost:3100/?query={server="demo"}&wait_for_ready=5s&delay_for=1s`,
+			dsn:          `loki://localhost:3100/?query={server="demo"}&wait_for_ready=5s&delay_for=1s&no_ready_check=true`,
 			expectedErr:  "",
 			waitForReady: 5 * time.Second,
 			delayFor:     1 * time.Second,
+			noReadyCheck: true,
 		},
 		{
 			name:   "SSL DSN",
@@ -256,6 +274,9 @@ func TestConfigureDSN(t *testing.T) {
 				t.Fatalf("Wrong DelayFor %v != %v", lokiSource.Config.DelayFor, test.delayFor)
 			}
 		}
+
+		assert.Equal(t, test.noReadyCheck, lokiSource.Config.NoReadyCheck)
+
 	}
 }
 


### PR DESCRIPTION
When using Loki hosted in Grafana cloud, the `/ready` endpoint does not exist, which prevents crowdsec from starting.

Add an option to bypass this check.
Defaults to `false` to keep the same behavior by default.