### PR TITLE
enhancement: add logdata to appsec AccumlateTxToEvent

### DIFF
--- a/pkg/acquisition/modules/appsec/utils.go
+++ b/pkg/acquisition/modules/appsec/utils.go
@@ -296,6 +296,7 @@ func (r *AppsecRunner) AccumulateTxToEvent(evt *types.Event, req *appsec.ParsedR
 			"hash":          hash,
 			"version":       version,
 			"matched_zones": matchedZones,
+			"logdata":       rule.Data(),
 		}
 		evt.Appsec.MatchedRules = append(evt.Appsec.MatchedRules, corazaRule)
 	}


### PR DESCRIPTION
logdata is a macro expanded string where most providers (OWASP CRS) store informational context around the alert.

For example:

https://github.com/coreruleset/coreruleset/blob/f98b5f122570b6f9bf4665f3c49bb424a207c058/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf#L182-L201

The alert is stating unix command was attempted to be injected but you cannot see which command was injected until you expose the `logdata` field, this is useful to most users that want to know what was attempted and blocked.