### PR TITLE
enhance: add opensuse leap 15 vagrant

### DIFF
--- a/test/ansible/vagrant/opensuse-leap-15/Vagrantfile
+++ b/test/ansible/vagrant/opensuse-leap-15/Vagrantfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Vagrant.configure('2') do |config|
+  config.vm.box = "opensuse/Leap-15.6.x86_64"
+  config.vm.provision "shell", inline: <<-SHELL
+  SHELL
+end
+
+common = '../common'
+load common if File.exist?(common)

--- a/test/ansible/vagrant/opensuse-leap-15/skip
+++ b/test/ansible/vagrant/opensuse-leap-15/skip
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+die() {
+    echo "$@" >&2
+    exit 1
+}
+
+[ "${DB_BACKEND}" = "mysql" ] && die "mysql role does not support this distribution"
+exit 0


### PR DESCRIPTION
Testing new development installation script:

_**warning development script is only meant for testing purposes please dont run on your production server**_

```
vagrant@localhost:~> curl https://install.dev.crowdsec.net|sudo repo=crowdsec-testing sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 14202  100 14202    0     0  78030      0 --:--:-- --:--:-- --:--:-- 78032
Detected operating system as opensuse/15.6.
Checking for curl...
Detected curl...
Downloading repository file: https://packagecloud.io/install/repositories/crowdsec/crowdsec-testing/config_file.repo?os=rpm_any&dist=rpm_any&source=script
done.

Automatically importing the following key:

  Repository:       crowdsec_crowdsec-testing
  Key Fingerprint:  62E5 CC8C F50B 7B79 C02A 79C1 67EE 2E83 8FEA 572E
  Key Name:         https://packagecloud.io/crowdsec/crowdsec-testing (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>
  Key Algorithm:    RSA 4096
  Key Created:      Wed 09 Jun 2021 12:24:09 PM UTC
  Key Expires:      (does not expire)
  Subkey:           32C2CDA325FF0E35 2021-06-09 [does not expire]
  Rpm Name:         gpg-pubkey-8fea572e-60c0b2e9



    Note: A GPG pubkey is clearly identified by its fingerprint. Do not rely on the key's name. If
    you are not sure whether the presented key is authentic, ask the repository provider or check
    their web site. Many providers maintain a web page showing the fingerprints of the GPG keys they
    are using.
Retrieving repository 'crowdsec_crowdsec-testing' metadata ..................................................................................................................................[done]
Building repository 'crowdsec_crowdsec-testing' cache .......................................................................................................................................[done]
Specified repositories have been refreshed.
Retrieving repository 'crowdsec_crowdsec-testing-source' metadata ...........................................................................................................................[done]
Building repository 'crowdsec_crowdsec-testing-source' cache ................................................................................................................................[done]
Specified repositories have been refreshed.

vagrant@localhost:~> zypper install crowdsec
Root privileges are required to run this command.
vagrant@localhost:~> sudo !!
sudo zypper install crowdsec
Retrieving repository 'Update repository of openSUSE Backports' metadata ....................................................................................................................[done]
Building repository 'Update repository of openSUSE Backports' cache .........................................................................................................................[done]
Retrieving repository 'Non-OSS Repository' metadata .........................................................................................................................................[done]
Building repository 'Non-OSS Repository' cache ..............................................................................................................................................[done]
Retrieving repository 'Open H.264 Codec (openSUSE Leap)' metadata ...........................................................................................................................[done]
Building repository 'Open H.264 Codec (openSUSE Leap)' cache ................................................................................................................................[done]
Retrieving repository 'Main Repository' metadata ............................................................................................................................................[done]
Building repository 'Main Repository' cache .................................................................................................................................................[done]
Retrieving repository 'Update repository with updates from SUSE Linux Enterprise 15' metadata ...............................................................................................[done]
Building repository 'Update repository with updates from SUSE Linux Enterprise 15' cache ....................................................................................................[done]
Retrieving repository 'Main Update Repository' metadata .....................................................................................................................................[done]
Building repository 'Main Update Repository' cache ..........................................................................................................................................[done]
Retrieving repository 'Update Repository (Non-Oss)' metadata ................................................................................................................................[done]
Building repository 'Update Repository (Non-Oss)' cache .....................................................................................................................................[done]
Loading repository data...
Reading installed packages...
Resolving package dependencies...

Problem: 1: nothing provides 'crontabs' needed by the to be installed crowdsec-1.6.4~rc2-1.el9.x86_64
 Solution 1: do not install crowdsec-1.6.4~rc2-1.el9.x86_64
 Solution 2: break crowdsec-1.6.4~rc2-1.el9.x86_64 by ignoring some of its dependencies

Choose from above solutions by number or cancel [1/2/c/d/?] (c): 2

Resolving dependencies...
Resolving package dependencies...

The following NEW package is going to be installed:
  crowdsec

1 new package to install.

Package download size:    74.1 MiB

Package install size change:
              |     248.4 MiB  required by packages that will be installed
   248.4 MiB  |  -      0 B    released by packages that will be removed

Backend:  classic_rpmtrans
Continue? [y/n/v/...? shows all options] (y):
Retrieving: crowdsec-1.6.4~rc2-1.el9.x86_64 (crowdsec_crowdsec-testing)                                                                                                        (1/1),  74.1 MiB
Retrieving: crowdsec-1.6.4~rc2-1.el9.x86_64.rpm ................................................................................................................................[done (18.4 MiB/s)]

Checking for file conflicts: ................................................................................................................................................................[done]
warning: /var/cache/zypp/packages/crowdsec_crowdsec-testing/crowdsec-1.6.4~rc2-1.el9.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 3cdf0db4: NOKEY
/bin/bash
Creating acquisition configuration
/usr/share/crowdsec/wizard.sh: line 136: ps: command not found
INFO[2024-11-12 18:09:54] crowdsec_wizard: using journald for 'sshd'
Machine 'f1e8af87e0fc4c27b074667d2e2ad402GYlMqABcHBjCRrm4' successfully added to the local API.
API credentials written to '/etc/crowdsec/local_api_credentials.yaml'.
level=info msg="Wrote index to /etc/crowdsec/hub/.index.json"
INFO[2024-11-12 18:09:56] crowdsec_wizard: Installing collection 'crowdsecurity/linux'
updated /var/lib/crowdsec/data/GeoLite2-City.mmdb
updated /var/lib/crowdsec/data/GeoLite2-ASN.mmdb
installed crowdsecurity/linux
INFO[2024-11-12 18:09:59] crowdsec_wizard: Installing collection 'crowdsecurity/sshd'
installed crowdsecurity/sshd
installed crowdsecurity/whitelists
Get started with CrowdSec:
 * Detailed guides are available in our documentation: https://docs.crowdsec.net
 * Configuration items created by the community can be found at the Hub: https://hub.crowdsec.net
 * Gain insights into your use of CrowdSec with the help of the console https://app.crowdsec.net
(1/1) Installing: crowdsec-1.6.4~rc2-1.el9.x86_64 ...........................................................................................................................................[done]
```

```
vagrant@localhost:~> cscli metrics
FATA[2024-11-12T18:11:44Z] while reading yaml file: open /etc/crowdsec/config.yaml: permission denied
vagrant@localhost:~> sudo !!
sudo cscli metrics
Local API Metrics:
╭────────────────────┬────────┬──────╮
│ Route              │ Method │ Hits │
├────────────────────┼────────┼──────┤
│ /v1/heartbeat      │ GET    │ 1    │
│ /v1/usage-metrics  │ POST   │ 1    │
│ /v1/watchers/login │ POST   │ 1    │
╰────────────────────┴────────┴──────╯

Local API Machines Metrics:
╭──────────────────────────────────────────────────┬───────────────┬────────┬──────╮
│ Machine                                          │ Route         │ Method │ Hits │
├──────────────────────────────────────────────────┼───────────────┼────────┼──────┤
│ f1e8af87e0fc4c27b074667d2e2ad402GYlMqABcHBjCRrm4 │ /v1/heartbeat │ GET    │ 1    │
╰──────────────────────────────────────────────────┴───────────────┴────────┴──────╯

vagrant@localhost:~> cat /etc/crowdsec/acquis.yaml
#Generated acquisition file - wizard.sh (service: sshd) / files :
journalctl_filter:
 - _SYSTEMD_UNIT=sshd.service
labels:
  type: syslog
---
```