### PR TITLE
cscli: don't assume master hub branch if version check fails (after retrying)

### DIFF
--- a/cmd/crowdsec-cli/clihub/hub.go
+++ b/cmd/crowdsec-cli/clihub/hub.go
@@ -100,7 +100,7 @@ func (cli *cliHub) newBranchCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Println(branch)
+			fmt.Fprintln(os.Stdout, branch)
 			return nil
 		},
 	}
@@ -154,7 +154,7 @@ func (cli *cliHub) update(ctx context.Context, withContent bool) error {
 	}
 
 	if !updated && (log.StandardLogger().Level >= log.InfoLevel) {
-		fmt.Println("Nothing to do, the hub index is up to date.")
+		fmt.Fprintln(os.Stdout, "Nothing to do, the hub index is up to date.")
 	}
 
 	if err := hub.Load(); err != nil {
@@ -233,7 +233,7 @@ func (cli *cliHub) upgrade(ctx context.Context, interactive bool, dryRun bool, f
 	}
 
 	if msg := reload.UserMessage(); msg != "" && plan.ReloadNeeded {
-		fmt.Println("\n" + msg)
+		fmt.Fprintln(os.Stdout, "\n"+msg)
 	}
 
 	return nil
@@ -285,17 +285,17 @@ func (cli *cliHub) types() error {
 			return err
 		}
 
-		fmt.Print(string(s))
+		fmt.Fprint(os.Stdout, string(s))
 	case "json":
 		jsonStr, err := json.Marshal(cwhub.ItemTypes)
 		if err != nil {
 			return err
 		}
 
-		fmt.Println(string(jsonStr))
+		fmt.Fprintln(os.Stdout, string(jsonStr))
 	case "raw":
 		for _, itemType := range cwhub.ItemTypes {
-			fmt.Println(itemType)
+			fmt.Fprintln(os.Stdout, itemType)
 		}
 	}
 

--- a/cmd/crowdsec-cli/clihub/hub.go
+++ b/cmd/crowdsec-cli/clihub/hub.go
@@ -95,7 +95,11 @@ func (cli *cliHub) newBranchCmd() *cobra.Command {
 		Args:              args.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			branch := require.HubBranch(cmd.Context(), cli.cfg())
+			branch, err := require.HubBranch(cmd.Context(), cli.cfg())
+			if err != nil {
+				return err
+			}
+
 			fmt.Println(branch)
 			return nil
 		},
@@ -139,7 +143,10 @@ func (cli *cliHub) update(ctx context.Context, withContent bool) error {
 		return err
 	}
 
-	indexProvider := require.HubDownloader(ctx, cli.cfg())
+	indexProvider, err := require.HubDownloader(ctx, cli.cfg())
+	if err != nil {
+		return err
+	}
 
 	updated, err := hub.Update(ctx, indexProvider, withContent)
 	if err != nil {
@@ -201,7 +208,10 @@ func (cli *cliHub) upgrade(ctx context.Context, interactive bool, dryRun bool, f
 
 	plan := hubops.NewActionPlan(hub)
 
-	contentProvider := require.HubDownloader(ctx, cfg)
+	contentProvider, err := require.HubDownloader(ctx, cfg)
+	if err != nil {
+		return err
+	}
 
 	for _, itemType := range cwhub.ItemTypes {
 		for _, item := range hub.GetInstalledByType(itemType, true) {

--- a/cmd/crowdsec-cli/cliitem/cmdinspect.go
+++ b/cmd/crowdsec-cli/cliitem/cmdinspect.go
@@ -33,10 +33,16 @@ func (cli *cliItem) inspect(ctx context.Context, args []string, url string, diff
 		cfg.Cscli.PrometheusUrl = url
 	}
 
-	var contentProvider cwhub.ContentProvider
+	var (
+		contentProvider cwhub.ContentProvider
+		err             error
+	)
 
 	if diff {
-		contentProvider = require.HubDownloader(ctx, cfg)
+		contentProvider, err = require.HubDownloader(ctx, cfg)
+		if err != nil {
+			return err
+		}
 	}
 
 	hub, err := require.Hub(cfg, log.StandardLogger())

--- a/cmd/crowdsec-cli/cliitem/cmdinspect.go
+++ b/cmd/crowdsec-cli/cliitem/cmdinspect.go
@@ -232,7 +232,7 @@ func inspectItem(hub *cwhub.Hub, item *cwhub.Item, wantMetrics bool, output stri
 	}
 
 	if wantMetrics {
-		fmt.Fprintf(os.Stdout, "\nCurrent metrics: \n")
+		fmt.Fprint(os.Stdout, "\nCurrent metrics: \n")
 
 		if err := showMetrics(prometheusURL, hub, item, wantColor); err != nil {
 			return err

--- a/cmd/crowdsec-cli/cliitem/cmdinstall.go
+++ b/cmd/crowdsec-cli/cliitem/cmdinstall.go
@@ -54,7 +54,10 @@ func (cli *cliItem) install(ctx context.Context, args []string, interactive bool
 
 	plan := hubops.NewActionPlan(hub)
 
-	contentProvider := require.HubDownloader(ctx, cfg)
+	contentProvider, err := require.HubDownloader(ctx, cfg)
+	if err != nil {
+		return err
+	}
 
 	for _, name := range args {
 		item := hub.GetItem(cli.name, name)

--- a/cmd/crowdsec-cli/cliitem/cmdupgrade.go
+++ b/cmd/crowdsec-cli/cliitem/cmdupgrade.go
@@ -54,7 +54,10 @@ func (cli *cliItem) upgrade(ctx context.Context, args []string, interactive bool
 		return err
 	}
 
-	contentProvider := require.HubDownloader(ctx, cfg)
+	contentProvider, err := require.HubDownloader(ctx, cfg)
+	if err != nil {
+		return err
+	}
 
 	plan, err := cli.upgradePlan(hub, contentProvider, args, force, all)
 	if err != nil {

--- a/cmd/crowdsec-cli/clisetup/setup.go
+++ b/cmd/crowdsec-cli/clisetup/setup.go
@@ -295,7 +295,10 @@ func (cli *cliSetup) install(ctx context.Context, interactive bool, dryRun bool,
 		return err
 	}
 
-	contentProvider := require.HubDownloader(ctx, cfg)
+	contentProvider, err := require.HubDownloader(ctx, cfg)
+	if err != nil {
+		return err
+	}
 
 	showPlan := (log.StandardLogger().Level >= log.InfoLevel)
 	verbosePlan := (cfg.Cscli.Output == "raw")

--- a/cmd/crowdsec-cli/require/branch.go
+++ b/cmd/crowdsec-cli/require/branch.go
@@ -51,7 +51,7 @@ func lookupLatest(ctx context.Context) (string, error) {
 
 	resp, err := backoff.Retry(ctx, operation,
 		backoff.WithBackOff(bo),
-		backoff.WithMaxElapsedTime(5 * time.Second),
+		backoff.WithMaxElapsedTime(5*time.Second),
 	)
 	if err != nil {
 		return "", err

--- a/cmd/crowdsec-cli/require/branch.go
+++ b/cmd/crowdsec-cli/require/branch.go
@@ -9,34 +9,53 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/cenkalti/backoff/v5"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/mod/semver"
 
 	"github.com/crowdsecurity/go-cs-lib/version"
 
+	"github.com/crowdsecurity/crowdsec/pkg/apiclient/useragent"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion"
 )
 
 // lookupLatest returns the latest crowdsec version based on github
 func lookupLatest(ctx context.Context) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
+	bo := backoff.NewConstantBackOff(1 * time.Second)
 
 	url := "https://version.crowdsec.net/latest"
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
-	if err != nil {
-		return "", fmt.Errorf("unable to create request for %s: %w", url, err)
-	}
-
 	client := &http.Client{}
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("unable to send request to %s: %w", url, err)
+	operation := func() (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create request for %s: %w", url, err)
+		}
+
+		req.Header.Set("User-Agent", useragent.Default())
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("unable to send request to %s: %w", url, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, fmt.Errorf("unexpected status code %d from %s", resp.StatusCode, url)
+		}
+
+		return resp, nil
 	}
-	defer resp.Body.Close()
+
+	resp, err := backoff.Retry(ctx, operation,
+		backoff.WithBackOff(bo),
+		backoff.WithMaxElapsedTime(5 * time.Second),
+	)
+	if err != nil {
+		return "", err
+	}
 
 	latest := make(map[string]any)
 
@@ -56,51 +75,53 @@ func lookupLatest(ctx context.Context) (string, error) {
 	return name, nil
 }
 
-func chooseBranch(ctx context.Context, cfg *csconfig.Config) string {
+func chooseBranch(ctx context.Context, cfg *csconfig.Config) (string, error) {
 	// this was set from config.yaml or flag
 	if cfg.Cscli.HubBranch != "" {
 		log.Debugf("Hub override from config: branch '%s'", cfg.Cscli.HubBranch)
-		return cfg.Cscli.HubBranch
-	}
-
-	latest, err := lookupLatest(ctx)
-	if err != nil {
-		log.Warningf("Unable to retrieve latest crowdsec version: %s, using hub branch 'master'", err)
-		return "master"
+		return cfg.Cscli.HubBranch, nil
 	}
 
 	csVersion := cwversion.BaseVersion()
 	if csVersion == "" {
 		log.Warning("Crowdsec version is not set, using hub branch 'master'")
-		return "master"
+		return "master", nil
+	}
+
+	latest, err := lookupLatest(ctx)
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve latest crowdsec version: %w", err)
 	}
 
 	if csVersion == latest {
 		log.Debugf("Latest crowdsec version (%s), using hub branch 'master'", version.String())
-		return "master"
+		return "master", nil
 	}
 
 	// if current version is greater than the latest we are in pre-release
 	if semver.Compare(csVersion, latest) == 1 {
 		log.Debugf("Your current crowdsec version seems to be a pre-release (%s), using hub branch 'master'", version.String())
-		return "master"
+		return "master", nil
 	}
 
 	log.Warnf("A new CrowdSec release is available (%s). "+
 		"Your version is '%s'. Please update it to use new parsers/scenarios/collections.",
 		latest, csVersion)
 
-	return csVersion
+	return csVersion, nil
 }
 
 // HubBranch sets the branch (in cscli config) and returns its value
 // It can be "master", or the branch corresponding to the current crowdsec version, or the value overridden in config/flag
-func HubBranch(ctx context.Context, cfg *csconfig.Config) string {
-	branch := chooseBranch(ctx, cfg)
+func HubBranch(ctx context.Context, cfg *csconfig.Config) (string, error) {
+	branch, err := chooseBranch(ctx, cfg)
+	if err != nil {
+		return "", err
+	}
 
 	cfg.Cscli.HubBranch = branch
 
-	return branch
+	return branch, nil
 }
 
 func HubURLTemplate(cfg *csconfig.Config) string {

--- a/cmd/crowdsec-cli/require/require.go
+++ b/cmd/crowdsec-cli/require/require.go
@@ -83,16 +83,20 @@ func DB(c *csconfig.Config) error {
 	return nil
 }
 
-func HubDownloader(ctx context.Context, c *csconfig.Config) *cwhub.Downloader {
+func HubDownloader(ctx context.Context, c *csconfig.Config) (*cwhub.Downloader, error) {
 	// set branch in config, and log if necessary
-	branch := HubBranch(ctx, c)
+	branch, err := HubBranch(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
 	urlTemplate := HubURLTemplate(c)
 	remote := &cwhub.Downloader{
 		Branch:      branch,
 		URLTemplate: urlTemplate,
 	}
 
-	return remote
+	return remote, nil
 }
 
 // Hub initializes the hub. If a remote configuration is provided, it can be used to download the index and items.


### PR DESCRIPTION
This avoids a situation where "hub update" downloads the master branch by mistake and contains objects that are not in the regular branch.