### PR TITLE
enhance: Attempt to reduce body reads on appsec

### DIFF
--- a/pkg/appsec/tx.go
+++ b/pkg/appsec/tx.go
@@ -1,6 +1,8 @@
 package appsec
 
 import (
+	"io"
+
 	"github.com/corazawaf/coraza/v3"
 	"github.com/corazawaf/coraza/v3/experimental"
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
@@ -72,6 +74,11 @@ func (t *ExtendedTransaction) WriteRequestBody(body []byte) (*types.Interruption
 	return t.Tx.WriteRequestBody(body)
 }
 
+// ReadRequestBodyFrom streams the request body from the provided reader into the transaction.
+func (t *ExtendedTransaction) ReadRequestBodyFrom(r io.Reader) (*types.Interruption, int, error) {
+	return t.Tx.ReadRequestBodyFrom(r)
+}
+
 func (t *ExtendedTransaction) Interruption() *types.Interruption {
 	return t.Tx.Interruption()
 }
@@ -94,4 +101,9 @@ func (t *ExtendedTransaction) ID() string {
 
 func (t *ExtendedTransaction) Close() error {
 	return t.Tx.Close()
+}
+
+// IsRequestBodyAccessible exposes whether the engine has request body access enabled.
+func (t *ExtendedTransaction) IsRequestBodyAccessible() bool {
+	return t.Tx.IsRequestBodyAccessible()
 }


### PR DESCRIPTION
**What changed**
  - `pkg/appsec/request.go`: Stop eagerly reading HTTP bodies. `NewParsedRequestFromRequest` no longer copies the body into `ParsedRequest.Body`; it keeps `HTTPRequest.Body` for later streaming.
  - `pkg/appsec/tx.go`: Expose streaming/body-access helpers on `ExtendedTransaction`:
    - `ReadRequestBodyFrom(io.Reader)`
    - `IsRequestBodyAccessible()`
  - `pkg/acquisition/modules/appsec/appsec_runner.go`:
    - Pre-buffer the request body once only if out-of-band rules exist and OOB body inspection is enabled (optionally capped by `OutOfBandOptions.RequestBodyInMemoryLimit`).
    - For inband: stream body directly from `HTTPRequest.Body` when not pre-buffered; otherwise write from the single pre-buffer.
    - For out-of-band: reuse the same pre-buffer to avoid a second copy.

- **How it works**
  - Inband:
    - If no OOB body inspection needed: body is streamed to Coraza via `ReadRequestBodyFrom`, avoiding allocations.
    - If OOB needs the body: reuses the single pre-buffered slice for inband too.
  - Out-of-band:
    - Only reads body if there are OOB rules and body inspection is enabled; uses the same pre-buffered slice.
  - This removes the per-request default body copy and avoids retaining the body in multiple places.

- **Why**
  - Reduce allocations and memory retention from:
    - Avoiding default `[]byte` body copies in `ParsedRequest`.
    - Buffering at most once when OOB needs the body.
    - Streaming directly to Coraza when possible.

- **Behavioral impact**
  - `ParsedRequest.Body` is often nil now; consumers should use `ParsedRequest.HTTPRequest.Body` or Coraza tx streaming paths.
  - Body pre-buffering occurs only when required by OOB settings.
  - May impact hooks but further testing is needed.