### PR TITLE
deb packaging: prevent installing crowdsec.service twice

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -3,7 +3,6 @@ config/profiles.yaml    etc/crowdsec/
 config/simulation.yaml  etc/crowdsec/
 
 config/patterns/*       etc/crowdsec/patterns
-config/crowdsec.service lib/systemd/system
 
 # Referenced configs:
 cmd/notification-slack/slack.yaml        etc/crowdsec/notifications/

--- a/debian/preinst
+++ b/debian/preinst
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Source debconf library.
-. /usr/share/debconf/confmodule
-
-echo "You can always run the configuration again interactively by using '/usr/share/crowdsec/wizard.sh -c'"


### PR DESCRIPTION
We don't need to explicitly copy the crowdsec.service file, but the standard location is /usr/lib, not /lib - hence we duplicate it by copying explicitly if /lib is not linked to /usr/lib.

Also we don't need preinst anymore and the message is in postinst as well.