### PR TITLE
enhance: Log appsec error on writing response to remediation

### DIFF
--- a/pkg/acquisition/modules/appsec/appsec.go
+++ b/pkg/acquisition/modules/appsec/appsec.go
@@ -446,7 +446,7 @@ func (w *AppsecSource) appsecHandler(rw http.ResponseWriter, r *http.Request) {
 		logger.Errorf("unable to serialize response: %s", err)
 		rw.WriteHeader(http.StatusInternalServerError)
 	} else {
-		if err := rw.Write(body); err != nil {
+		if _, err := rw.Write(body); err != nil {
 			logger.Errorf("unable to write response: %s", err)
 		}
 	}

--- a/pkg/acquisition/modules/appsec/appsec.go
+++ b/pkg/acquisition/modules/appsec/appsec.go
@@ -446,6 +446,8 @@ func (w *AppsecSource) appsecHandler(rw http.ResponseWriter, r *http.Request) {
 		logger.Errorf("unable to serialize response: %s", err)
 		rw.WriteHeader(http.StatusInternalServerError)
 	} else {
-		rw.Write(body)
+		if err := rw.Write(body); err != nil {
+			logger.Errorf("unable to write response: %s", err)
+		}
 	}
 }


### PR DESCRIPTION
To aid debugging lua-cs-bouncer issues, we should also log the error if it is generated from trying to write a response to the remediation as the previous log can be seen as it managed to write but we dont know if it did or didnt 🤷🏻 

https://github.com/crowdsecurity/lua-cs-bouncer/issues/77