### PR TITLE
fix(apiserver): ensure nil is returned after setting token and expiration and before we reauthenticate

### DIFF
--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -315,6 +315,8 @@ func (a *apic) Authenticate(ctx context.Context, config *csconfig.OnlineApiClien
 
 		a.apiClient.GetClient().Transport.(*apiclient.JWTTransport).Token = token
 		a.apiClient.GetClient().Transport.(*apiclient.JWTTransport).Expiration = exp
+
+		return nil
 	}
 
 	log.Debug("No token found, authenticating")


### PR DESCRIPTION
ensure nil is returned after setting token and expiration and before we reauthenticate