### PR TITLE
lapi: return specific error if a unix socket path is too long for the OS

### DIFF
--- a/pkg/acquisition/modules/appsec/appsec.go
+++ b/pkg/acquisition/modules/appsec/appsec.go
@@ -27,6 +27,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/appsec"
 	"github.com/crowdsecurity/crowdsec/pkg/appsec/allowlists"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
+	"github.com/crowdsecurity/crowdsec/pkg/csnet"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
@@ -361,7 +362,7 @@ func (w *AppsecSource) listenAndServe(ctx context.Context, t *tomb.Tomb) error {
 
 		listener, err := net.Listen("unix", socket)
 		if err != nil {
-			serverError <- fmt.Errorf("appsec server failed: %w", err)
+			serverError <- csnet.WrapSockErr(err, socket)
 			return
 		}
 

--- a/pkg/apiclient/client_test.go
+++ b/pkg/apiclient/client_test.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/nettest"
 
 	"github.com/crowdsecurity/go-cs-lib/cstest"
 )
@@ -69,8 +70,10 @@ func setupUnixSocketWithPrefix(t *testing.T, socket string, urlPrefix string) (m
 	apiHandler.Handle(baseURLPath+"/", http.StripPrefix(baseURLPath, mux))
 
 	server := httptest.NewUnstartedServer(apiHandler)
-	l, _ := net.Listen("unix", socket)
-	_ = server.Listener.Close()
+	l, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+	err = server.Listener.Close()
+	require.NoError(t, err)
 	server.Listener = l
 	server.Start()
 
@@ -117,8 +120,8 @@ func TestNewClientOk(t *testing.T) {
 
 func TestNewClientOk_UnixSocket(t *testing.T) {
 	ctx := t.Context()
-	tmpDir := t.TempDir()
-	socket := path.Join(tmpDir, "socket")
+	socket, err := nettest.LocalPath()
+	require.NoError(t, err)
 
 	mux, urlx, teardown := setupUnixSocketWithPrefix(t, socket, "v1")
 	defer teardown()
@@ -221,8 +224,8 @@ func TestNewDefaultClient(t *testing.T) {
 func TestNewDefaultClient_UnixSocket(t *testing.T) {
 	ctx := t.Context()
 
-	tmpDir := t.TempDir()
-	socket := path.Join(tmpDir, "socket")
+	socket, err := nettest.LocalPath()
+	require.NoError(t, err)
 
 	mux, urlx, teardown := setupUnixSocketWithPrefix(t, socket, "v1")
 	defer teardown()

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/apiserver/controllers"
 	v1 "github.com/crowdsecurity/crowdsec/pkg/apiserver/middlewares/v1"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
+	"github.com/crowdsecurity/crowdsec/pkg/csnet"
 	"github.com/crowdsecurity/crowdsec/pkg/csplugin"
 	"github.com/crowdsecurity/crowdsec/pkg/database"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
@@ -467,7 +468,7 @@ func (s *APIServer) listenAndServeLAPI(apiReady chan bool) error {
 
 		listener, err := net.Listen("unix", socket)
 		if err != nil {
-			serverError <- fmt.Errorf("while creating unix listener: %w", err)
+			serverError <- csnet.WrapSockErr(err, socket)
 			return
 		}
 

--- a/pkg/csnet/socket.go
+++ b/pkg/csnet/socket.go
@@ -1,0 +1,23 @@
+package csnet
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// WrapSockErr wraps the provided error with a possible cause if the unix socket path exceeds
+// a system-specific maximum length. It returns the original error otherwise.
+func WrapSockErr(err error, socket string) error {
+	limit := 0
+	switch runtime.GOOS {
+	case "linux":
+		// the actual numbers are not exported in Go, so we hardcode them
+		limit = 108
+	case "freebsd", "darwin", "openbsd":
+		limit = 104
+	}
+	if limit > 0 && len(socket) > limit {
+		return fmt.Errorf("%w (path length exceeds system limit: %d > %d)", err, len(socket), limit)
+	}
+	return err
+}

--- a/test/bats/01_crowdsec_lapi.bats
+++ b/test/bats/01_crowdsec_lapi.bats
@@ -42,6 +42,14 @@ teardown() {
     assert_stderr --partial "local API server stopped with error: listening on 127.0.0.1:-80: listen tcp: address -80: invalid port"
 }
 
+@test "lapi (socket path too long)" {
+    LONG_NAME="12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
+    export LONG_NAME
+    rune -0 config_set '.api.server.listen_socket = strenv(BATS_FILE_TMPDIR) + "/" + strenv(LONG_NAME)'
+    rune -1 "$CROWDSEC" -no-cs
+    assert_stderr --partial "local API server stopped with error: listen unix $BATS_FILE_TMPDIR/$LONG_NAME: bind: invalid argument (path length exceeds system limit"
+}
+
 @test "lapi (listen on random port)" {
     config_set '.common.log_media="stdout"'
     rune -0 config_set 'del(.api.server.listen_socket) | .api.server.listen_uri="127.0.0.1:0"'


### PR DESCRIPTION
give the user a hint on what's happening (nothing more we can do) and make sure the tests don't fail for the same reason.