### PR TITLE
Allowlists: fix range check in LAPI endpoint

### DIFF
--- a/pkg/apiclient/allowlists_service.go
+++ b/pkg/apiclient/allowlists_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	qs "github.com/google/go-querystring/query"
 	log "github.com/sirupsen/logrus"
@@ -74,7 +75,8 @@ func (s *AllowlistsService) Get(ctx context.Context, name string, opts Allowlist
 }
 
 func (s *AllowlistsService) CheckIfAllowlisted(ctx context.Context, value string) (bool, *Response, error) {
-	u := s.client.URLPrefix + "/allowlists/check/" + value
+	escapedValue := url.PathEscape(value)
+	u := s.client.URLPrefix + "/allowlists/check/" + escapedValue
 
 	req, err := s.client.PrepareRequest(ctx, http.MethodHead, u, nil)
 	if err != nil {
@@ -92,7 +94,8 @@ func (s *AllowlistsService) CheckIfAllowlisted(ctx context.Context, value string
 }
 
 func (s *AllowlistsService) CheckIfAllowlistedWithReason(ctx context.Context, value string) (*models.CheckAllowlistResponse, *Response, error) {
-	u := s.client.URLPrefix + "/allowlists/check/" + value
+	escapedValue := url.PathEscape(value)
+	u := s.client.URLPrefix + "/allowlists/check/" + escapedValue
 
 	req, err := s.client.PrepareRequest(ctx, http.MethodGet, u, nil)
 	if err != nil {

--- a/pkg/apiserver/allowlists_test.go
+++ b/pkg/apiserver/allowlists_test.go
@@ -115,13 +115,35 @@ func TestCheckInAllowlist(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, resp.Allowlisted)
 
+	// GET request, should return 200 and status in body
+	w = lapi.RecordResponse(t, ctx, http.MethodGet, "/v1/allowlists/check/2.3.4.0%2F24", emptyBody, passwordAuthType)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	resp = models.CheckAllowlistResponse{}
+
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+
+	require.NoError(t, err)
+	require.False(t, resp.Allowlisted)
+
 	// HEAD request, should return 200
 	w = lapi.RecordResponse(t, ctx, http.MethodHead, "/v1/allowlists/check/1.2.3.4", emptyBody, passwordAuthType)
 
 	require.Equal(t, http.StatusOK, w.Code)
 
+	// HEAD request, should return 200
+	w = lapi.RecordResponse(t, ctx, http.MethodHead, "/v1/allowlists/check/1.2.3.0%2F24", emptyBody, passwordAuthType)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
 	// HEAD request, should return 204
 	w = lapi.RecordResponse(t, ctx, http.MethodHead, "/v1/allowlists/check/2.3.4.5", emptyBody, passwordAuthType)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+
+	// HEAD request, should return 204
+	w = lapi.RecordResponse(t, ctx, http.MethodHead, "/v1/allowlists/check/2.3.4.5%2F24", emptyBody, passwordAuthType)
 
 	require.Equal(t, http.StatusNoContent, w.Code)
 }

--- a/pkg/apiserver/controllers/controller.go
+++ b/pkg/apiserver/controllers/controller.go
@@ -98,6 +98,8 @@ func (c *Controller) NewV1() error {
 	c.Router.GET("/health", gin.WrapF(serveHealth()))
 	c.Router.Use(v1.PrometheusMiddleware())
 	c.Router.HandleMethodNotAllowed = true
+	c.Router.UnescapePathValues = true
+	c.Router.UseRawPath = true
 	c.Router.NoRoute(func(ctx *gin.Context) {
 		ctx.AbortWithStatus(http.StatusNotFound)
 	})

--- a/test/bats/cscli-allowlists.bats
+++ b/test/bats/cscli-allowlists.bats
@@ -135,6 +135,17 @@ teardown() {
     refute_stderr
 }
 
+@test "cscli allolists: range check" {
+    rune -0 cscli allowlist create foo -d 'a foo'
+    rune -0 cscli allowlist add foo 192.168.0.0/16
+    rune -1 cscli decisions add -r 192.168.10.20/24
+    assert_stderr 'Error: 192.168.10.20/24 is allowlisted by item 192.168.0.0/16 from foo, use --bypass-allowlist to add the decision anyway'
+    refute_output
+    rune -0 cscli decisions add -r 192.168.10.20/24 --bypass-allowlist
+    assert_stderr --partial 'Decision successfully added'
+    refute_output
+}
+
 @test "cscli allowlists delete" {
     rune -1 cscli allowlist delete
     assert_stderr 'Error: accepts 1 arg(s), received 0'


### PR DESCRIPTION
Properly escape the value to check for allowlisting when querying the LAPI endpoint.
The bug only impacted `cscli`, LAPI and the appsec do not use this endpoint to check if a value is allowlisted or not.