### PR TITLE
refact apiclient.Config: remove field Scenarios

### DIFF
--- a/cmd/crowdsec-cli/clicapi/capi.go
+++ b/cmd/crowdsec-cli/clicapi/capi.go
@@ -173,7 +173,6 @@ func queryCAPIStatus(ctx context.Context, db *database.Client, hub *cwhub.Hub, c
 	client, err := apiclient.NewClient(&apiclient.Config{
 		MachineID: login,
 		Password:  passwd,
-		Scenarios: itemsForAPI,
 		URL:       apiURL,
 		// I don't believe papi is neede to check enrollement
 		// PapiURL:       papiURL,

--- a/cmd/crowdsec-cli/cliconsole/console.go
+++ b/cmd/crowdsec-cli/cliconsole/console.go
@@ -85,9 +85,11 @@ func (cli *cliConsole) enroll(ctx context.Context, key string, name string, over
 	c, _ := apiclient.NewClient(&apiclient.Config{
 		MachineID:     cli.cfg().API.Server.OnlineClient.Credentials.Login,
 		Password:      password,
-		Scenarios:     hub.GetInstalledListForAPI(),
 		URL:           apiURL,
 		VersionPrefix: "v3",
+		UpdateScenario: func(_ context.Context) ([]string, error) {
+			return hub.GetInstalledListForAPI(), nil
+		},
 	})
 
 	resp, err := c.Auth.EnrollWatcher(ctx, key, name, tags, overwrite)

--- a/cmd/crowdsec-cli/cliconsole/console.go
+++ b/cmd/crowdsec-cli/cliconsole/console.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/fatih/color"
@@ -159,12 +159,14 @@ func optionFilterDisable(opts []string, disableOpts []string) ([]string, error) 
 		// discard all elements == opt
 
 		j := 0
+
 		for _, o := range opts {
 			if o != opt {
 				opts[j] = o
 				j++
 			}
 		}
+
 		opts = opts[:j]
 	}
 
@@ -325,7 +327,7 @@ func (cli *cliConsole) newStatusCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("failed to serialize configuration: %w", err)
 				}
-				fmt.Println(string(data))
+				fmt.Fprintln(os.Stdout, string(data))
 			case "raw":
 				csvwriter := csv.NewWriter(os.Stdout)
 				err := csvwriter.Write([]string{"option", "enabled"})

--- a/pkg/apiclient/auth_service_test.go
+++ b/pkg/apiclient/auth_service_test.go
@@ -73,6 +73,7 @@ func initBasicMuxMock(t *testing.T, mux *http.ServeMux, path string) {
  */
 func TestWatcherRegister(t *testing.T) {
 	ctx := t.Context()
+
 	log.SetLevel(log.DebugLevel)
 
 	mux, urlx, teardown := setup()
@@ -111,6 +112,7 @@ func TestWatcherRegister(t *testing.T) {
 
 func TestWatcherAuth(t *testing.T) {
 	ctx := t.Context()
+
 	log.SetLevel(log.DebugLevel)
 
 	mux, urlx, teardown := setup()
@@ -129,10 +131,10 @@ func TestWatcherAuth(t *testing.T) {
 
 	// ok auth
 	clientConfig := &Config{
-		MachineID:     "test_login",
-		Password:      "test_password",
-		URL:           apiURL,
-		VersionPrefix: "v1",
+		MachineID:      "test_login",
+		Password:       "test_password",
+		URL:            apiURL,
+		VersionPrefix:  "v1",
 		UpdateScenario: updateScenario,
 	}
 
@@ -179,6 +181,7 @@ func TestWatcherAuth(t *testing.T) {
 
 func TestWatcherUnregister(t *testing.T) {
 	ctx := t.Context()
+
 	log.SetLevel(log.DebugLevel)
 
 	mux, urlx, teardown := setup()
@@ -218,10 +221,10 @@ func TestWatcherUnregister(t *testing.T) {
 	}
 
 	mycfg := &Config{
-		MachineID:     "test_login",
-		Password:      "test_password",
-		URL:           apiURL,
-		VersionPrefix: "v1",
+		MachineID:      "test_login",
+		Password:       "test_password",
+		URL:            apiURL,
+		VersionPrefix:  "v1",
 		UpdateScenario: updateScenario,
 	}
 
@@ -236,6 +239,7 @@ func TestWatcherUnregister(t *testing.T) {
 
 func TestWatcherEnroll(t *testing.T) {
 	ctx := t.Context()
+
 	log.SetLevel(log.DebugLevel)
 
 	mux, urlx, teardown := setup()
@@ -277,10 +281,10 @@ func TestWatcherEnroll(t *testing.T) {
 	}
 
 	mycfg := &Config{
-		MachineID:     "test_login",
-		Password:      "test_password",
-		URL:           apiURL,
-		VersionPrefix: "v1",
+		MachineID:      "test_login",
+		Password:       "test_password",
+		URL:            apiURL,
+		VersionPrefix:  "v1",
 		UpdateScenario: updateScenario,
 	}
 

--- a/pkg/apiclient/auth_service_test.go
+++ b/pkg/apiclient/auth_service_test.go
@@ -2,6 +2,7 @@ package apiclient
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -122,22 +123,29 @@ func TestWatcherAuth(t *testing.T) {
 	apiURL, err := url.Parse(urlx + "/")
 	require.NoError(t, err)
 
+	updateScenario := func(_ context.Context) ([]string, error) {
+		return []string{"crowdsecurity/test"}, nil
+	}
+
 	// ok auth
 	clientConfig := &Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
 		URL:           apiURL,
 		VersionPrefix: "v1",
-		Scenarios:     []string{"crowdsecurity/test"},
+		UpdateScenario: updateScenario,
 	}
 
 	client, err := NewClient(clientConfig)
 	require.NoError(t, err)
 
+	scenarios, err := clientConfig.UpdateScenario(ctx)
+	require.NoError(t, err)
+
 	_, _, err = client.Auth.AuthenticateWatcher(ctx, models.WatcherAuthRequest{
 		MachineID: &clientConfig.MachineID,
 		Password:  &clientConfig.Password,
-		Scenarios: clientConfig.Scenarios,
+		Scenarios: scenarios,
 	})
 	require.NoError(t, err)
 
@@ -205,12 +213,16 @@ func TestWatcherUnregister(t *testing.T) {
 	apiURL, err := url.Parse(urlx + "/")
 	require.NoError(t, err)
 
+	updateScenario := func(_ context.Context) ([]string, error) {
+		return []string{"crowdsecurity/test"}, nil
+	}
+
 	mycfg := &Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
 		URL:           apiURL,
 		VersionPrefix: "v1",
-		Scenarios:     []string{"crowdsecurity/test"},
+		UpdateScenario: updateScenario,
 	}
 
 	client, err := NewClient(mycfg)
@@ -260,12 +272,16 @@ func TestWatcherEnroll(t *testing.T) {
 	apiURL, err := url.Parse(urlx + "/")
 	require.NoError(t, err)
 
+	updateScenario := func(_ context.Context) ([]string, error) {
+		return []string{"crowdsecurity/test"}, nil
+	}
+
 	mycfg := &Config{
 		MachineID:     "test_login",
 		Password:      "test_password",
 		URL:           apiURL,
 		VersionPrefix: "v1",
-		Scenarios:     []string{"crowdsecurity/test"},
+		UpdateScenario: updateScenario,
 	}
 
 	client, err := NewClient(mycfg)

--- a/pkg/apiclient/client.go
+++ b/pkg/apiclient/client.go
@@ -87,7 +87,6 @@ func InitLAPIClient(ctx context.Context, apiUrl string, papiUrl string, login st
 	client, err := NewClient(&Config{
 		MachineID:     login,
 		Password:      pwd,
-		Scenarios:     scenarios,
 		URL:           apiURL,
 		PapiURL:       papiURL,
 		VersionPrefix: "v1",
@@ -138,7 +137,6 @@ func NewClient(config *Config) (*ApiClient, error) {
 	t := &JWTTransport{
 		MachineID:      &config.MachineID,
 		Password:       &config.Password,
-		Scenarios:      config.Scenarios,
 		UserAgent:      userAgent,
 		VersionPrefix:  config.VersionPrefix,
 		UpdateScenario: config.UpdateScenario,

--- a/pkg/apiclient/config.go
+++ b/pkg/apiclient/config.go
@@ -10,7 +10,6 @@ import (
 type Config struct {
 	MachineID         string
 	Password          strfmt.Password
-	Scenarios         []string
 	URL               *url.URL
 	PapiURL           *url.URL
 	VersionPrefix     string

--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -67,7 +67,6 @@ type apic struct {
 	metricsTomb   tomb.Tomb
 	startup       bool
 	credentials   *csconfig.ApiCredentialsCfg
-	scenarioList  []string
 	consoleConfig *csconfig.ConsoleConfig
 	isPulling     chan bool
 	whitelists    *csconfig.CapiWhitelist
@@ -196,7 +195,6 @@ func NewAPIC(ctx context.Context, config *csconfig.OnlineApiClientCfg, dbClient 
 		pullTomb:                  tomb.Tomb{},
 		pushTomb:                  tomb.Tomb{},
 		metricsTomb:               tomb.Tomb{},
-		scenarioList:              make([]string, 0),
 		consoleConfig:             consoleConfig,
 		pullInterval:              pullIntervalDefault,
 		pullIntervalFirst:         randomDuration(pullIntervalDefault, pullIntervalDelta),
@@ -223,18 +221,12 @@ func NewAPIC(ctx context.Context, config *csconfig.OnlineApiClientCfg, dbClient 
 		return nil, fmt.Errorf("while parsing '%s': %w", config.Credentials.PapiURL, err)
 	}
 
-	ret.scenarioList, err = ret.FetchScenariosListFromDB(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("while fetching scenarios from db: %w", err)
-	}
-
 	ret.apiClient, err = apiclient.NewClient(&apiclient.Config{
 		MachineID:      config.Credentials.Login,
 		Password:       strfmt.Password(config.Credentials.Password),
 		URL:            apiURL,
 		PapiURL:        papiURL,
 		VersionPrefix:  "v3",
-		Scenarios:      ret.scenarioList,
 		UpdateScenario: ret.FetchScenariosListFromDB,
 	})
 	if err != nil {

--- a/pkg/apiserver/apic_test.go
+++ b/pkg/apiserver/apic_test.go
@@ -63,7 +63,6 @@ func getAPIC(t *testing.T, ctx context.Context) *apic {
 		pullTomb:     tomb.Tomb{},
 		pushTomb:     tomb.Tomb{},
 		metricsTomb:  tomb.Tomb{},
-		scenarioList: make([]string, 0),
 		consoleConfig: &csconfig.ConsoleConfig{
 			ShareManualDecisions:  ptr.Of(false),
 			ShareTaintedScenarios: ptr.Of(false),


### PR DESCRIPTION
The callback UpdateScenario could use a better name, it now includes both scenarios and appsec-rules. SomethingProvider?