### PR TITLE
enhance: Allow the use of 'd' suffix in profiles

### DIFF
--- a/pkg/csprofiles/csprofiles.go
+++ b/pkg/csprofiles/csprofiles.go
@@ -2,13 +2,13 @@ package csprofiles
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/expr-lang/expr"
 	"github.com/expr-lang/expr/vm"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
+	utils "github.com/crowdsecurity/crowdsec/pkg/database"
 	"github.com/crowdsecurity/crowdsec/pkg/exprhelpers"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/crowdsecurity/crowdsec/pkg/types"
@@ -84,7 +84,7 @@ func NewProfile(profilesCfg []*csconfig.ProfileCfg) ([]*Runtime, error) {
 					duration = defaultDuration
 				}
 
-				if _, err := time.ParseDuration(duration); err != nil {
+				if _, err := utils.ParseDuration(duration); err != nil {
 					return nil, fmt.Errorf("error parsing duration '%s' of %s: %w", duration, profile.Name, err)
 				}
 			}
@@ -136,7 +136,7 @@ func (profile *Runtime) GenerateDecisionFromProfile(alert *models.Alert) ([]*mod
 				profile.Logger.Warningf("Failed to run duration_expr : %v", err)
 			} else {
 				durationStr := fmt.Sprint(duration)
-				if _, err := time.ParseDuration(durationStr); err != nil {
+				if _, err := utils.ParseDuration(durationStr); err != nil {
 					profile.Logger.Warningf("Failed to parse expr duration result '%s'", duration)
 				} else {
 					*decision.Duration = durationStr

--- a/pkg/database/alerts.go
+++ b/pkg/database/alerts.go
@@ -292,7 +292,7 @@ func (c *Client) UpdateCommunityBlocklist(ctx context.Context, alertItem *models
 
 		duration, err := time.ParseDuration(*decisionItem.Duration)
 		if err != nil {
-			return 0,0,0, rollbackOnError(txClient, err, "parsing decision duration")
+			return 0, 0, 0, rollbackOnError(txClient, err, "parsing decision duration")
 		}
 
 		if decisionItem.Scope == nil {
@@ -382,7 +382,7 @@ func (c *Client) createDecisionChunk(ctx context.Context, simulated bool, stopAt
 			sz                                   int
 		)
 
-		duration, err := time.ParseDuration(*decisionItem.Duration)
+		duration, err := ParseDuration(*decisionItem.Duration)
 		if err != nil {
 			return nil, errors.Wrapf(ParseDurationFail, "decision duration '%+v' : %s", *decisionItem.Duration, err)
 		}


### PR DESCRIPTION
fix: #3556 

Allow the use of `d` suffix in profiles within expr and static string