### PR TITLE
support dump: generate pprof files with debug=1 to avoid generating an unusable heap dump

### DIFF
--- a/cmd/crowdsec-cli/clisupport/support.go
+++ b/cmd/crowdsec-cli/clisupport/support.go
@@ -314,7 +314,7 @@ func (cli *cliSupport) dumpPprof(ctx context.Context, zw *zip.Writer, prometheus
 		ctx,
 		http.MethodGet,
 		fmt.Sprintf(
-			"http://%s/debug/pprof/%s?debug=1",
+			"http://%s/debug/pprof/%s",
 			net.JoinHostPort(
 				prometheusCfg.ListenAddr,
 				strconv.Itoa(prometheusCfg.ListenPort),


### PR DESCRIPTION
For some reason that I cannot totally explain (and that doesn't seem to be documented), generating a heap dump with `debug=1` makes it unusable for analysis with `go tool pprof`.

Let's just remove the parameter, it has not impact on the other profiles that are generated.