### PR TITLE
Improve logging for file acquisition

### DIFF
--- a/pkg/acquisition/modules/file/file.go
+++ b/pkg/acquisition/modules/file/file.go
@@ -503,7 +503,7 @@ func (f *FileSource) setupTailForFile(file string, out chan types.Event, seekEnd
 		seekInfo.Whence = io.SeekEnd
 	}
 
-	logger.Infof("Starting tail for file %s (offset: %d, whence: %d)", file, seekInfo.Offset, seekInfo.Whence)
+	logger.Infof("Starting tail (offset: %d, whence: %d)", seekInfo.Offset, seekInfo.Whence)
 
 	tail, err := tail.TailFile(file, tail.Config{
 		ReOpen:   true,


### PR DESCRIPTION
When an Agent first starts initial file discovery is independant from ongoing (either through file system events of poll discovery) discovery. 

During startup some logging happens indicating what files are being added/tailed:

> time="2025-08-02T08:33:51Z" level=info msg="Adding file /log-clusterlogs-traefik/320144_access.log to datasources" type=file                                                                                  " type=file 

But after that, there is no clue about what is happening with new files being tailed (not even in DEBUG level).

I had a tough time figuring out if some files were being tailed after being added if the agent had already started due to the lack of feedback in the logs for this process.

I added a couple of INFO level logs that happen rarely and are very helpful to keep an eye on file tails.