### PR TITLE
Fix avoidable prometheus metrics cardinality

### DIFF
--- a/pkg/apiserver/controllers/v1/metrics.go
+++ b/pkg/apiserver/controllers/v1/metrics.go
@@ -32,7 +32,7 @@ func PrometheusMachinesMiddleware() gin.HandlerFunc {
 		if machineID != "" {
 			metrics.LapiMachineHits.With(prometheus.Labels{
 				"machine": machineID,
-				"route":   c.Request.URL.Path,
+				"route":   c.FullPath(),
 				"method":  c.Request.Method,
 			}).Inc()
 		}
@@ -47,7 +47,7 @@ func PrometheusBouncersMiddleware() gin.HandlerFunc {
 		if bouncer != nil {
 			metrics.LapiBouncerHits.With(prometheus.Labels{
 				"bouncer": bouncer.Name,
-				"route":   c.Request.URL.Path,
+				"route":   c.FullPath(),
 				"method":  c.Request.Method,
 			}).Inc()
 		}
@@ -61,12 +61,12 @@ func PrometheusMiddleware() gin.HandlerFunc {
 		startTime := time.Now()
 
 		metrics.LapiRouteHits.With(prometheus.Labels{
-			"route":  c.Request.URL.Path,
+			"route":  c.FullPath(),
 			"method": c.Request.Method,
 		}).Inc()
 		c.Next()
 
 		elapsed := time.Since(startTime)
-		metrics.LapiResponseTime.With(prometheus.Labels{"method": c.Request.Method, "endpoint": c.Request.URL.Path}).Observe(elapsed.Seconds())
+		metrics.LapiResponseTime.With(prometheus.Labels{"method": c.Request.Method, "endpoint": c.FullPath()}).Observe(elapsed.Seconds())
 	}
 }


### PR DESCRIPTION
I am running decently sized crowdsec setup (more than 100k active decisions simultaneously) with significant proportion of bans added using cscli. Also, my setup requires collection of Prometheus full metrics to collect historical data regarding popularity of some decisions.

All of the above contributes to extremely large size of resulting metrics endpoint response (more than tens of megabytes), as well as RAM overhead (see screenshot 1). After manual inspection I have noticed that the problematic metrics include `cs_lapi_machine_requests_total` like these:

```
cs_lapi_machine_requests_total{machine="[redacted]",method="GET",route="/v1/allowlists/check/192.0.2.1"} 1
cs_lapi_machine_requests_total{machine="[redacted]",method="GET",route="/v1/allowlists/check/192.0.2.2"} 1
```

I would like to argue usefulness of exposing raw URL in metrics including query parameters like IP addresses specified above.

Instead, I propose to use `func (c *Context) FullPath() string` instead (available since gin-gonic/gin v1.5.0 so this change could be backported). It returns a matched route full path instead of raw URL as in original request, therefore preventing unnecessary overhead and too high labels cardinality for setups configured to offer full Prometheus metrics level without aggregation (which in fact removes some metrics instead).

I expect this to be not a breaking change.

<details><summary>Screenshot 1</summary>
<p>

<img width="1835" height="675" alt="image" src="https://github.com/user-attachments/assets/5d3b9368-e888-4f7f-9ed4-36e1c6b99a88" />

Before / after this patch in my setup

</p>
</details> 