### PR TITLE
rpm: declare ghost file permissions

### DIFF
--- a/rpm/SPECS/crowdsec.spec
+++ b/rpm/SPECS/crowdsec.spec
@@ -130,13 +130,13 @@ rm -rf %{buildroot}
 
 %{_unitdir}/%{name}.service
 
-%ghost %{_sysconfdir}/%{name}/hub/.index.json
-%ghost %{_localstatedir}/log/%{name}.log
+%ghost %attr(0600,root,root) %{_sysconfdir}/%{name}/hub/.index.json
+%ghost %attr(0600,root,root) %{_localstatedir}/log/%{name}.log
 %dir /var/lib/%{name}/data/
 %dir %{_sysconfdir}/%{name}/hub
 
-%ghost %{_sysconfdir}/crowdsec/local_api_credentials.yaml
-%ghost %{_sysconfdir}/crowdsec/online_api_credentials.yaml
+%ghost %attr(0600,root,root) %{_sysconfdir}/crowdsec/local_api_credentials.yaml
+%ghost %attr(0600,root,root) %{_sysconfdir}/crowdsec/online_api_credentials.yaml
 %ghost %{_sysconfdir}/crowdsec/acquis.yaml
 
 %pre


### PR DESCRIPTION
part of https://github.com/crowdsecurity/crowdsec/issues/3723

(acquis.yaml is not distributed or created since 1.7.0)