### PR TITLE
appsec: handle SendAlert() properly for out of band matches

### DIFF
--- a/pkg/acquisition/modules/appsec/appsec_runner.go
+++ b/pkg/acquisition/modules/appsec/appsec_runner.go
@@ -286,7 +286,6 @@ func (r *AppsecRunner) handleInBandInterrupt(request *appsec.ParsedRequest) {
 				r.outChan <- *appsecOvlfw
 			}
 		}
-
 		// Should the in band match trigger an event ?
 		if r.AppsecRuntime.Response.SendEvent {
 			r.outChan <- evt
@@ -332,7 +331,9 @@ func (r *AppsecRunner) handleOutBandInterrupt(request *appsec.ParsedRequest) {
 				r.logger.Errorf("unable to generate appsec event : %s", err)
 				return
 			}
-			r.outChan <- *appsecOvlfw
+			if appsecOvlfw != nil {
+				r.outChan <- *appsecOvlfw
+			}
 		}
 	}
 }

--- a/pkg/acquisition/modules/appsec/utils.go
+++ b/pkg/acquisition/modules/appsec/utils.go
@@ -60,8 +60,8 @@ func AppsecEventGenerationGeoIPEnrich(src *models.Source) error {
 }
 
 func AppsecEventGeneration(inEvt types.Event, request *http.Request) (*types.Event, error) {
-	// if the request didnd't trigger inband rules, we don't want to generate an event to LAPI/CAPI
-	if !inEvt.Appsec.HasInBandMatches {
+	// if the request didn't trigger inband rules or out-of-band rules, we don't want to generate an event to LAPI/CAPI
+	if !inEvt.Appsec.HasInBandMatches && !inEvt.Appsec.HasOutBandMatches {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Fix #2820 