### PR TITLE
file acquisition: remove redundant logging info

### DIFF
--- a/pkg/acquisition/modules/file/file.go
+++ b/pkg/acquisition/modules/file/file.go
@@ -353,7 +353,7 @@ func (f *FileSource) StreamingAcquisition(ctx context.Context, out chan types.Ev
 			continue
 		}
 
-		if err := fd.Close(); err != nil {
+		if err = fd.Close(); err != nil {
 			f.logger.Errorf("unable to close %s : %s", file, err)
 			continue
 		}
@@ -381,6 +381,7 @@ func (f *FileSource) StreamingAcquisition(ctx context.Context, out chan types.Ev
 
 			if networkFS {
 				f.logger.Warnf("Disabling inotify polling on %s as it is on a network share. You can manually set poll_without_inotify to true to make this message disappear, or to false to enforce inotify poll", file)
+
 				pollFile = true
 			}
 		}

--- a/pkg/acquisition/modules/file/file.go
+++ b/pkg/acquisition/modules/file/file.go
@@ -562,12 +562,12 @@ func (f *FileSource) monitorNewFiles(out chan types.Event, t *tomb.Tomb) error {
 
 func (f *FileSource) tailFile(out chan types.Event, t *tomb.Tomb, tail *tail.Tail) error {
 	logger := f.logger.WithField("tail", tail.Filename)
-	logger.Debugf("-> Starting tail of %s", tail.Filename)
+	logger.Debug("-> start tailing")
 
 	for {
 		select {
 		case <-t.Dying():
-			logger.Infof("File datasource %s stopping", tail.Filename)
+			logger.Info("File datasource stopping")
 
 			if err := tail.Stop(); err != nil {
 				f.logger.Errorf("error in stop : %s", err)
@@ -576,7 +576,7 @@ func (f *FileSource) tailFile(out chan types.Event, t *tomb.Tomb, tail *tail.Tai
 
 			return nil
 		case <-tail.Dying(): // our tailer is dying
-			errMsg := fmt.Sprintf("file reader of %s died", tail.Filename)
+			errMsg := "file reader died"
 
 			err := tail.Err()
 			if err != nil {
@@ -588,7 +588,7 @@ func (f *FileSource) tailFile(out chan types.Event, t *tomb.Tomb, tail *tail.Tai
 			return nil
 		case line := <-tail.Lines:
 			if line == nil {
-				logger.Warningf("tail for %s is empty", tail.Filename)
+				logger.Warning("tail is empty")
 				continue
 			}
 
@@ -663,7 +663,7 @@ func (f *FileSource) readFile(filename string, out chan types.Event, t *tomb.Tom
 	for scanner.Scan() {
 		select {
 		case <-t.Dying():
-			logger.Infof("File datasource %s stopping", filename)
+			logger.Info("File datasource stopping")
 			return nil
 		default:
 			if scanner.Text() == "" {

--- a/pkg/acquisition/modules/file/file_test.go
+++ b/pkg/acquisition/modules/file/file_test.go
@@ -219,6 +219,7 @@ filename: test_files/test_delete.log`,
 
 			err := f.Configure([]byte(tc.config), subLogger, configuration.METRICS_NONE)
 			cstest.RequireErrorContains(t, err, tc.expectedConfigErr)
+
 			if tc.expectedConfigErr != "" {
 				return
 			}
@@ -226,18 +227,19 @@ filename: test_files/test_delete.log`,
 			if tc.afterConfigure != nil {
 				tc.afterConfigure()
 			}
+
 			err = f.OneShotAcquisition(ctx, out, &tomb)
-			actualLines := len(out)
 			cstest.RequireErrorContains(t, err, tc.expectedErr)
 
 			if tc.expectedLines != 0 {
-				assert.Equal(t, tc.expectedLines, actualLines)
+				assert.Len(t, out, tc.expectedLines)
 			}
 
 			if tc.expectedOutput != "" {
 				assert.Contains(t, hook.LastEntry().Message, tc.expectedOutput)
 				hook.Reset()
 			}
+
 			if tc.teardown != nil {
 				tc.teardown()
 			}
@@ -391,6 +393,7 @@ force_inotify: true`, testPattern),
 			}
 
 			actualLines := 0
+
 			if tc.expectedLines != 0 {
 				go func() {
 					for {


### PR DESCRIPTION
The filename is already provided as logging field.