### PR TITLE
Allow `cscli capi register` to run without an existing online api credentials file

### DIFF
--- a/cmd/crowdsec-cli/clicapi/capi.go
+++ b/cmd/crowdsec-cli/clicapi/capi.go
@@ -44,12 +44,12 @@ func (cli *cliCapi) NewCommand() *cobra.Command {
 		Short:             "Manage interaction with Central API (CAPI)",
 		DisableAutoGenTag: true,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			cfg := cli.cfg()
-			if err := require.LAPI(cfg); err != nil {
-				return err
-			}
-			// Only require CAPI for subcommands other than 'register'
+			// Only require LAPI/CAPI for subcommands other than 'register'
 			if cmd.Name() != "register" {
+				cfg := cli.cfg()
+				if err := require.LAPI(cfg); err != nil {
+					return err
+				}
 				return require.CAPI(cfg)
 			}
 			return nil

--- a/cmd/crowdsec-cli/clicapi/capi.go
+++ b/cmd/crowdsec-cli/clicapi/capi.go
@@ -43,13 +43,16 @@ func (cli *cliCapi) NewCommand() *cobra.Command {
 		Use:               "capi [action]",
 		Short:             "Manage interaction with Central API (CAPI)",
 		DisableAutoGenTag: true,
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			cfg := cli.cfg()
 			if err := require.LAPI(cfg); err != nil {
 				return err
 			}
-
-			return require.CAPI(cfg)
+			// Only require CAPI for subcommands other than 'register'
+			if cmd.Name() != "register" {
+				return require.CAPI(cfg)
+			}
+			return nil
 		},
 	}
 


### PR DESCRIPTION
### Description

The fix ensures that the CAPI check is only required for subcommands other than `register`, allowing the command to execute correctly and create the credentials file automatically.

### Issue Fixed

Fixes #3632

### Changes Made

* Updated the CLI behavior so the requirement for CAPI is only enforced for subcommands other than `register`.
* Refactored the `cliCapi` function to move the Local API (LAPI) and Central API (CAPI) requirement check inside the condition specific to subcommands.

### Testing

* Successfully tested in a clean Docker environment, verifying the credentials file is automatically created.
* Confirmed no regressions or permission-related issues.

### Additional Notes

This modification supports seamless automated deployments, particularly beneficial for Docker-based setups.
