### PR TITLE
unify the output format of start_at and stop_at

### DIFF
--- a/pkg/apiserver/controllers/v1/alerts.go
+++ b/pkg/apiserver/controllers/v1/alerts.go
@@ -20,8 +20,8 @@ import (
 )
 
 func FormatOneAlert(alert *ent.Alert) *models.Alert {
-	startAt := alert.StartedAt.String()
-	StopAt := alert.StoppedAt.String()
+	startAt := alert.StartedAt.Format(time.RFC3339)
+	StopAt := alert.StoppedAt.Format(time.RFC3339)
 
 	machineID := "N/A"
 	if alert.Edges.Owner != nil {


### PR DESCRIPTION
We currently use `.String()`, which doesn't provide consistent output. I had occurences where output format was `2025-08-14 03:48:51 +0000 UTC` and others where it was `2019-01-14 14:03:53 +0100 +0100`. I don't believe it's at risk of breaking anything as it's only used by `cscli alerts list` ?

