### PR TITLE
fix: Use clientIP when passing coraza

### DIFF
--- a/pkg/acquisition/modules/appsec/appsec_runner.go
+++ b/pkg/acquisition/modules/appsec/appsec_runner.go
@@ -135,7 +135,7 @@ func (r *AppsecRunner) processRequest(tx appsec.ExtendedTransaction, request *ap
 		//FIXME: should we abort here ?
 	}
 
-	request.Tx.ProcessConnection(request.RemoteAddr, 0, "", 0)
+	request.Tx.ProcessConnection(request.ClientIP, 0, "", 0)
 
 	for k, v := range request.Args {
 		for _, vv := range v {


### PR DESCRIPTION
Fix: #3245 

However, `r.RemoteAddr` is still the remediation, I dont know if we want to fully drop it 🤷🏻 