### PR TITLE
enhance: Experimental scaling routines when channels become saturated

### DIFF
--- a/cmd/crowdsec/stage_pool.go
+++ b/cmd/crowdsec/stage_pool.go
@@ -26,13 +26,13 @@ type StagePool struct {
 	logger *log.Entry
 }
 
-func NewStagePool(name string, t *tomb.Tomb, inLen func() (int, int), min, max int, launchWorker func(), logger *log.Entry) *StagePool {
+func NewStagePool(name string, t *tomb.Tomb, inLen func() (int, int), minWorkers, maxWorkers int, launchWorker func(), logger *log.Entry) *StagePool {
 	return &StagePool{
 		name:         name,
 		tomb:         t,
 		inLen:        inLen,
-		min:          min,
-		max:          max,
+		min:          minWorkers,
+		max:          maxWorkers,
 		launchWorker: launchWorker,
 		upThresh:     70,
 		downThresh:   20,

--- a/cmd/crowdsec/stage_pool.go
+++ b/cmd/crowdsec/stage_pool.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	tomb "gopkg.in/tomb.v2"
+)
+
+// StagePool is a minimal scaffold to manage a pool of workers for a stage and a monitor to autoscale.
+type StagePool struct {
+	name         string
+	tomb         *tomb.Tomb
+	inLen        func() (int, int) // returns len and cap of the input queue
+	min          int
+	max          int
+	launchWorker func()
+	requestStop  func() bool // ask one worker to stop, returns true if a worker was signaled
+
+	// autoscale tuning
+	upThresh     int // percent
+	downThresh   int // percent
+	upCooldown   time.Duration
+	downCooldown time.Duration
+
+	logger *log.Entry
+}
+
+func NewStagePool(name string, t *tomb.Tomb, inLen func() (int, int), min, max int, launchWorker func(), logger *log.Entry) *StagePool {
+	return &StagePool{
+		name:         name,
+		tomb:         t,
+		inLen:        inLen,
+		min:          min,
+		max:          max,
+		launchWorker: launchWorker,
+		upThresh:     70,
+		downThresh:   20,
+		upCooldown:   time.Second,
+		downCooldown: 5 * time.Second,
+		logger:       logger,
+	}
+}
+
+// Start launches initial workers and, if enabled, a monitor goroutine.
+// If enableAutoscale is false, only the initial workers are started.
+func (p *StagePool) Start(initial int, enableAutoscale bool) {
+	if initial < 1 {
+		initial = 1
+	}
+	if p.max < p.min {
+		p.max = p.min
+	}
+	// ensure we never scale below the initial number of workers
+	if p.min < initial {
+		p.min = initial
+	}
+
+	// launch initial workers
+	for range initial {
+		p.launchWorker()
+	}
+
+	if !enableAutoscale {
+		return
+	}
+
+	p.tomb.Go(func() error {
+		// monitor and scale
+		current := initial
+		var hotCount, coldCount int
+		lastUp := time.Time{}
+		lastDown := time.Time{}
+		ticker := time.NewTicker(300 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-p.tomb.Dying():
+				return nil
+			case <-ticker.C:
+				llen, capn := p.inLen()
+				if capn == 0 {
+					continue
+				}
+				usage := (llen * 100) / capn
+				if usage >= p.upThresh && current < p.max {
+					hotCount++
+					coldCount = 0
+					if hotCount >= 3 && time.Since(lastUp) >= p.upCooldown {
+						p.launchWorker()
+						current++
+						lastUp = time.Now()
+						p.logger.Infof("autoscale(%s): scale up to %d (queue %d/%d)", p.name, current, llen, capn)
+					}
+				} else if usage <= p.downThresh && current > p.min {
+					coldCount++
+					hotCount = 0
+					if coldCount >= 10 && time.Since(lastDown) >= p.downCooldown {
+						// attempt to gracefully stop one worker
+						stopped := false
+						if p.requestStop != nil {
+							stopped = p.requestStop()
+						}
+						if stopped {
+							current--
+							lastDown = time.Now()
+							p.logger.Infof("autoscale(%s): scale down to %d (queue %d/%d)", p.name, current, llen, capn)
+						} else {
+							p.logger.Debugf("autoscale(%s): no idle worker available to stop", p.name)
+						}
+					}
+				} else {
+					hotCount = 0
+					coldCount = 0
+				}
+			}
+		}
+	})
+}

--- a/pkg/fflag/crowdsec.go
+++ b/pkg/fflag/crowdsec.go
@@ -8,6 +8,9 @@ var (
 	PapiClient              = &Feature{Name: "papi_client", Description: "Enable Polling API client", State: DeprecatedState}
 	Re2GrokSupport          = &Feature{Name: "re2_grok_support", Description: "Enable RE2 support for GROK patterns"}
 	Re2RegexpInfileSupport  = &Feature{Name: "re2_regexp_in_file_support", Description: "Enable RE2 support for RegexpInFile expr helper"}
+	ParsersAutoscale        = &Feature{Name: "parsers_autoscale", Description: "Enable adaptive scaling for parser workers"}
+	BucketsAutoscale        = &Feature{Name: "buckets_autoscale", Description: "Enable adaptive scaling for bucket workers"}
+	OutputsAutoscale        = &Feature{Name: "outputs_autoscale", Description: "Enable adaptive scaling for output workers"}
 )
 
 func RegisterAllFeatures() error {
@@ -32,6 +35,21 @@ func RegisterAllFeatures() error {
 	}
 
 	err = Crowdsec.RegisterFeature(Re2RegexpInfileSupport)
+	if err != nil {
+		return err
+	}
+
+	err = Crowdsec.RegisterFeature(ParsersAutoscale)
+	if err != nil {
+		return err
+	}
+
+	err = Crowdsec.RegisterFeature(BucketsAutoscale)
+	if err != nil {
+		return err
+	}
+
+	err = Crowdsec.RegisterFeature(OutputsAutoscale)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Very experimental, tested under heavy load, current code happy but can DRY.

### What this adds
- Adaptive autoscaling for parser, buckets, and outputs stages (feature-flagged)
- Buffered hot-path channels and small buffer per-bucket
- Backoff in bucket pour to avoid busy-spin
- Demoted noisy “stuck for X sending” log

### How to enable
- Enable autoscaling via env or feature.yaml:
  - Env:
    - `CROWDSEC_FEATURE_PARSERS_AUTOSCALE=true`
    - `CROWDSEC_FEATURE_BUCKETS_AUTOSCALE=true`
    - `CROWDSEC_FEATURE_OUTPUTS_AUTOSCALE=true`
  - feature.yaml:
    - parsers_autoscale
    - buckets_autoscale
    - outputs_autoscale

### How to test
- Start the agent normally, then generate a burst of logs.
- Observe scale events in logs:
  - “autoscale(parser): scale up to N …”
  - “autoscale(buckets): scale up to N …”
  - “autoscale(outputs): scale up to N …”
- Let load subside; parser/buckets should scale down gradually (not below initial). Outputs stop immediately on downscale request.
- Verify no warning spam about “stuck for … sending event …”.
- Check that overflow events still appear and alerts get pushed.
- Optionally monitor CPU: under sustained load you should see reduced busy-waiting compared to before.

### Changes (high-level)
- Buffered channels:
  - `inputLineChan`, `inputEventChan` sized to downstream workers.
  - Overflow channel (`LoadBuckets`) sized to output workers.
  - Per-bucket `In` channel now buffered (4).
- Autoscaling scaffold:
  - New `StagePool` with scale-up/down logic and min floor.
  - Parser: controlled by `parsers_autoscale`, idle-based downscale.
  - Buckets: controlled by `buckets_autoscale`, idle-based downscale.
  - Outputs: controlled by `outputs_autoscale`, immediate stop on downscale.
- Pour path:
  - Exponential backoff on full `bucket.In` to avoid CPU spin.
  - Suppressed/demoted “stuck for X sending …” log.
- Feature flags:
  - Added `parsers_autoscale`, `buckets_autoscale`, `outputs_autoscale`.