### PR TITLE
lint: enable perfsprint micro-optimizations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -170,10 +170,23 @@ linters:
         - waitgroup
 
     perfsprint:
+      # Optimizes even if it requires an int or uint type cast.
+      # Default: true
+      int-conversion: true
+      # Optimizes into `err.Error()` even if it is only equivalent for non-nil errors.
+      # Default: false
+      err-error: false
+      # Optimizes `fmt.Errorf`.
+      # Default: true
+      errorf: true
+      # Optimizes `fmt.Sprintf` with only one argument.
+      # Default: true
+      sprintf1: true
+      # Optimizes into strings concatenation.
+      # Default: true
+      strconcat: false
+      # string concatenation in a loop
       concat-loop: false
-      hex-format: false
-      integer-format: false
-      string-format: false
 
     unused:
       # Mark all struct fields that have been written to as used.

--- a/pkg/acquisition/modules/appsec/utils.go
+++ b/pkg/acquisition/modules/appsec/utils.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"strconv"
 	"time"
 
 	"github.com/oschwald/geoip2-golang"
@@ -62,7 +63,7 @@ func AppsecEventGenerationGeoIPEnrich(src *models.Source) error {
 	} else if asndata != nil {
 		record := asndata.(*geoip2.ASN)
 		src.AsName = record.AutonomousSystemOrganization
-		src.AsNumber = fmt.Sprintf("%d", record.AutonomousSystemNumber)
+		src.AsNumber = strconv.FormatUint(uint64(record.AutonomousSystemNumber), 10)
 	}
 
 	cityData, err := exprhelpers.GeoIPEnrich(src.IP)
@@ -422,7 +423,7 @@ func (r *AppsecRunner) AccumulateTxToEvent(evt *pipeline.Event, state *appsec.Ap
 		var name string
 		version := ""
 		hash := ""
-		ruleNameProm := fmt.Sprintf("%d", rule.Rule().ID())
+		ruleNameProm := strconv.Itoa(rule.Rule().ID())
 
 		if details, ok := appsec.AppsecRulesDetails[rule.Rule().ID()]; ok {
 			// Only set them for custom rules, not for rules written in seclang

--- a/pkg/apiserver/middlewares/v1/api_key.go
+++ b/pkg/apiserver/middlewares/v1/api_key.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/netip"
@@ -79,7 +80,7 @@ func HashSHA512(str string) string {
 	hashedKey := sha512.New()
 	hashedKey.Write([]byte(str))
 
-	hashStr := fmt.Sprintf("%x", hashedKey.Sum(nil))
+	hashStr := hex.EncodeToString(hashedKey.Sum(nil))
 
 	return hashStr
 }

--- a/pkg/appsec/appsec_rule/modsecurity.go
+++ b/pkg/appsec/appsec_rule/modsecurity.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"strconv"
 	"strings"
 
 	cztypes "github.com/corazawaf/coraza/v3/types"
@@ -94,7 +95,7 @@ func (m *ModsecurityRule) generateRuleID(rule *CustomRule, appsecRuleName string
 	h.Write([]byte(appsecRuleName))
 	h.Write([]byte(rule.Match.Type))
 	h.Write([]byte(rule.Match.Value))
-	h.Write([]byte(fmt.Sprintf("%d", depth)))
+	h.Write([]byte(strconv.Itoa(depth)))
 	for _, zone := range rule.Zones {
 		h.Write([]byte(zone))
 	}

--- a/pkg/appsec/ja4h/ja4h.go
+++ b/pkg/appsec/ja4h/ja4h.go
@@ -2,6 +2,7 @@ package ja4h
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"slices"
@@ -120,7 +121,7 @@ func jA4H_b(req *http.Request) string {
 // hashTruncated computes a truncated SHA256 hash for the given input.
 func hashTruncated(input string) string {
 	hash := sha256.Sum256([]byte(input))
-	return fmt.Sprintf("%x", hash)[:truncatedHashLength]
+	return hex.EncodeToString(hash[:])[:truncatedHashLength]
 }
 
 // jA4H_c computes a truncated SHA256 hash of sorted cookie names.

--- a/pkg/cticlient/client.go
+++ b/pkg/cticlient/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient/useragent"
@@ -129,7 +130,7 @@ func (c *CrowdsecCTIClient) Fire(params FireParams) (*FireResponse, error) {
 	paramsMap := make(map[string]string)
 
 	if params.Page != nil {
-		paramsMap["page"] = fmt.Sprintf("%d", *params.Page)
+		paramsMap["page"] = strconv.Itoa(*params.Page)
 	}
 
 	if params.Since != nil {
@@ -137,7 +138,7 @@ func (c *CrowdsecCTIClient) Fire(params FireParams) (*FireResponse, error) {
 	}
 
 	if params.Limit != nil {
-		paramsMap["limit"] = fmt.Sprintf("%d", *params.Limit)
+		paramsMap["limit"] = strconv.Itoa(*params.Limit)
 	}
 
 	body, err := c.doRequest(ctx, http.MethodGet, fireEndpoint, paramsMap)

--- a/pkg/longpollclient/client.go
+++ b/pkg/longpollclient/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -54,7 +55,7 @@ const timeoutMessage = "no events before timeout"
 func (c *LongPollClient) doQuery(ctx context.Context) (*http.Response, error) {
 	logger := c.logger.WithField("method", "doQuery")
 	query := c.url.Query()
-	query.Set("since_time", fmt.Sprintf("%d", c.since))
+	query.Set("since_time", strconv.FormatInt(c.since, 10))
 	query.Set("timeout", c.timeout)
 	c.url.RawQuery = query.Encode()
 


### PR DESCRIPTION
replace Sprintf with faster strconv