### PR TITLE
Fix cp -n

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ENTRYPOINT ["/bin/bash", "/docker_start.sh"]
 
 FROM slim AS full
 
-# Due to the wizard using cp -n, we have to copy the config files directly from the source as -n does not exist in busybox cp
+# Due to the wizard using cp --update=none, we have to copy the config files directly from the source as --update=none does not exist in busybox cp
 # The files are here for reference, as users will need to mount a new version to be actually able to use notifications
 COPY --from=build \
     /go/src/crowdsec/cmd/notification-email/email.yaml \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -65,7 +65,7 @@ ENTRYPOINT ["/bin/bash", "docker_start.sh"]
 
 FROM slim AS plugins
 
-# Due to the wizard using cp -n, we have to copy the config files directly from the source as -n does not exist in busybox cp
+# Due to the wizard using cp --update=none, we have to copy the config files directly from the source as --update=none does not exist in busybox cp
 # The files are here for reference, as users will need to mount a new version to be actually able to use notifications
 COPY --from=build \
     /go/src/crowdsec/cmd/notification-email/email.yaml \

--- a/wizard.sh
+++ b/wizard.sh
@@ -509,12 +509,12 @@ install_plugins(){
     cp ${FILE_PLUGIN_BINARY} ${CROWDSEC_PLUGIN_DIR}
 
     if [[ ${DOCKER_MODE} == "false" ]]; then
-        cp -n ${SLACK_PLUGIN_CONFIG} /etc/crowdsec/notifications/
-        cp -n ${SPLUNK_PLUGIN_CONFIG} /etc/crowdsec/notifications/
-        cp -n ${HTTP_PLUGIN_CONFIG} /etc/crowdsec/notifications/
-        cp -n ${EMAIL_PLUGIN_CONFIG} /etc/crowdsec/notifications/
-        cp -n ${SENTINEL_PLUGIN_CONFIG} /etc/crowdsec/notifications/
-        cp -n ${FILE_PLUGIN_CONFIG} /etc/crowdsec/notifications/
+        cp --update=none ${SLACK_PLUGIN_CONFIG} /etc/crowdsec/notifications/
+        cp --update=none ${SPLUNK_PLUGIN_CONFIG} /etc/crowdsec/notifications/
+        cp --update=none ${HTTP_PLUGIN_CONFIG} /etc/crowdsec/notifications/
+        cp --update=none ${EMAIL_PLUGIN_CONFIG} /etc/crowdsec/notifications/
+        cp --update=none ${SENTINEL_PLUGIN_CONFIG} /etc/crowdsec/notifications/
+        cp --update=none ${FILE_PLUGIN_CONFIG} /etc/crowdsec/notifications/
     fi
 }
 


### PR DESCRIPTION
Running the wizard script for installation gives me the following output a few times:

`cp: warning: behavior of -n is non-portable and may change in future; use --update=none instead`

So I updated the commands and comments regarding that.