### PR TITLE
`cscli hubtest --appsec` : Bail when we cannot invoke nuclei

### DIFF
--- a/pkg/hubtest/nucleirunner.go
+++ b/pkg/hubtest/nucleirunner.go
@@ -51,10 +51,10 @@ func (nc *NucleiConfig) RunNucleiTemplate(testName string, templatePath string, 
 	}
 
 	if err != nil {
-		log.Warningf("Error running nuclei: %s", err)
 		log.Warningf("Stdout saved to %s", outputPrefix+"_stdout.txt")
 		log.Warningf("Stderr saved to %s", outputPrefix+"_stderr.txt")
 		log.Warningf("Nuclei generated output saved to %s", outputPrefix+".json")
+		log.Fatalf("Error running nuclei: %s", err)
 		return err
 	} else if out.String() == "" {
 		log.Warningf("Stdout saved to %s", outputPrefix+"_stdout.txt")


### PR DESCRIPTION
When we fail to invoke `nuclei` (typically because not installed, not in `$PATH` etc.), we currently go to the end of the testing process, letting the user scroll the crowdsec logs before figuring out that it didn't matter, as we couldn't invoke nuclei at all.

We should leave the testing process early, giving the user  a clear error message.