### PR TITLE
Removed updating of machine last_heartbeat based on baseMetrics in MachineUpdateBaseMetrics

### DIFF
--- a/pkg/database/machines.go
+++ b/pkg/database/machines.go
@@ -34,14 +34,6 @@ func (c *Client) MachineUpdateBaseMetrics(ctx context.Context, machineID string,
 	os := baseMetrics.Os
 	features := strings.Join(baseMetrics.FeatureFlags, ",")
 
-	var heartbeat time.Time
-
-	if len(baseMetrics.Metrics) == 0 {
-		heartbeat = time.Now().UTC()
-	} else {
-		heartbeat = time.Unix(*baseMetrics.Metrics[0].Meta.UtcNowTimestamp, 0)
-	}
-
 	hubState := map[string][]schema.ItemState{}
 	for itemType, items := range hubItems {
 		hubState[itemType] = []schema.ItemState{}
@@ -61,7 +53,6 @@ func (c *Client) MachineUpdateBaseMetrics(ctx context.Context, machineID string,
 		SetOsname(*os.Name).
 		SetOsversion(*os.Version).
 		SetFeatureflags(features).
-		SetLastHeartbeat(heartbeat).
 		SetHubstate(hubState).
 		SetDatasources(datasources).
 		Save(ctx)


### PR DESCRIPTION
This fix removes the update of machine last_heartbeat in `MachineUpdateBaseMetrics` for 3 reasons
- The implemented logic doesn't make sense. It updates the fields with the first timestamp of found for that machine in the baseMetrics. When using flush.agents_autodelete, agents can be deleted wrongly because of this logic. (See #3424 
- It shouldn't update the last_heartbeat column at all. Machines will call back to the LAPI and `UpdateMachineLastHeartBeat` is being called to update it.
- `BouncerUpdateBaseMetrics` in the bouncer package doesn't update the similar column last pull neither.