### PR TITLE
cloudwatch: fix flaxy test

### DIFF
--- a/pkg/acquisition/modules/cloudwatch/cloudwatch_test.go
+++ b/pkg/acquisition/modules/cloudwatch/cloudwatch_test.go
@@ -585,6 +585,10 @@ func (s *CloudwatchSuite) TestOneShotAcquisition() {
 					},
 				})
 				require.NoError(t, err)
+
+				// prevent flaky test due to slow CI
+				end := time.Now().UTC().Add(5 * time.Second)
+				cw.Config.EndTime = &end
 			},
 			expectedResMessages: []string{"test_message_2"},
 		},


### PR DESCRIPTION
Error: Not equal:
expected: []string{"test_message_2"}
actual  : []string{}