### PR TITLE
enhance: add fedora 41 vagrant

### DIFF
--- a/test/ansible/vagrant/fedora-41/Vagrantfile
+++ b/test/ansible/vagrant/fedora-41/Vagrantfile
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Vagrant.configure('2') do |config|
+  config.vm.box = "fedora/40-cloud-base"
+  config.vm.provision "shell", inline: <<-SHELL
+  SHELL
+  config.vm.provision "shell" do |s|
+    s.inline = "sudo dnf upgrade --refresh -y && sudo dnf install dnf-plugin-system-upgrade -y && sudo dnf system-upgrade download --releasever=41 -y && sudo dnf system-upgrade reboot -y"
+  end
+end
+
+common = '../common'
+load common if File.exist?(common)

--- a/test/ansible/vagrant/fedora-41/skip
+++ b/test/ansible/vagrant/fedora-41/skip
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+die() {
+    echo "$@" >&2
+    exit 1
+}
+
+[ "${DB_BACKEND}" = "mysql" ] && die "mysql role does not support this distribution"
+exit 0


### PR DESCRIPTION
I dont think these are in the pipeline, however, I thought it be useful to have a vagrantfile that deploys 41 so we can test easier.

(40, with provision to upgrade to 41 since there no image so far on vagrant cloud)