### PR TITLE
cscli: when prompting, use default in case of EOF instead of going for "no"

### DIFF
--- a/pkg/hubops/plan.go
+++ b/pkg/hubops/plan.go
@@ -205,7 +205,7 @@ func (p *ActionPlan) Confirm(verbose bool) (bool, error) {
 		Default: true,
 	}
 
-	// in case of EOF, it's likely been closed by the window manager (freebsd?), ignore it
+	// in case of EOF, it's likely been closed by the package manager (freebsd?), ignore it
 	if err := survey.AskOne(prompt, &answer); err != nil {
 		if errors.Is(err, io.EOF) {
 			return prompt.Default, nil

--- a/pkg/hubops/plan.go
+++ b/pkg/hubops/plan.go
@@ -2,7 +2,9 @@ package hubops
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 	"strings"
@@ -203,7 +205,11 @@ func (p *ActionPlan) Confirm(verbose bool) (bool, error) {
 		Default: true,
 	}
 
+	// in case of EOF, it's likely been closed by the window manager (freebsd?), ignore it
 	if err := survey.AskOne(prompt, &answer); err != nil {
+		if errors.Is(err, io.EOF) {
+			return prompt.Default, nil
+		}
 		return false, err
 	}
 


### PR DESCRIPTION
This is required to hub update/upgrade when installing on, for example, freebsd.