### PR TITLE
enhance: Add averagetime function which allows to compute avergage

### DIFF
--- a/pkg/exprhelpers/expr_lib.go
+++ b/pkg/exprhelpers/expr_lib.go
@@ -517,6 +517,13 @@ var exprFuncs = []exprCustomFunc{
 			new(func(*http.Request) string),
 		},
 	},
+	{
+		name:     "AverageTime",
+		function: AverageTime,
+		signature: []any{
+			new(func(...time.Time) time.Duration),
+		},
+	},
 }
 
 //go 1.20 "CutPrefix":              strings.CutPrefix,

--- a/pkg/exprhelpers/helpers.go
+++ b/pkg/exprhelpers/helpers.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -628,6 +629,26 @@ func ParseUri(params ...any) (any, error) {
 	maps.Copy(ret, parsed)
 
 	return ret, nil
+}
+
+// func AverageTime(params ...time.Time) time.Duration
+func AverageTime(params ...any) (any, error) {
+	if len(params) < 2 {
+		return 0, fmt.Errorf("need at least two times to calculate an average interval")
+	}
+
+	// Sort times in ascending order
+	sort.Slice(params, func(i, j int) bool {
+		return params[i].(time.Time).Before(params[j].(time.Time))
+	})
+
+	var total time.Duration
+	for i := 1; i < len(params); i++ {
+		total += params[i].(time.Time).Sub(params[i-1].(time.Time))
+	}
+
+	average := total / time.Duration(len(params)-1)
+	return average, nil
 }
 
 // func KeyExists(key string, dict map[string]interface{}) bool {


### PR DESCRIPTION
### **Summary**

This PR introduces a new helper function `AverageTime` designed to compute the average time difference between multiple event timestamps. This allows detection scenarios to evaluate whether the average request interval exceeds a specified duration.

---

### **Motivation**

Certain scenarios, such as detecting slow bruteforce require understanding the average time gap between requests rather than simply counting events.

---

### **New Functionality**

* **`AverageTime(args ...time.Time) time.Duration`**

  * Accepts any number of `time.Time` arguments.
  * Returns the average duration between consecutive timestamps.
  * Ignores the order of arguments (sorted internally for correctness).

---

### **Usage Example**

```yaml
type: conditional
name: me/slow-http
debug: true
description: "Detect slow HTTP requests returning 404"
filter: "evt.Meta.log_type in ['http_access-log', 'http_error-log'] && evt.Parsed.static_ressource == 'false' && evt.Parsed.verb in ['GET', 'HEAD']"
groupby: "evt.Meta.source_ip + '/' + evt.Parsed.target_fqdn"
capacity: -1
condition: |
    len(queue.Queue) >= 3 &&
    AverageTime(queue.Queue[-1].Time, queue.Queue[-2].Time, queue.Queue[-3].Time) > duration("5m") &&
    all(queue.Queue, #.Meta.http_status == '404')
leakspeed: 1h
labels:
  remediation: true
```

---

### **Why is this useful?**

This function enables scenarios that require time-based analysis beyond fixed thresholds. Examples include:

* Detecting slow HTTP scanning.
* Identifying rate anomalies over time.
* Combining time-based checks with other behavioral indicators for more accurate detection.
* Less overlap between traditional leaky buckets

---

### **Tests**

* Added unit tests for:

  * Basic average calculation.
  * Multiple timestamps with irregular intervals.
  * Edge case: fewer than 2 timestamps.
* Verified scenario example triggers correctly under simulated conditions.