### PR TITLE
leakybucket: refactor queue handling to improve queue handling

### DIFF
--- a/pkg/leakybucket/bayesian.go
+++ b/pkg/leakybucket/bayesian.go
@@ -82,7 +82,7 @@ func (c *BayesianBucket) AfterBucketPour(b *BucketFactory) func(types.Event, *Le
 		if c.posterior > c.threshold {
 			l.logger.Debugf("Bayesian bucket overflow")
 			l.Ovflw_ts = l.Last_ts
-			l.Out <- l.Queue
+			l.Out <- &l.Queue
 			return nil
 		}
 
@@ -152,7 +152,7 @@ func (b *BayesianEvent) compileCondition() error {
 
 	conditionalExprCacheLock.Unlock()
 	//release the lock during compile same as coditional bucket
-	compiledExpr, err = expr.Compile(b.rawCondition.ConditionalFilterName, exprhelpers.GetExprOptions(map[string]interface{}{"queue": &types.Queue{}, "leaky": &Leaky{}, "evt": &types.Event{}})...)
+	compiledExpr, err = expr.Compile(b.rawCondition.ConditionalFilterName, exprhelpers.GetExprOptions(map[string]interface{}{"queue.Queue": []types.Event{}, "leaky": &Leaky{}, "evt": &types.Event{}})...)
 	if err != nil {
 		return fmt.Errorf("bayesian condition compile error: %w", err)
 	}

--- a/pkg/leakybucket/bucket.go
+++ b/pkg/leakybucket/bucket.go
@@ -32,7 +32,7 @@ type Leaky struct {
 	Limiter         rate.RateLimiter `json:"-"`
 	SerializedState rate.Lstate
 	//Queue is used to hold the cache of objects in the bucket, it is used to know 'how many' objects we have in buffer.
-	Queue *types.Queue
+	Queue types.Queue
 	//Leaky buckets are receiving message through a chan
 	In chan *types.Event `json:"-"`
 	//Leaky buckets are pushing their overflows through a chan
@@ -308,7 +308,7 @@ func LeakRoutine(leaky *Leaky) error {
 			)
 			leaky.Ovflw_ts = time.Now().UTC()
 			close(leaky.Signal)
-			ofw := leaky.Queue
+			ofw := &leaky.Queue
 			alert = types.RuntimeAlert{Mapkey: leaky.Mapkey}
 
 			if leaky.timedOverflow {
@@ -370,7 +370,7 @@ func Pour(leaky *Leaky, msg types.Event) {
 		leaky.Ovflw_ts = time.Now().UTC()
 		leaky.logger.Debugf("Last event to be poured, bucket overflow.")
 		leaky.Queue.Add(msg)
-		leaky.Out <- leaky.Queue
+		leaky.Out <- &leaky.Queue
 	}
 }
 

--- a/pkg/leakybucket/conditional.go
+++ b/pkg/leakybucket/conditional.go
@@ -36,7 +36,7 @@ func (c *ConditionalOverflow) OnBucketInit(g *BucketFactory) error {
 	} else {
 		conditionalExprCacheLock.Unlock()
 		//release the lock during compile
-		compiledExpr, err = expr.Compile(g.ConditionalOverflow, exprhelpers.GetExprOptions(map[string]interface{}{"queue": &types.Queue{}, "leaky": &Leaky{}, "evt": &types.Event{}})...)
+		compiledExpr, err = expr.Compile(g.ConditionalOverflow, exprhelpers.GetExprOptions(map[string]interface{}{"queue.Queue": []types.Event{}, "leaky": &Leaky{}, "evt": &types.Event{}})...)
 		if err != nil {
 			return fmt.Errorf("conditional compile error : %w", err)
 		}
@@ -71,7 +71,7 @@ func (c *ConditionalOverflow) AfterBucketPour(b *BucketFactory) func(types.Event
 			if condition {
 				l.logger.Debugf("Conditional bucket overflow")
 				l.Ovflw_ts = l.Last_ts
-				l.Out <- l.Queue
+				l.Out <- &l.Queue
 				return nil
 			}
 		}

--- a/pkg/leakybucket/manager_load.go
+++ b/pkg/leakybucket/manager_load.go
@@ -459,7 +459,7 @@ func LoadBucket(bucketFactory *BucketFactory, tomb *tomb.Tomb) error {
 		bucketFactory.logger.Tracef("Adding conditional overflow")
 		bucketFactory.processors = append(bucketFactory.processors, &ConditionalOverflow{})
 		// we're compiling and discarding the expression to be able to detect it during loading
-		_, err = expr.Compile(bucketFactory.ConditionalOverflow, exprhelpers.GetExprOptions(map[string]any{"queue": &types.Queue{}, "leaky": &Leaky{}, "evt": &types.Event{}})...)
+		_, err = expr.Compile(bucketFactory.ConditionalOverflow, exprhelpers.GetExprOptions(map[string]any{"queue.Queue": []types.Event{}, "leaky": &Leaky{}, "evt": &types.Event{}})...)
 		if err != nil {
 			return fmt.Errorf("invalid condition '%s' in %s: %w", bucketFactory.ConditionalOverflow, bucketFactory.Filename, err)
 		}

--- a/pkg/leakybucket/overflow_filter.go
+++ b/pkg/leakybucket/overflow_filter.go
@@ -28,7 +28,7 @@ func NewOverflowFilter(g *BucketFactory) (*OverflowFilter, error) {
 	u := OverflowFilter{}
 	u.Filter = g.OverflowFilter
 
-	u.FilterRuntime, err = expr.Compile(u.Filter, exprhelpers.GetExprOptions(map[string]interface{}{"queue": &types.Queue{}, "signal": &types.RuntimeAlert{}, "leaky": &Leaky{}})...)
+	u.FilterRuntime, err = expr.Compile(u.Filter, exprhelpers.GetExprOptions(map[string]interface{}{"queue.Queue": []types.Event{}, "signal": &types.RuntimeAlert{}, "leaky": &Leaky{}})...)
 	if err != nil {
 		g.logger.Errorf("Unable to compile filter : %v", err)
 		return nil, fmt.Errorf("unable to compile filter : %v", err)

--- a/pkg/leakybucket/overflows.go
+++ b/pkg/leakybucket/overflows.go
@@ -196,7 +196,7 @@ func eventSources(evt types.Event, leaky *Leaky) (map[string]models.Source, erro
 }
 
 // EventsFromQueue iterates the queue to collect & prepare meta-datas from alert
-func EventsFromQueue(queue *types.Queue) []*models.Event {
+func EventsFromQueue(queue types.Queue) []*models.Event {
 	events := []*models.Event{}
 
 	qEvents := queue.GetQueue()
@@ -249,7 +249,7 @@ func EventsFromQueue(queue *types.Queue) []*models.Event {
 }
 
 // alertFormatSource iterates over the queue to collect sources
-func alertFormatSource(leaky *Leaky, queue *types.Queue) (map[string]models.Source, string, error) {
+func alertFormatSource(leaky *Leaky, queue types.Queue) (map[string]models.Source, string, error) {
 	var source_type string
 
 	sources := make(map[string]models.Source)
@@ -324,7 +324,7 @@ func NewAlert(leaky *Leaky, queue *types.Queue) (types.RuntimeAlert, error) {
 	runtimeAlert.Mapkey = leaky.Mapkey
 
 	// Get the sources from Leaky/Queue
-	sources, source_scope, err := alertFormatSource(leaky, queue)
+	sources, source_scope, err := alertFormatSource(leaky, *queue)
 	if err != nil {
 		return runtimeAlert, fmt.Errorf("unable to collect sources from bucket: %w", err)
 	}
@@ -343,7 +343,7 @@ func NewAlert(leaky *Leaky, queue *types.Queue) (types.RuntimeAlert, error) {
 
 	*apiAlert.Message = fmt.Sprintf("%s %s performed '%s' (%d events over %s) at %s", source_scope, sourceStr, leaky.Name, leaky.Total_count, leaky.Ovflw_ts.Sub(leaky.First_ts), leaky.Last_ts)
 	// Get the events from Leaky/Queue
-	apiAlert.Events = EventsFromQueue(queue)
+	apiAlert.Events = EventsFromQueue(*queue)
 
 	var warnings []error
 

--- a/pkg/leakybucket/timemachine.go
+++ b/pkg/leakybucket/timemachine.go
@@ -43,7 +43,7 @@ func TimeMachinePour(l *Leaky, msg types.Event) {
 		l.Ovflw_ts = d
 		l.logger.Debugf("Bucket overflow at %s", l.Ovflw_ts)
 		l.Queue.Add(msg)
-		l.Out <- l.Queue
+		l.Out <- &l.Queue
 	}
 }
 

--- a/pkg/leakybucket/trigger.go
+++ b/pkg/leakybucket/trigger.go
@@ -42,7 +42,7 @@ func (t *Trigger) OnBucketPour(b *BucketFactory) func(types.Event, *Leaky) *type
 
 		l.logger.Debug("Bucket overflow")
 		l.Queue.Add(msg)
-		l.Out <- l.Queue
+		l.Out <- &l.Queue
 
 		return nil
 	}

--- a/pkg/types/queue.go
+++ b/pkg/types/queue.go
@@ -5,20 +5,20 @@ import (
 )
 
 // Queue holds a limited size queue
-type Queue struct {
+type LocalQueue struct {
 	Queue []Event
 	L     int //capacity
 }
 
 // NewQueue create a new queue with a size of l
-func NewQueue(l int) *Queue {
+func NewLocalQueue(l int) *LocalQueue {
 	if l == -1 {
-		return &Queue{
+		return &LocalQueue{
 			Queue: make([]Event, 0),
 			L:     int(^uint(0) >> 1), // max integer value, architecture independent
 		}
 	}
-	q := &Queue{
+	q := &LocalQueue{
 		Queue: make([]Event, 0, l),
 		L:     l,
 	}
@@ -28,14 +28,27 @@ func NewQueue(l int) *Queue {
 
 // Add an event in the queue. If it has already l elements, the first
 // element is dropped before adding the new m element
-func (q *Queue) Add(m Event) {
+func (q *LocalQueue) Add(m Event) {
 	for len(q.Queue) > q.L { //we allow to add one element more than the true capacity
 		q.Queue = q.Queue[1:]
 	}
 	q.Queue = append(q.Queue, m)
 }
+func (q *LocalQueue) GetSize() int {
+	return len(q.Queue)
+}
 
 // GetQueue returns the entire queue
-func (q *Queue) GetQueue() []Event {
+func (q *LocalQueue) GetQueue() []Event {
 	return q.Queue
+}
+
+type Queue interface {
+	GetQueue() []Event
+	GetSize() int
+	Add(Event)
+}
+
+func NewQueue(l int) Queue {
+	return NewLocalQueue(l)
 }


### PR DESCRIPTION
Refactored the Queue type to introduce a new ~LocalQueue~ implementation and updated all references to use the new interface. This change ensures better type safety and flexibility in queue operations.

BREAKING CHANGE: The ~Queue~ type has been replaced with a new ~LocalQueue~ implementation, and a ~Queue~ interface has been introduced. This may require updates to any code directly interacting with the ~Queue~ type.