### PR TITLE
CI: update action for generating docker description

### DIFF
--- a/.github/workflows/update_docker_hub_doc.yml
+++ b/.github/workflows/update_docker_hub_doc.yml
@@ -25,5 +25,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: crowdsecurity/crowdsec
-          short-description: ${{ github.event.repository.description }}
+          short-description: "Crowdsec - An open-source, lightweight agent to detect and respond to bad behaviours."
           readme-filepath: "./docker/README.md"


### PR DESCRIPTION
I suggest we use the same short description for the dockerhub page and github:

(docker)

Crowdsec - An open-source, lightweight agent to detect and respond to bad behaviours.

vs (repo):

CrowdSec - the open-source and participative security solution offering crowdsourced protection against malicious IPs and access to the most advanced real-world CTI.