### PR TITLE
lint: explicit error checks

### DIFF
--- a/cmd/crowdsec-cli/clihub/hub.go
+++ b/cmd/crowdsec-cli/clihub/hub.go
@@ -177,11 +177,15 @@ func (cli *cliHub) upgrade(ctx context.Context, yes bool, dryRun bool, force boo
 
 	for _, itemType := range cwhub.ItemTypes {
 		for _, item := range hub.GetInstalledByType(itemType, true) {
-			plan.AddCommand(hubops.NewDownloadCommand(item, contentProvider, force))
+			if err := plan.AddCommand(hubops.NewDownloadCommand(item, contentProvider, force)); err != nil {
+				return err
+			}
 		}
 	}
 
-	plan.AddCommand(hubops.NewDataRefreshCommand(force))
+	if err := plan.AddCommand(hubops.NewDataRefreshCommand(force)); err != nil {
+		return err
+	}
 
 	verbose := (cfg.Cscli.Output == "raw")
 

--- a/pkg/acquisition/modules/file/file_test.go
+++ b/pkg/acquisition/modules/file/file_test.go
@@ -333,14 +333,19 @@ force_inotify: true`, testPattern),
 			logLevel:      log.DebugLevel,
 			name:          "GlobInotifyChmod",
 			afterConfigure: func() {
-				f, _ := os.Create("test_files/a.log")
-				f.Close()
+				f, err := os.Create("test_files/a.log")
+				require.NoError(t, err)
+				err = f.Close()
+				require.NoError(t, err)
 				time.Sleep(1 * time.Second)
-				os.Chmod("test_files/a.log", 0o000)
+				err = os.Chmod("test_files/a.log", 0o000)
+				require.NoError(t, err)
 			},
 			teardown: func() {
-				os.Chmod("test_files/a.log", 0o644)
-				os.Remove("test_files/a.log")
+				err := os.Chmod("test_files/a.log", 0o644)
+				require.NoError(t, err)
+				err = os.Remove("test_files/a.log")
+				require.NoError(t, err)
 			},
 		},
 		{
@@ -353,7 +358,8 @@ force_inotify: true`, testPattern),
 			logLevel:      log.DebugLevel,
 			name:          "InotifyMkDir",
 			afterConfigure: func() {
-				os.Mkdir("test_files/pouet/", 0o700)
+				err := os.Mkdir("test_files/pouet/", 0o700)
+				require.NoError(t, err)
 			},
 			teardown: func() {
 				os.Remove("test_files/pouet/")

--- a/pkg/acquisition/modules/http/http_test.go
+++ b/pkg/acquisition/modules/http/http_test.go
@@ -256,7 +256,8 @@ basic_auth:
 
 	h.Server.Close()
 	tomb.Kill(nil)
-	tomb.Wait()
+	err = tomb.Wait()
+	require.NoError(t, err)
 }
 
 func TestStreamingAcquisitionUnknownPath(t *testing.T) {
@@ -278,7 +279,8 @@ basic_auth:
 
 	h.Server.Close()
 	tomb.Kill(nil)
-	tomb.Wait()
+	err = tomb.Wait()
+	require.NoError(t, err)
 }
 
 func TestStreamingAcquisitionBasicAuth(t *testing.T) {
@@ -310,7 +312,8 @@ basic_auth:
 
 	h.Server.Close()
 	tomb.Kill(nil)
-	tomb.Wait()
+	err = tomb.Wait()
+	require.NoError(t, err)
 }
 
 func TestStreamingAcquisitionBadHeaders(t *testing.T) {
@@ -337,7 +340,8 @@ headers:
 
 	h.Server.Close()
 	tomb.Kill(nil)
-	tomb.Wait()
+	err = tomb.Wait()
+	require.NoError(t, err)
 }
 
 func TestStreamingAcquisitionMaxBodySize(t *testing.T) {
@@ -365,7 +369,8 @@ max_body_size: 5`), 0)
 
 	h.Server.Close()
 	tomb.Kill(nil)
-	tomb.Wait()
+	err = tomb.Wait()
+	require.NoError(t, err)
 }
 
 func TestStreamingAcquisitionSuccess(t *testing.T) {
@@ -400,7 +405,8 @@ headers:
 
 	h.Server.Close()
 	tomb.Kill(nil)
-	tomb.Wait()
+	err = tomb.Wait()
+	require.NoError(t, err)
 }
 
 func TestStreamingAcquisitionCustomStatusCodeAndCustomHeaders(t *testing.T) {
@@ -439,7 +445,8 @@ custom_headers:
 
 	h.Server.Close()
 	tomb.Kill(nil)
-	tomb.Wait()
+	err = tomb.Wait()
+	require.NoError(t, err)
 }
 
 type slowReader struct {
@@ -525,7 +532,8 @@ timeout: 1s`), 0)
 
 	h.Server.Close()
 	tomb.Kill(nil)
-	tomb.Wait()
+	err = tomb.Wait()
+	require.NoError(t, err)
 }
 
 func TestStreamingAcquisitionTLSHTTPRequest(t *testing.T) {
@@ -549,7 +557,8 @@ tls:
 
 	h.Server.Close()
 	tomb.Kill(nil)
-	tomb.Wait()
+	err = tomb.Wait()
+	require.NoError(t, err)
 }
 
 func TestStreamingAcquisitionTLSWithHeadersAuthSuccess(t *testing.T) {
@@ -604,7 +613,8 @@ tls:
 
 	h.Server.Close()
 	tomb.Kill(nil)
-	tomb.Wait()
+	err = tomb.Wait()
+	require.NoError(t, err)
 }
 
 func TestStreamingAcquisitionMTLS(t *testing.T) {
@@ -661,7 +671,8 @@ tls:
 
 	h.Server.Close()
 	tomb.Kill(nil)
-	tomb.Wait()
+	err = tomb.Wait()
+	require.NoError(t, err)
 }
 
 func TestStreamingAcquisitionGzipData(t *testing.T) {
@@ -713,7 +724,8 @@ headers:
 
 	h.Server.Close()
 	tomb.Kill(nil)
-	tomb.Wait()
+	err = tomb.Wait()
+	require.NoError(t, err)
 }
 
 func TestStreamingAcquisitionNDJson(t *testing.T) {
@@ -751,7 +763,8 @@ headers:
 
 	h.Server.Close()
 	tomb.Kill(nil)
-	tomb.Wait()
+	err = tomb.Wait()
+	require.NoError(t, err)
 }
 
 func assertMetrics(t *testing.T, metrics []prometheus.Collector, expected int) {

--- a/pkg/acquisition/modules/http/http_test.go
+++ b/pkg/acquisition/modules/http/http_test.go
@@ -231,7 +231,8 @@ func SetupAndRunHTTPSource(t *testing.T, h *HTTPSource, config []byte, metricLev
 	require.NoError(t, err)
 
 	for _, metric := range h.GetMetrics() {
-		prometheus.Register(metric)
+		err = prometheus.Register(metric)
+		require.NoError(t, err)
 	}
 
 	return out, &tomb

--- a/pkg/acquisition/modules/journalctl/journalctl_test.go
+++ b/pkg/acquisition/modules/journalctl/journalctl_test.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/tomb.v2"
 
 	"github.com/crowdsecurity/go-cs-lib/cstest"
@@ -268,7 +269,8 @@ journalctl_filter:
 		}
 
 		tomb.Kill(nil)
-		tomb.Wait()
+		err = tomb.Wait()
+		require.NoError(t, err)
 
 		output, _ := exec.Command("pgrep", "-x", "journalctl").CombinedOutput()
 		if len(output) != 0 {

--- a/pkg/acquisition/modules/kafka/kafka_test.go
+++ b/pkg/acquisition/modules/kafka/kafka_test.go
@@ -194,7 +194,8 @@ topic: crowdsecplaintext`), subLogger, configuration.METRICS_NONE)
 			}
 			require.Equal(t, ts.expectedLines, actualLines)
 			tomb.Kill(nil)
-			tomb.Wait()
+			err = tomb.Wait()
+			require.NoError(t, err)
 		})
 	}
 }
@@ -271,7 +272,8 @@ tls:
 			}
 			require.Equal(t, ts.expectedLines, actualLines)
 			tomb.Kill(nil)
-			tomb.Wait()
+			err = tomb.Wait()
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/acquisition/modules/kinesis/kinesis_test.go
+++ b/pkg/acquisition/modules/kinesis/kinesis_test.go
@@ -63,7 +63,8 @@ func GenSubObject(t *testing.T, i int) []byte {
 
 	var b bytes.Buffer
 	gz := gzip.NewWriter(&b)
-	gz.Write(body)
+	_, err = gz.Write(body)
+	require.NoError(t, err)
 	gz.Close()
 	// AWS actually base64 encodes the data, but it looks like kinesis automatically decodes it at some point
 	// localstack does not do it, so let's just write a raw gzipped stream
@@ -198,7 +199,8 @@ stream_name: stream-1-shard`,
 		}
 
 		tomb.Kill(nil)
-		tomb.Wait()
+		err = tomb.Wait()
+		require.NoError(t, err)
 	}
 }
 
@@ -246,7 +248,8 @@ stream_name: stream-2-shards`,
 		}
 		assert.Equal(t, test.count, c)
 		tomb.Kill(nil)
-		tomb.Wait()
+		err = tomb.Wait()
+		require.NoError(t, err)
 	}
 }
 
@@ -290,7 +293,8 @@ from_subscription: true`,
 			assert.Equal(t, fmt.Sprintf("%d", i), e.Line.Raw)
 		}
 		tomb.Kill(nil)
-		tomb.Wait()
+		err = tomb.Wait()
+		require.NoError(t, err)
 	}
 }
 

--- a/pkg/acquisition/modules/kubernetesaudit/k8s_audit_test.go
+++ b/pkg/acquisition/modules/kubernetesaudit/k8s_audit_test.go
@@ -85,7 +85,8 @@ webhook_path: /k8s-audit`,
 			err = f.Configure([]byte(test.config), subLogger, configuration.METRICS_NONE)
 
 			require.NoError(t, err)
-			f.StreamingAcquisition(ctx, out, tb)
+			err = f.StreamingAcquisition(ctx, out, tb)
+			require.NoError(t, err)
 
 			time.Sleep(1 * time.Second)
 			tb.Kill(nil)
@@ -260,7 +261,8 @@ webhook_path: /k8s-audit`,
 			req := httptest.NewRequest(test.method, "/k8s-audit", strings.NewReader(test.body))
 			w := httptest.NewRecorder()
 
-			f.StreamingAcquisition(ctx, out, tb)
+			err = f.StreamingAcquisition(ctx, out, tb)
+			require.NoError(t, err)
 
 			f.webhookHandler(w, req)
 

--- a/pkg/acquisition/modules/syslog/syslog_test.go
+++ b/pkg/acquisition/modules/syslog/syslog_test.go
@@ -10,6 +10,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/tomb.v2"
 
 	"github.com/crowdsecurity/go-cs-lib/cstest"
@@ -168,7 +169,8 @@ listen_addr: 127.0.0.1`,
 			}
 			assert.Equal(t, ts.expectedLines, actualLines)
 			tomb.Kill(nil)
-			tomb.Wait()
+			err = tomb.Wait()
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/apiclient/alerts_service_test.go
+++ b/pkg/apiclient/alerts_service_test.go
@@ -23,7 +23,8 @@ func TestAlertsListAsMachine(t *testing.T) {
 	mux, urlx, teardown := setup()
 	mux.HandleFunc("/watchers/login", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		_, err := w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		assert.NoError(t, err)
 	})
 
 	log.Printf("URL is %s", urlx)
@@ -202,7 +203,8 @@ func TestAlertsGetAsMachine(t *testing.T) {
 	mux, urlx, teardown := setup()
 	mux.HandleFunc("/watchers/login", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		_, err := w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		assert.NoError(t, err)
 	})
 	log.Printf("URL is %s", urlx)
 
@@ -368,13 +370,15 @@ func TestAlertsCreateAsMachine(t *testing.T) {
 	mux, urlx, teardown := setup()
 	mux.HandleFunc("/watchers/login", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		_, err := w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		assert.NoError(t, err)
 	})
 
 	mux.HandleFunc("/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`["3"]`))
+		_, err := w.Write([]byte(`["3"]`))
+		assert.NoError(t, err)
 	})
 
 	log.Printf("URL is %s", urlx)
@@ -408,14 +412,16 @@ func TestAlertsDeleteAsMachine(t *testing.T) {
 	mux, urlx, teardown := setup()
 	mux.HandleFunc("/watchers/login", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		_, err := w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		assert.NoError(t, err)
 	})
 
 	mux.HandleFunc("/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		assert.Equal(t, "ip=1.2.3.4", r.URL.RawQuery)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"message":"0 deleted alerts"}`))
+		_, err := w.Write([]byte(`{"message":"0 deleted alerts"}`))
+		assert.NoError(t, err)
 	})
 
 	log.Printf("URL is %s", urlx)

--- a/pkg/apiclient/auth_key_test.go
+++ b/pkg/apiclient/auth_key_test.go
@@ -24,10 +24,12 @@ func TestApiAuth(t *testing.T) {
 		if r.Header.Get("X-Api-Key") == "ixu" {
 			assert.Equal(t, "ip=1.2.3.4", r.URL.RawQuery)
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`null`))
+			_, err := w.Write([]byte(`null`))
+			assert.NoError(t, err)
 		} else {
 			w.WriteHeader(http.StatusForbidden)
-			w.Write([]byte(`{"message":"access forbidden"}`))
+			_, err := w.Write([]byte(`{"message":"access forbidden"}`))
+			assert.NoError(t, err)
 		}
 	})
 

--- a/pkg/apiclient/client_http_test.go
+++ b/pkg/apiclient/client_http_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/crowdsecurity/go-cs-lib/cstest"
@@ -31,7 +32,8 @@ func TestNewRequestInvalid(t *testing.T) {
 	/*mock login*/
 	mux.HandleFunc("/watchers/login", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte(`{"code": 401, "message" : "bad login/password"}`))
+		_, err := w.Write([]byte(`{"code": 401, "message" : "bad login/password"}`))
+		assert.NoError(t, err)
 	})
 
 	mux.HandleFunc("/alerts", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/apiclient/client_test.go
+++ b/pkg/apiclient/client_test.go
@@ -101,7 +101,8 @@ func TestNewClientOk(t *testing.T) {
 	/*mock login*/
 	mux.HandleFunc("/watchers/login", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		_, err := w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		assert.NoError(t, err)
 	})
 
 	mux.HandleFunc("/alerts", func(w http.ResponseWriter, r *http.Request) {
@@ -138,7 +139,8 @@ func TestNewClientOk_UnixSocket(t *testing.T) {
 	/*mock login*/
 	mux.HandleFunc("/watchers/login", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		_, err := w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		assert.NoError(t, err)
 	})
 
 	mux.HandleFunc("/alerts", func(w http.ResponseWriter, r *http.Request) {
@@ -174,7 +176,8 @@ func TestNewClientKo(t *testing.T) {
 	/*mock login*/
 	mux.HandleFunc("/watchers/login", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte(`{"code": 401, "message" : "bad login/password"}`))
+		_, err := w.Write([]byte(`{"code": 401, "message" : "bad login/password"}`))
+		assert.NoError(t, err)
 	})
 
 	mux.HandleFunc("/alerts", func(w http.ResponseWriter, r *http.Request) {
@@ -200,7 +203,8 @@ func TestNewDefaultClient(t *testing.T) {
 
 	mux.HandleFunc("/alerts", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte(`{"code": 401, "message" : "brr"}`))
+		_, err := w.Write([]byte(`{"code": 401, "message" : "brr"}`))
+		assert.NoError(t, err)
 	})
 
 	_, _, err = client.Alerts.List(context.Background(), AlertsListOpts{})
@@ -228,7 +232,8 @@ func TestNewDefaultClient_UnixSocket(t *testing.T) {
 
 	mux.HandleFunc("/alerts", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte(`{"code": 401, "message" : "brr"}`))
+		_, err := w.Write([]byte(`{"code": 401, "message" : "brr"}`))
+		assert.NoError(t, err)
 	})
 
 	_, _, err = client.Alerts.List(context.Background(), AlertsListOpts{})
@@ -266,7 +271,8 @@ func TestNewClientRegisterOK(t *testing.T) {
 	mux.HandleFunc("/watchers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		_, err := w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		assert.NoError(t, err)
 	})
 
 	apiURL, err := url.Parse(urlx + "/")
@@ -298,7 +304,8 @@ func TestNewClientRegisterOK_UnixSocket(t *testing.T) {
 	mux.HandleFunc("/watchers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		_, err := w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		assert.NoError(t, err)
 	})
 
 	apiURL, err := url.Parse(urlx)
@@ -331,7 +338,8 @@ func TestNewClientBadAnswer(t *testing.T) {
 	mux.HandleFunc("/watchers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte(`bad`))
+		_, err := w.Write([]byte(`bad`))
+		assert.NoError(t, err)
 	})
 
 	apiURL, err := url.Parse(urlx + "/")

--- a/pkg/apiclient/decisions_service_test.go
+++ b/pkg/apiclient/decisions_service_test.go
@@ -31,11 +31,12 @@ func TestDecisionsList(t *testing.T) {
 			assert.Equal(t, "ip=1.2.3.4", r.URL.RawQuery)
 			assert.Equal(t, "ixu", r.Header.Get("X-Api-Key"))
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`[{"duration":"3h59m55.756182786s","id":4,"origin":"cscli","scenario":"manual 'ban' from '82929df7ee394b73b81252fe3b4e50203yaT2u6nXiaN7Ix9'","scope":"Ip","type":"ban","value":"1.2.3.4"}]`))
+			_, err := w.Write([]byte(`[{"duration":"3h59m55.756182786s","id":4,"origin":"cscli","scenario":"manual 'ban' from '82929df7ee394b73b81252fe3b4e50203yaT2u6nXiaN7Ix9'","scope":"Ip","type":"ban","value":"1.2.3.4"}]`))
+			assert.NoError(t, err)
 		} else {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`null`))
-			// no results
+			_, err := w.Write([]byte(`null`))
+			assert.NoError(t, err)
 		}
 	})
 
@@ -90,10 +91,12 @@ func TestDecisionsStream(t *testing.T) {
 		if r.Method == http.MethodGet {
 			if strings.Contains(r.URL.RawQuery, "startup=true") {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"deleted":null,"new":[{"duration":"3h59m55.756182786s","id":4,"origin":"cscli","scenario":"manual 'ban' from '82929df7ee394b73b81252fe3b4e50203yaT2u6nXiaN7Ix9'","scope":"Ip","type":"ban","value":"1.2.3.4"}]}`))
+				_, err := w.Write([]byte(`{"deleted":null,"new":[{"duration":"3h59m55.756182786s","id":4,"origin":"cscli","scenario":"manual 'ban' from '82929df7ee394b73b81252fe3b4e50203yaT2u6nXiaN7Ix9'","scope":"Ip","type":"ban","value":"1.2.3.4"}]}`))
+				assert.NoError(t, err)
 			} else {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"deleted":null,"new":null}`))
+				_, err := w.Write([]byte(`{"deleted":null,"new":null}`))
+				assert.NoError(t, err)
 			}
 		}
 	})
@@ -163,10 +166,12 @@ func TestDecisionsStreamV3Compatibility(t *testing.T) {
 		if r.Method == http.MethodGet {
 			if strings.Contains(r.URL.RawQuery, "startup=true") {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"deleted":[{"scope":"ip","decisions":["1.2.3.5"]}],"new":[{"scope":"ip", "scenario": "manual 'ban' from '82929df7ee394b73b81252fe3b4e50203yaT2u6nXiaN7Ix9'", "decisions":[{"duration":"3h59m55.756182786s","value":"1.2.3.4"}]}]}`))
+				_, err := w.Write([]byte(`{"deleted":[{"scope":"ip","decisions":["1.2.3.5"]}],"new":[{"scope":"ip", "scenario": "manual 'ban' from '82929df7ee394b73b81252fe3b4e50203yaT2u6nXiaN7Ix9'", "decisions":[{"duration":"3h59m55.756182786s","value":"1.2.3.4"}]}]}`))
+				assert.NoError(t, err)
 			} else {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"deleted":null,"new":null}`))
+				_, err := w.Write([]byte(`{"deleted":null,"new":null}`))
+				assert.NoError(t, err)
 			}
 		}
 	})
@@ -227,9 +232,10 @@ func TestDecisionsStreamV3(t *testing.T) {
 
 		if r.Method == http.MethodGet {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"deleted":[{"scope":"ip","decisions":["1.2.3.5"]}],
+			_, err := w.Write([]byte(`{"deleted":[{"scope":"ip","decisions":["1.2.3.5"]}],
 			"new":[{"scope":"ip", "scenario": "manual 'ban' from '82929df7ee394b73b81252fe3b4e50203yaT2u6nXiaN7Ix9'", "decisions":[{"duration":"3h59m55.756182786s","value":"1.2.3.4"}]}],
 			"links": {"blocklists":[{"name":"blocklist1","url":"/v3/blocklist","scope":"ip","remediation":"ban","duration":"24h"}]}}`))
+			assert.NoError(t, err)
 		}
 	})
 
@@ -303,7 +309,8 @@ func TestDecisionsFromBlocklist(t *testing.T) {
 
 		if r.Method == http.MethodGet {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("1.2.3.4\r\n1.2.3.5"))
+			_, err := w.Write([]byte("1.2.3.4\r\n1.2.3.5"))
+			assert.NoError(t, err)
 		}
 	})
 
@@ -388,14 +395,16 @@ func TestDeleteDecisions(t *testing.T) {
 	mux, urlx, teardown := setup()
 	mux.HandleFunc("/watchers/login", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		_, err := w.Write([]byte(`{"code": 200, "expire": "2030-01-02T15:04:05Z", "token": "oklol"}`))
+		assert.NoError(t, err)
 	})
 
 	mux.HandleFunc("/decisions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		assert.Equal(t, "ip=1.2.3.4", r.URL.RawQuery)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"nbDeleted":"1"}`))
+		_, err := w.Write([]byte(`{"nbDeleted":"1"}`))
+		assert.NoError(t, err)
 		// w.Write([]byte(`{"message":"0 deleted alerts"}`))
 	})
 

--- a/pkg/apiserver/alerts_test.go
+++ b/pkg/apiserver/alerts_test.go
@@ -142,7 +142,8 @@ func TestCreateAlertChannels(t *testing.T) {
 	ctx := context.Background()
 	apiServer, config := NewAPIServer(t, ctx)
 	apiServer.controller.PluginChannel = make(chan csplugin.ProfileAlert)
-	apiServer.InitController()
+	err := apiServer.InitController()
+	require.NoError(t, err)
 
 	loginResp := LoginToTestAPI(t, ctx, apiServer.router, config)
 	lapi := LAPI{router: apiServer.router, loginResp: loginResp}

--- a/pkg/csprofiles/csprofiles_test.go
+++ b/pkg/csprofiles/csprofiles_test.go
@@ -119,7 +119,8 @@ func TestEvaluateProfile(t *testing.T) {
 		Alert      *models.Alert
 	}
 
-	exprhelpers.Init(nil)
+	err := exprhelpers.Init(nil)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name                  string

--- a/pkg/cwhub/download_test.go
+++ b/pkg/cwhub/download_test.go
@@ -20,10 +20,12 @@ func TestFetchIndex(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("with_content") == "true" {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`Hi I'm an index with content`))
+			_, err := w.Write([]byte(`Hi I'm an index with content`))
+			assert.NoError(t, err)
 		} else {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`Hi I'm a regular index`))
+			_, err := w.Write([]byte(`Hi I'm a regular index`))
+			assert.NoError(t, err)
 		}
 	}))
 	defer mockServer.Close()

--- a/pkg/fflag/features_test.go
+++ b/pkg/fflag/features_test.go
@@ -377,7 +377,7 @@ func TestGetEnabledFeatures(t *testing.T) {
 	feat1, err := fr.GetFeature("new_standard")
 	require.NoError(t, err)
 	err = feat1.Set(true)
-	require.NoError(t, err)
+	require.Error(t, err, "the flag is deprecated")
 
 	feat2, err := fr.GetFeature("experimental1")
 	require.NoError(t, err)

--- a/pkg/fflag/features_test.go
+++ b/pkg/fflag/features_test.go
@@ -376,11 +376,13 @@ func TestGetEnabledFeatures(t *testing.T) {
 
 	feat1, err := fr.GetFeature("new_standard")
 	require.NoError(t, err)
-	feat1.Set(true)
+	err = feat1.Set(true)
+	require.NoError(t, err)
 
 	feat2, err := fr.GetFeature("experimental1")
 	require.NoError(t, err)
-	feat2.Set(true)
+	err = feat2.Set(true)
+	require.NoError(t, err)
 
 	expected := []string{
 		"experimental1",

--- a/pkg/parser/whitelist_test.go
+++ b/pkg/parser/whitelist_test.go
@@ -284,9 +284,9 @@ func TestWhitelistCheck(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var err error
 			node.Whitelist = tt.whitelist
-			node.CompileWLs()
+			_, err := node.CompileWLs()
+			require.NoError(t, err)
 			isWhitelisted := node.CheckIPsWL(tt.event)
 			if !isWhitelisted {
 				isWhitelisted, err = node.CheckExprWL(map[string]interface{}{"evt": tt.event}, tt.event)

--- a/pkg/setup/install.go
+++ b/pkg/setup/install.go
@@ -71,10 +71,14 @@ func InstallHubItems(ctx context.Context, hub *cwhub.Hub, contentProvider cwhub.
 				return fmt.Errorf("collection %s not found", collection)
 			}
 
-			plan.AddCommand(hubops.NewDownloadCommand(item, contentProvider, forceAction))
+			if err := plan.AddCommand(hubops.NewDownloadCommand(item, contentProvider, forceAction)); err != nil {
+				return err
+			}
 
 			if !downloadOnly {
-				plan.AddCommand(hubops.NewEnableCommand(item, forceAction))
+				if err := plan.AddCommand(hubops.NewEnableCommand(item, forceAction)); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -84,10 +88,14 @@ func InstallHubItems(ctx context.Context, hub *cwhub.Hub, contentProvider cwhub.
 				return fmt.Errorf("parser %s not found", parser)
 			}
 
-			plan.AddCommand(hubops.NewDownloadCommand(item, contentProvider, forceAction))
+			if err := plan.AddCommand(hubops.NewDownloadCommand(item, contentProvider, forceAction)); err != nil {
+				return err
+			}
 
 			if !downloadOnly {
-				plan.AddCommand(hubops.NewEnableCommand(item, forceAction))
+				if err := plan.AddCommand(hubops.NewEnableCommand(item, forceAction)); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -97,10 +105,14 @@ func InstallHubItems(ctx context.Context, hub *cwhub.Hub, contentProvider cwhub.
 				return fmt.Errorf("scenario %s not found", scenario)
 			}
 
-			plan.AddCommand(hubops.NewDownloadCommand(item, contentProvider, forceAction))
+			if err := plan.AddCommand(hubops.NewDownloadCommand(item, contentProvider, forceAction)); err != nil {
+				return err
+			}
 
 			if !downloadOnly {
-				plan.AddCommand(hubops.NewEnableCommand(item, forceAction))
+				if err := plan.AddCommand(hubops.NewEnableCommand(item, forceAction)); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -110,10 +122,14 @@ func InstallHubItems(ctx context.Context, hub *cwhub.Hub, contentProvider cwhub.
 				return fmt.Errorf("postoverflow %s not found", postoverflow)
 			}
 
-			plan.AddCommand(hubops.NewDownloadCommand(item, contentProvider, forceAction))
+			if err := plan.AddCommand(hubops.NewDownloadCommand(item, contentProvider, forceAction)); err != nil {
+				return err
+			}
 
 			if !downloadOnly {
-				plan.AddCommand(hubops.NewEnableCommand(item, forceAction))
+				if err := plan.AddCommand(hubops.NewEnableCommand(item, forceAction)); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
this creates a metrics register for each test to avoid registering them twice, which triggers an error