### PR TITLE
cscli inspect: don't show metrics or converted rules if an item is not installed

### DIFF
--- a/cmd/crowdsec-cli/cliitem/cmdinspect.go
+++ b/cmd/crowdsec-cli/cliitem/cmdinspect.go
@@ -56,7 +56,9 @@ func (cli cliItem) inspect(ctx context.Context, args []string, url string, diff 
 			continue
 		}
 
-		if err = inspectItem(hub, item, !noMetrics, cfg.Cscli.Output, cfg.Cscli.PrometheusUrl, cfg.Cscli.Color); err != nil {
+		wantMetrics := !noMetrics && item.State.IsInstalled()
+
+		if err = inspectItem(hub, item, wantMetrics, cfg.Cscli.Output, cfg.Cscli.PrometheusUrl, cfg.Cscli.Color); err != nil {
 			return err
 		}
 

--- a/cmd/crowdsec-cli/cliitem/hubappsec.go
+++ b/cmd/crowdsec-cli/cliitem/hubappsec.go
@@ -85,10 +85,11 @@ cscli appsec-configs upgrade crowdsecurity/virtual-patching -i
 cscli appsec-configs upgrade crowdsecurity/virtual-patching --interactive`,
 		},
 		inspectHelp: cliHelp{
-			example: `# Display metadata, state, metrics and ancestor collections of appsec-configs (installed or not).
+			example: `# Display metadata, state, ancestor collections of appsec-configs (installed or not).
 cscli appsec-configs inspect crowdsecurity/virtual-patching
 
-# Don't collect metrics (avoid error if crowdsec is not running).
+# If the config is installed, its metrics are collected and shown as well (with an error if crowdsec is not running).
+# To avoid this, use --no-metrics.
 cscli appsec-configs inspect crowdsecurity/virtual-patching --no-metrics
 
 # Display difference between a tainted item and the latest one.
@@ -118,6 +119,10 @@ func NewAppsecRule(cfg configGetter) *cliItem {
 		}
 
 		appsecRule := appsec.AppsecCollectionConfig{}
+
+		if item.State.LocalPath == "" {
+			return nil
+		}
 
 		yamlContent, err := os.ReadFile(item.State.LocalPath)
 		if err != nil {
@@ -222,10 +227,11 @@ cscli appsec-rules upgrade crowdsecurity/crs -i
 cscli appsec-rules upgrade crowdsecurity/crs --interactive`,
 		},
 		inspectHelp: cliHelp{
-			example: `# Display metadata, state, metrics and ancestor collections of appsec-rules (installed or not).
+			example: `# Display metadata, state, ancestor collections of appsec-rules (installed or not).
 cscli appsec-rules inspect crowdsecurity/crs
 
-# Don't collect metrics (avoid error if crowdsec is not running).
+# If the rule is installed, its metrics are collected and shown as well (with an error if crowdsec is not running).
+# To avoid this, use --no-metrics.
 cscli appsec-configs inspect crowdsecurity/crs --no-metrics
 
 # Display difference between a tainted item and the latest one.

--- a/cmd/crowdsec-cli/cliitem/hubcollection.go
+++ b/cmd/crowdsec-cli/cliitem/hubcollection.go
@@ -76,10 +76,11 @@ cscli collections upgrade crowdsecurity/http-cve crowdsecurity/iptables -i
 cscli collections upgrade crowdsecurity/http-cve crowdsecurity/iptables --interactive`,
 		},
 		inspectHelp: cliHelp{
-			example: `# Display metadata, state, metrics and dependencies of collections (installed or not).
+			example: `# Display metadata, state, and dependencies of collections (installed or not).
 cscli collections inspect crowdsecurity/http-cve crowdsecurity/iptables
 
-# Don't collect metrics (avoid error if crowdsec is not running).
+# If the collection is installed, its metrics are collected and shown as well (with an error if crowdsec is not running).
+# To avoid this, use --no-metrics.
 cscli collections inspect crowdsecurity/http-cve crowdsecurity/iptables --no-metrics
 
 # Display difference between a tainted item and the latest one, or the reason for the taint if it's a dependency.

--- a/cmd/crowdsec-cli/cliitem/hubparser.go
+++ b/cmd/crowdsec-cli/cliitem/hubparser.go
@@ -76,10 +76,11 @@ cscli parsers upgrade crowdsecurity/caddy-logs crowdsecurity/sshd-logs -i
 cscli parsers upgrade crowdsecurity/caddy-logs crowdsecurity/sshd-logs --interactive`,
 		},
 		inspectHelp: cliHelp{
-			example: `# Display metadata, state, metrics and ancestor collections of parsers (installed or not).
+			example: `# Display metadata, state and ancestor collections of parsers (installed or not).
 cscli parsers inspect crowdsecurity/httpd-logs crowdsecurity/sshd-logs
 
-# Don't collect metrics (avoid error if crowdsec is not running).
+# If the parser is installed, its metrics are collected and shown as well (with an error if crowdsec is not running).
+# To avoid this, use --no-metrics.
 cscli parsers inspect crowdsecurity/httpd-logs --no-metrics
 
 # Display difference between a tainted item and the latest one.

--- a/cmd/crowdsec-cli/cliitem/hubscenario.go
+++ b/cmd/crowdsec-cli/cliitem/hubscenario.go
@@ -76,10 +76,11 @@ cscli scenarios upgrade crowdsecurity/ssh-bf crowdsecurity/http-probing -i
 cscli scenarios upgrade crowdsecurity/ssh-bf crowdsecurity/http-probing --interactive`,
 		},
 		inspectHelp: cliHelp{
-			example: `# Display metadata, state, metrics and ancestor collections of scenarios (installed or not).
+			example: `# Display metadata, state and ancestor collections of scenarios (installed or not).
 cscli scenarios inspect crowdsecurity/ssh-bf crowdsecurity/http-probing
 
-# Don't collect metrics (avoid error if crowdsec is not running).
+# If the scenario is installed, its metrics are collected and shown as well (with an error if crowdsec is not running).
+# To avoid this, use --no-metrics.
 cscli scenarios inspect crowdsecurity/ssh-bf --no-metrics
 
 # Display difference between a tainted item and the latest one.


### PR DESCRIPTION
Fix https://github.com/crowdsecurity/crowdsec/issues/3569 and https://github.com/crowdsecurity/crowdsec/issues/3568