### PR TITLE
Increase hub download timeout to 10 minutes

### DIFF
--- a/pkg/cwhub/cwhub.go
+++ b/pkg/cwhub/cwhub.go
@@ -19,6 +19,6 @@ func (t *hubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // HubClient is the HTTP client used to communicate with the CrowdSec Hub.
 var HubClient = &http.Client{
-	Timeout:   120 * time.Second,
+	Timeout:   10 * time.Minute,
 	Transport: &hubTransport{http.DefaultTransport},
 }


### PR DESCRIPTION
120 seconds may not be enough to download data files.