### PR TITLE
enhancement: Hubtest respect patterndir option set via config.yaml

### DIFF
--- a/cmd/crowdsec-cli/clihubtest/explain.go
+++ b/cmd/crowdsec-cli/clihubtest/explain.go
@@ -14,9 +14,12 @@ func (cli *cliHubTest) explain(testName string, details bool, skipOk bool) error
 		return fmt.Errorf("can't load test: %+v", err)
 	}
 
+	cfg := cli.cfg()
+	patternDir := cfg.ConfigPaths.PatternDir
+
 	err = test.ParserAssert.LoadTest(test.ParserResultFile)
 	if err != nil {
-		if err = test.Run(); err != nil {
+		if err = test.Run(patternDir); err != nil {
 			return fmt.Errorf("running test '%s' failed: %+v", test.Name, err)
 		}
 
@@ -27,7 +30,7 @@ func (cli *cliHubTest) explain(testName string, details bool, skipOk bool) error
 
 	err = test.ScenarioAssert.LoadTest(test.ScenarioResultFile, test.BucketPourResultFile)
 	if err != nil {
-		if err = test.Run(); err != nil {
+		if err = test.Run(patternDir); err != nil {
 			return fmt.Errorf("running test '%s' failed: %+v", test.Name, err)
 		}
 

--- a/cmd/crowdsec-cli/clihubtest/hubtest.go
+++ b/cmd/crowdsec-cli/clihubtest/hubtest.go
@@ -43,13 +43,12 @@ func (cli *cliHubTest) NewCommand() *cobra.Command {
 		DisableAutoGenTag: true,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
-			cfg := cli.cfg()
-			HubTest, err = hubtest.NewHubTest(hubPath, crowdsecPath, cscliPath, false, cfg.ConfigPaths.PatternDir)
+			HubTest, err = hubtest.NewHubTest(hubPath, crowdsecPath, cscliPath, false)
 			if err != nil {
 				return fmt.Errorf("unable to load hubtest: %+v", err)
 			}
 
-			HubAppsecTests, err = hubtest.NewHubTest(hubPath, crowdsecPath, cscliPath, true, cfg.ConfigPaths.PatternDir)
+			HubAppsecTests, err = hubtest.NewHubTest(hubPath, crowdsecPath, cscliPath, true)
 			if err != nil {
 				return fmt.Errorf("unable to load appsec specific hubtest: %+v", err)
 			}

--- a/cmd/crowdsec-cli/clihubtest/hubtest.go
+++ b/cmd/crowdsec-cli/clihubtest/hubtest.go
@@ -43,12 +43,13 @@ func (cli *cliHubTest) NewCommand() *cobra.Command {
 		DisableAutoGenTag: true,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			var err error
-			HubTest, err = hubtest.NewHubTest(hubPath, crowdsecPath, cscliPath, false)
+			cfg := cli.cfg()
+			HubTest, err = hubtest.NewHubTest(hubPath, crowdsecPath, cscliPath, false, cfg.ConfigPaths.PatternDir)
 			if err != nil {
 				return fmt.Errorf("unable to load hubtest: %+v", err)
 			}
 
-			HubAppsecTests, err = hubtest.NewHubTest(hubPath, crowdsecPath, cscliPath, true)
+			HubAppsecTests, err = hubtest.NewHubTest(hubPath, crowdsecPath, cscliPath, true, cfg.ConfigPaths.PatternDir)
 			if err != nil {
 				return fmt.Errorf("unable to load appsec specific hubtest: %+v", err)
 			}

--- a/cmd/crowdsec-cli/clihubtest/run.go
+++ b/cmd/crowdsec-cli/clihubtest/run.go
@@ -42,12 +42,14 @@ func (cli *cliHubTest) run(runAll bool, nucleiTargetHost string, appSecHost stri
 	// set timezone to avoid DST issues
 	os.Setenv("TZ", "UTC")
 
+	patternDir := cfg.ConfigPaths.PatternDir
+
 	for _, test := range hubPtr.Tests {
 		if cfg.Cscli.Output == "human" {
 			log.Infof("Running test '%s'", test.Name)
 		}
 
-		err := test.Run()
+		err := test.Run(patternDir)
 		if err != nil {
 			log.Errorf("running test '%s' failed: %+v", test.Name, err)
 		}

--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -91,7 +91,6 @@ func loadConfigFor(command string) (*csconfig.Config, string, error) {
 		"help",
 		"completion",
 		"version",
-		"hubtest",
 	}
 
 	if !slices.Contains(noNeedConfig, command) {

--- a/pkg/hubtest/hubtest.go
+++ b/pkg/hubtest/hubtest.go
@@ -25,8 +25,9 @@ type HubTest struct {
 	NucleiTargetHost          string
 	AppSecHost                string
 
-	HubIndex *cwhub.Hub
-	Tests    []*HubTestItem
+	HubIndex   *cwhub.Hub
+	Tests      []*HubTestItem
+	PatternDir string
 }
 
 const (
@@ -58,7 +59,7 @@ http:
 `
 )
 
-func NewHubTest(hubPath string, crowdsecPath string, cscliPath string, isAppsecTest bool) (HubTest, error) {
+func NewHubTest(hubPath string, crowdsecPath string, cscliPath string, isAppsecTest bool, patternDir string) (HubTest, error) {
 	hubPath, err := filepath.Abs(hubPath)
 	if err != nil {
 		return HubTest{}, fmt.Errorf("can't get absolute path of hub: %+v", err)
@@ -116,6 +117,7 @@ func NewHubTest(hubPath string, crowdsecPath string, cscliPath string, isAppsecT
 			NucleiTargetHost:          DefaultNucleiTarget,
 			AppSecHost:                DefaultAppsecHost,
 			HubIndex:                  hub,
+			PatternDir:                patternDir,
 		}, nil
 	}
 
@@ -149,6 +151,7 @@ func NewHubTest(hubPath string, crowdsecPath string, cscliPath string, isAppsecT
 		TemplateProfilePath:    filepath.Join(HubTestPath, templateProfileFile),
 		TemplateSimulationPath: filepath.Join(HubTestPath, templateSimulationFile),
 		HubIndex:               hub,
+		PatternDir:             patternDir,
 	}, nil
 }
 

--- a/pkg/hubtest/hubtest.go
+++ b/pkg/hubtest/hubtest.go
@@ -27,7 +27,6 @@ type HubTest struct {
 
 	HubIndex   *cwhub.Hub
 	Tests      []*HubTestItem
-	PatternDir string
 }
 
 const (
@@ -59,7 +58,7 @@ http:
 `
 )
 
-func NewHubTest(hubPath string, crowdsecPath string, cscliPath string, isAppsecTest bool, patternDir string) (HubTest, error) {
+func NewHubTest(hubPath string, crowdsecPath string, cscliPath string, isAppsecTest bool) (HubTest, error) {
 	hubPath, err := filepath.Abs(hubPath)
 	if err != nil {
 		return HubTest{}, fmt.Errorf("can't get absolute path of hub: %+v", err)
@@ -117,7 +116,6 @@ func NewHubTest(hubPath string, crowdsecPath string, cscliPath string, isAppsecT
 			NucleiTargetHost:          DefaultNucleiTarget,
 			AppSecHost:                DefaultAppsecHost,
 			HubIndex:                  hub,
-			PatternDir:                patternDir,
 		}, nil
 	}
 
@@ -151,7 +149,6 @@ func NewHubTest(hubPath string, crowdsecPath string, cscliPath string, isAppsecT
 		TemplateProfilePath:    filepath.Join(HubTestPath, templateProfileFile),
 		TemplateSimulationPath: filepath.Join(HubTestPath, templateSimulationFile),
 		HubIndex:               hub,
-		PatternDir:             patternDir,
 	}, nil
 }
 

--- a/pkg/hubtest/hubtest_item.go
+++ b/pkg/hubtest/hubtest_item.go
@@ -78,6 +78,7 @@ type HubTestItem struct {
 
 	NucleiTargetHost string
 	AppSecHost       string
+	PatternDir       string
 }
 
 const (
@@ -159,6 +160,7 @@ func NewTest(name string, hubTest *HubTest) (*HubTestItem, error) {
 		CustomItemsLocation:       []string{hubTest.HubPath, testPath},
 		NucleiTargetHost:          hubTest.NucleiTargetHost,
 		AppSecHost:                hubTest.AppSecHost,
+		PatternDir:                hubTest.PatternDir,
 	}, nil
 }
 
@@ -417,11 +419,9 @@ func (t *HubTestItem) RunWithLogFile() error {
 		return fmt.Errorf("unable to copy '%s' to '%s': %v", t.TemplateSimulationPath, t.RuntimeSimulationFilePath, err)
 	}
 
-	crowdsecPatternsFolder := csconfig.DefaultConfigPath("patterns")
-
 	// copy template patterns folder to runtime folder
-	if err = CopyDir(crowdsecPatternsFolder, t.RuntimePatternsPath); err != nil {
-		return fmt.Errorf("unable to copy 'patterns' from '%s' to '%s': %w", crowdsecPatternsFolder, t.RuntimePatternsPath, err)
+	if err = CopyDir(t.PatternDir, t.RuntimePatternsPath); err != nil {
+		return fmt.Errorf("unable to copy 'patterns' from '%s' to '%s': %w", t.PatternDir, t.RuntimePatternsPath, err)
 	}
 
 	// install the hub in the runtime folder
@@ -596,11 +596,9 @@ func (t *HubTestItem) Run() error {
 		return fmt.Errorf("unable to copy '%s' to '%s': %v", t.TemplateSimulationPath, t.RuntimeSimulationFilePath, err)
 	}
 
-	crowdsecPatternsFolder := csconfig.DefaultConfigPath("patterns")
-
 	// copy template patterns folder to runtime folder
-	if err = CopyDir(crowdsecPatternsFolder, t.RuntimePatternsPath); err != nil {
-		return fmt.Errorf("unable to copy 'patterns' from '%s' to '%s': %w", crowdsecPatternsFolder, t.RuntimePatternsPath, err)
+	if err = CopyDir(t.PatternDir, t.RuntimePatternsPath); err != nil {
+		return fmt.Errorf("unable to copy 'patterns' from '%s' to '%s': %w", t.PatternDir, t.RuntimePatternsPath, err)
 	}
 
 	// create the appsec-configs dir

--- a/pkg/hubtest/hubtest_item.go
+++ b/pkg/hubtest/hubtest_item.go
@@ -78,7 +78,6 @@ type HubTestItem struct {
 
 	NucleiTargetHost string
 	AppSecHost       string
-	PatternDir       string
 }
 
 const (
@@ -160,7 +159,6 @@ func NewTest(name string, hubTest *HubTest) (*HubTestItem, error) {
 		CustomItemsLocation:       []string{hubTest.HubPath, testPath},
 		NucleiTargetHost:          hubTest.NucleiTargetHost,
 		AppSecHost:                hubTest.AppSecHost,
-		PatternDir:                hubTest.PatternDir,
 	}, nil
 }
 
@@ -384,7 +382,7 @@ func createDirs(dirs []string) error {
 	return nil
 }
 
-func (t *HubTestItem) RunWithLogFile() error {
+func (t *HubTestItem) RunWithLogFile(patternDir string) error {
 	testPath := filepath.Join(t.HubTestPath, t.Name)
 	if _, err := os.Stat(testPath); os.IsNotExist(err) {
 		return fmt.Errorf("test '%s' doesn't exist in '%s', exiting", t.Name, t.HubTestPath)
@@ -420,8 +418,8 @@ func (t *HubTestItem) RunWithLogFile() error {
 	}
 
 	// copy template patterns folder to runtime folder
-	if err = CopyDir(t.PatternDir, t.RuntimePatternsPath); err != nil {
-		return fmt.Errorf("unable to copy 'patterns' from '%s' to '%s': %w", t.PatternDir, t.RuntimePatternsPath, err)
+	if err = CopyDir(patternDir, t.RuntimePatternsPath); err != nil {
+		return fmt.Errorf("unable to copy 'patterns' from '%s' to '%s': %w", patternDir, t.RuntimePatternsPath, err)
 	}
 
 	// install the hub in the runtime folder
@@ -566,7 +564,7 @@ func (t *HubTestItem) RunWithLogFile() error {
 	return nil
 }
 
-func (t *HubTestItem) Run() error {
+func (t *HubTestItem) Run(patternDir string) error {
 	var err error
 
 	t.Success = false
@@ -597,8 +595,8 @@ func (t *HubTestItem) Run() error {
 	}
 
 	// copy template patterns folder to runtime folder
-	if err = CopyDir(t.PatternDir, t.RuntimePatternsPath); err != nil {
-		return fmt.Errorf("unable to copy 'patterns' from '%s' to '%s': %w", t.PatternDir, t.RuntimePatternsPath, err)
+	if err = CopyDir(patternDir, t.RuntimePatternsPath); err != nil {
+		return fmt.Errorf("unable to copy 'patterns' from '%s' to '%s': %w", patternDir, t.RuntimePatternsPath, err)
 	}
 
 	// create the appsec-configs dir
@@ -632,7 +630,7 @@ func (t *HubTestItem) Run() error {
 	}
 
 	if t.Config.LogFile != "" {
-		return t.RunWithLogFile()
+		return t.RunWithLogFile(patternDir)
 	} else if t.Config.NucleiTemplate != "" {
 		return t.RunWithNucleiTemplate()
 	}


### PR DESCRIPTION
Another one for #3183 , this passes through the configuration option for patterndir set via config.yaml

However, I have to unset the "noNeedConfig" option for hubtest, but I see if @mmetc has a better way 🤷🏻 