### PR TITLE
fix: normalize scope within range to ensure allowlist check

### DIFF
--- a/cmd/crowdsec-cli/clidecision/import.go
+++ b/cmd/crowdsec-cli/clidecision/import.go
@@ -199,7 +199,7 @@ func (cli *cliDecisions) import_(ctx context.Context, input string, duration str
 		decisionsStr := make([]string, 0, len(chunk))
 
 		for _, d := range chunk {
-			if *d.Scope != types.Ip && *d.Scope != types.Range {
+			if normalizedScope := types.NormalizeScope(*d.Scope); normalizedScope != types.Ip && normalizedScope != types.Range {
 				continue
 			}
 

--- a/test/bats/cscli-allowlists.bats
+++ b/test/bats/cscli-allowlists.bats
@@ -167,6 +167,18 @@ teardown() {
     assert_stderr --partial 'Decision successfully added'
 }
 
+@test "cscli allowlist: check lowercase range decisions import" {
+    rune -0 cscli allowlist create foo -d 'a foo'
+    rune -0 cscli allowlist add foo 192.168.0.0/16
+    rune -1 cscli decisions import -i - <<<'192.168.0.0/24' --format values --scope range 
+    assert_output - <<-EOT
+	Parsing values
+	Value 192.168.0.0/24 is allowlisted by [192.168.0.0/16 from foo]
+	Imported 0 decisions
+	EOT
+    refute_stderr
+}
+
 @test "cscli allowlists check" {
     rune -0 cscli allowlist create foo -d 'a foo'
     rune -0 cscli allowlist add foo 192.168.0.0/16

--- a/test/bats/cscli-allowlists.bats
+++ b/test/bats/cscli-allowlists.bats
@@ -170,7 +170,7 @@ teardown() {
 @test "cscli allowlist: check lowercase range decisions import" {
     rune -0 cscli allowlist create foo -d 'a foo'
     rune -0 cscli allowlist add foo 192.168.0.0/16
-    rune -1 cscli decisions import -i - <<<'192.168.0.0/24' --format values --scope range 
+    rune -0 cscli decisions import -i - <<<'192.168.0.0/24' --format values --scope range 
     assert_output - <<-EOT
 	Parsing values
 	Value 192.168.0.0/24 is allowlisted by [192.168.0.0/16 from foo]


### PR DESCRIPTION
fix: #3734 

before:
```
$ echo "192.168.0.0/24" | cscli decisions import -i- --scope range --format values
Parsing values
Imported 1 decisions
```

after:
```
$ echo "192.168.0.0/24" | cscli decisions import -i- --scope range --format values
Parsing values
Value 192.168.0.0/24 is allowlisted by [192.168.0.0/24 from my_allowlist]
Imported 0 decisions
```