### PR TITLE
appsec: do not query LAPI multiple times when checking auth

### DIFF
--- a/pkg/acquisition/modules/appsec/appsec.go
+++ b/pkg/acquisition/modules/appsec/appsec.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/crowdsecurity/crowdsec/pkg/acquisition/configuration"
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
+	"github.com/crowdsecurity/crowdsec/pkg/apiclient/useragent"
 	"github.com/crowdsecurity/crowdsec/pkg/appsec"
 	"github.com/crowdsecurity/crowdsec/pkg/appsec/allowlists"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
@@ -462,6 +463,7 @@ func (w *AppsecSource) IsAuth(ctx context.Context, apiKey string) bool {
 	}
 
 	req.Header.Add("X-Api-Key", apiKey)
+	req.Header.Add("User-Agent", useragent.AppsecUserAgent())
 
 	client := &http.Client{
 		Timeout: 200 * time.Millisecond,

--- a/pkg/apiclient/useragent/useragent.go
+++ b/pkg/apiclient/useragent/useragent.go
@@ -7,3 +7,7 @@ import (
 func Default() string {
 	return "crowdsec/" + version.String() + "-" + version.System
 }
+
+func AppsecUserAgent() string {
+	return "appsec/" + version.String() + "-" + version.System
+}

--- a/pkg/apiserver/middlewares/v1/api_key.go
+++ b/pkg/apiserver/middlewares/v1/api_key.go
@@ -29,7 +29,6 @@ type APIKey struct {
 	TlsAuth    *TLSAuth
 }
 
-//
 func GenerateAPIKey(n int) (string, error) {
 	bytes := make([]byte, n)
 	if _, err := rand.Read(bytes); err != nil {
@@ -127,6 +126,10 @@ func (a *APIKey) authPlain(c *gin.Context, logger *log.Entry) *ent.Bouncer {
 		bouncer, err := a.DbClient.SelectBouncers(ctx, hashStr, types.ApiKeyAuthType)
 		if err != nil {
 			logger.Errorf("while fetching bouncer info: %s", err)
+			return nil
+		}
+		if len(bouncer) == 0 {
+			logger.Debugf("no bouncer found with this key")
 			return nil
 		}
 		return bouncer[0]


### PR DESCRIPTION
Also set a proper UA when querying LAPI (fixes #3489)