### PR TITLE
waf: allow glob when including seclang files

### DIFF
--- a/pkg/appsec/appsec_rules_collection.go
+++ b/pkg/appsec/appsec_rules_collection.go
@@ -77,24 +77,38 @@ func LoadCollection(pattern string, logger *log.Entry) ([]AppsecCollection, erro
 		if appsecRule.SecLangFilesRules != nil {
 			for _, rulesFile := range appsecRule.SecLangFilesRules {
 				logger.Debugf("Adding rules from %s", rulesFile)
-				fullPath := filepath.Join(hub.GetDataDir(), rulesFile)
+				globPattern := filepath.Join(hub.GetDataDir(), rulesFile)
 
-				c, err := os.ReadFile(fullPath)
+				matches, err := filepath.Glob(globPattern)
+
 				if err != nil {
-					logger.Errorf("unable to read file %s : %s", rulesFile, err)
+					logger.Errorf("unable to glob %s : %s", rulesFile, err)
 					continue
 				}
 
-				for line := range strings.SplitSeq(string(c), "\n") {
-					if strings.HasPrefix(line, "#") {
+				if len(matches) == 0 {
+					logger.Warnf("no file matched pattern %s", globPattern)
+					continue
+				}
+
+				for _, fullPath := range matches {
+					c, err := os.ReadFile(fullPath)
+					if err != nil {
+						logger.Errorf("unable to read file %s : %s", rulesFile, err)
 						continue
 					}
 
-					if strings.TrimSpace(line) == "" {
-						continue
-					}
+					for line := range strings.SplitSeq(string(c), "\n") {
+						if strings.HasPrefix(line, "#") {
+							continue
+						}
 
-					appsecCol.NativeRules = append(appsecCol.NativeRules, line)
+						if strings.TrimSpace(line) == "" {
+							continue
+						}
+
+						appsecCol.NativeRules = append(appsecCol.NativeRules, line)
+					}
 				}
 			}
 		}

--- a/pkg/hubops/download.go
+++ b/pkg/hubops/download.go
@@ -135,6 +135,7 @@ func downloadDataSet(ctx context.Context, dataFolder string, force bool, reader 
 			d := downloader.
 				New().
 				WithHTTPClient(cwhub.HubClient).
+				WithMakeDirs(true).
 				ToFile(destPath).
 				CompareContent().
 				BeforeRequest(func(req *http.Request) {


### PR DESCRIPTION
 - Allow appsec-rules to use glob patterns when loading seclang files with the `seclang_files_rules` directive
 - Allow datafiles to be downloaded to subdirectories of the hub datadir
 
 Both changes are required to implement support for CRS plugins (see https://github.com/crowdsecurity/sec-lists/pull/105/files and [FIXME-UPDATE-LINK-WHEN-HUB-PR-READY]())