### PR TITLE
remove the cscli_setup feature flag

### DIFF
--- a/cmd/crowdsec-cli/setup.go
+++ b/cmd/crowdsec-cli/setup.go
@@ -7,13 +7,9 @@ import (
 
 	"github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/clisetup"
 	"github.com/crowdsecurity/crowdsec/pkg/cwversion/component"
-	"github.com/crowdsecurity/crowdsec/pkg/fflag"
 )
 
 func (cli *cliRoot) addSetup(cmd *cobra.Command) {
-	if fflag.CscliSetup.IsEnabled() {
-		cmd.AddCommand(clisetup.New(cli.cfg).NewCommand())
-	}
-
+	cmd.AddCommand(clisetup.New(cli.cfg).NewCommand())
 	component.Register("cscli_setup")
 }

--- a/pkg/fflag/crowdsec.go
+++ b/pkg/fflag/crowdsec.go
@@ -3,7 +3,6 @@ package fflag
 var Crowdsec = FeatureRegister{EnvPrefix: "CROWDSEC_FEATURE_"}
 
 var (
-	CscliSetup              = &Feature{Name: "cscli_setup", Description: "Enable cscli setup command (service detection)", enabled: true}
 	DisableHttpRetryBackoff = &Feature{Name: "disable_http_retry_backoff", Description: "Disable http retry backoff"}
 	ChunkedDecisionsStream  = &Feature{Name: "chunked_decisions_stream", Description: "Enable chunked decisions stream"}
 	PapiClient              = &Feature{Name: "papi_client", Description: "Enable Polling API client", State: DeprecatedState}
@@ -12,12 +11,7 @@ var (
 )
 
 func RegisterAllFeatures() error {
-	err := Crowdsec.RegisterFeature(CscliSetup)
-	if err != nil {
-		return err
-	}
-
-	err = Crowdsec.RegisterFeature(DisableHttpRetryBackoff)
+	err := Crowdsec.RegisterFeature(DisableHttpRetryBackoff)
 	if err != nil {
 		return err
 	}

--- a/test/bats-detect/lib/setup_file_detect.sh
+++ b/test/bats-detect/lib/setup_file_detect.sh
@@ -53,5 +53,3 @@ rpm-remove() {
     fi
 }
 export -f rpm-remove
-
-export CROWDSEC_FEATURE_CSCLI_SETUP="true"

--- a/test/bats/01_cscli.bats
+++ b/test/bats/01_cscli.bats
@@ -271,7 +271,6 @@ teardown() {
 
 @test "cscli doc" {
     cd "$BATS_TEST_TMPDIR"
-    export CROWDSEC_FEATURE_CSCLI_SETUP="false"
     rune -1 cscli doc
     refute_output
     assert_stderr --regexp 'failed to generate cscli documentation: open doc/.*: no such file or directory'
@@ -281,36 +280,13 @@ teardown() {
     assert_output "Documentation generated in ./doc"
     refute_stderr
     assert_file_exists "doc/cscli.md"
-    assert_file_not_exist "doc/cscli_setup.md"
-
-    # commands guarded by feature flags are not documented unless the feature flag is set
-
-    export CROWDSEC_FEATURE_CSCLI_SETUP="true"
-    rune -0 cscli doc
-    assert_file_exists "doc/cscli_setup.md"
 
     # specify a target directory
     mkdir -p "$BATS_TEST_TMPDIR/doc2"
     rune -0 cscli doc --target "$BATS_TEST_TMPDIR/doc2"
     assert_output "Documentation generated in $BATS_TEST_TMPDIR/doc2"
     refute_stderr
-    assert_file_exists "$BATS_TEST_TMPDIR/doc2/cscli_setup.md"
-
-}
-
-@test "feature flags for subcommands" {
-    # it is possible to enable subcommands with feature flags
-    # defined in feature.yaml or envvars
-
-    export CROWDSEC_FEATURE_CSCLI_SETUP="false"
-    rune -1 cscli setup detect
-    assert_stderr --partial 'unknown command "setup" for "cscli"'
-    CONFIG_DIR=$(dirname "$CONFIG_YAML")
-    # currently, we have no subcommands guarded by feature flags
-    # echo ' - cscli_setup' >> "$CONFIG_DIR"/feature.yaml
-    export CROWDSEC_FEATURE_CSCLI_SETUP="true"
-    rune -0 cscli setup --help
-    assert_output --partial 'cscli setup [command]'
+    assert_file_exists "$BATS_TEST_TMPDIR/doc2/cscli.md"
 }
 
 @test "cscli config feature-flags" {

--- a/test/bats/cscli-setup.bats
+++ b/test/bats/cscli-setup.bats
@@ -15,8 +15,6 @@ setup_file() {
     # shellcheck disable=SC2154
     TESTDATA="$BATS_TEST_DIRNAME/testdata/cscli-setup"
     export TESTDATA
-
-    export CROWDSEC_FEATURE_CSCLI_SETUP="true"
 }
 
 teardown_file() {


### PR DESCRIPTION
This was never used outside testing, should not impact anyone. If someone really used the feature, it's not compatible anyway with the previous version and they'll get an error at runtime.