### PR TITLE
decisionStream: only select required fields from the DB

### DIFF
--- a/pkg/database/decisions.go
+++ b/pkg/database/decisions.go
@@ -26,9 +26,13 @@ type DecisionsByScenario struct {
 }
 
 func (c *Client) QueryAllDecisionsWithFilters(ctx context.Context, filter map[string][]string) ([]*ent.Decision, error) {
-	query := c.Ent.Decision.Query().Where(
-		decision.UntilGT(time.Now().UTC()),
-	)
+	// Do not select all fields.
+	// This can get pretty expensive network-wise if there are a lot of decisions and you are using a remote database
+	query := c.Ent.Decision.Query().
+		Select(decision.FieldID, decision.FieldUntil, decision.FieldScenario, decision.FieldScope, decision.FieldValue, decision.FieldType, decision.FieldOrigin, decision.FieldUUID).
+		Where(
+			decision.UntilGT(time.Now().UTC()),
+		)
 	// Allow a bouncer to ask for non-deduplicated results
 	if v, ok := filter["dedup"]; !ok || v[0] != "false" {
 		query = query.Where(longestDecisionForScopeTypeValue)
@@ -52,9 +56,11 @@ func (c *Client) QueryAllDecisionsWithFilters(ctx context.Context, filter map[st
 }
 
 func (c *Client) QueryExpiredDecisionsWithFilters(ctx context.Context, filter map[string][]string) ([]*ent.Decision, error) {
-	query := c.Ent.Decision.Query().Where(
-		decision.UntilLT(time.Now().UTC()),
-	)
+	query := c.Ent.Decision.Query().
+		Select(decision.FieldID, decision.FieldUntil, decision.FieldScenario, decision.FieldScope, decision.FieldValue, decision.FieldType, decision.FieldOrigin, decision.FieldUUID).
+		Where(
+			decision.UntilLT(time.Now().UTC()),
+		)
 	// Allow a bouncer to ask for non-deduplicated results
 	if v, ok := filter["dedup"]; !ok || v[0] != "false" {
 		query = query.Where(longestDecisionForScopeTypeValue)


### PR DESCRIPTION
When querying a remote database with a lot of decisions, the number of columns we select can have a big impact on performance.

During testing, a startup request to a LAPI using a DB hosted on AWS with around 200k decisions took between 1.3 and 1.5s.
With this change, the duration went down to between 700 and 900ms (the gains will vary a lot depending on the exact user setup, but it will help in all cases).

This should also slightly help with memory usage when a lot of bouncers are querying, as we won't be loading unnecessary data in memory.