### PR TITLE
Add dynamic log entry types for VictoriaLogs resolves #3624

### DIFF
--- a/pkg/acquisition/modules/victorialogs/internal/vlclient/types.go
+++ b/pkg/acquisition/modules/victorialogs/internal/vlclient/types.go
@@ -7,6 +7,8 @@ import (
 // Log represents a VictoriaLogs log line
 // See: https://docs.victoriametrics.com/victorialogs/querying/#querying-logs
 type Log struct {
-	Message string    `json:"_msg"`
-	Time    time.Time `json:"_time"`
+	Message string
+	Time    time.Time
+	// Used to store the value to set the type label
+	Program string
 }

--- a/pkg/acquisition/modules/victorialogs/victorialogs.go
+++ b/pkg/acquisition/modules/victorialogs/victorialogs.go
@@ -45,6 +45,7 @@ type VLConfiguration struct {
 	WaitForReady                      time.Duration       `yaml:"wait_for_ready"` // Retry interval, default is 10 seconds
 	Auth                              VLAuthConfiguration `yaml:"auth"`
 	MaxFailureDuration                time.Duration       `yaml:"max_failure_duration"` // Max duration of failure before stopping the source
+	ProgramKey                        string              `yaml:"program_key"` // VictorlaLogs JSON key to set label type
 	configuration.DataSourceCommonCfg `yaml:",inline"`
 }
 
@@ -126,6 +127,7 @@ func (l *VLSource) Configure(config []byte, logger *log.Entry, metricsLevel int)
 		Username:        l.Config.Auth.Username,
 		Password:        l.Config.Auth.Password,
 		FailMaxDuration: l.Config.MaxFailureDuration,
+		ProgramKey:      l.Config.ProgramKey,
 	}
 
 	l.Client = vlclient.NewVLClient(clientConfig)
@@ -274,6 +276,16 @@ func (l *VLSource) readOneEntry(entry *vlclient.Log, labels map[string]string, o
 	ll.Labels = labels
 	ll.Process = true
 	ll.Module = l.GetName()
+
+	if entry.Program != "" {
+		// make a copy of the provided map
+		// this prevents concurrent read/write access to the map
+		ll.Labels = make(map[string]string)
+		for k, v := range labels {
+			ll.Labels[k] = v
+		}
+		ll.Labels["type"] = entry.Program
+	}
 
 	if l.metricsLevel != configuration.METRICS_NONE {
 		linesRead.With(prometheus.Labels{"source": l.Config.URL}).Inc()


### PR DESCRIPTION
Adds a key for the VictoriaLogs configuration named program_key. If that key is set and the JSON blob for an entry returned by the VictoriaLogs query contains that key with a string value, the Labels.type value is set to the string value. This allows the log entry type to be set dynmically.