### PR TITLE
feat(appsec): support transaction id header for request tracing

### DIFF
--- a/pkg/appsec/request.go
+++ b/pkg/appsec/request.go
@@ -25,6 +25,7 @@ const (
 	APIKeyHeaderName      = "X-Crowdsec-Appsec-Api-Key"
 	UserAgentHeaderName   = "X-Crowdsec-Appsec-User-Agent"
 	HTTPVersionHeaderName = "X-Crowdsec-Appsec-Http-Version"
+	TransactionIDHeaderName = "X-Crowdsec-Appsec-Transaction-Id"
 )
 
 type ParsedRequest struct {
@@ -320,6 +321,12 @@ func NewParsedRequestFromRequest(r *http.Request, logger *log.Entry) (ParsedRequ
 
 	userAgent := r.Header.Get(UserAgentHeaderName) //This one is optional
 
+	// Extract transaction ID from header if present, otherwise generate a new UUID
+	transactionID := r.Header.Get(TransactionIDHeaderName)
+	if transactionID == "" {
+		transactionID = uuid.New().String()
+	}
+
 	httpVersion := r.Header.Get(HTTPVersionHeaderName)
 	if httpVersion == "" {
 		logger.Debugf("missing '%s' header", HTTPVersionHeaderName)
@@ -350,6 +357,7 @@ func NewParsedRequestFromRequest(r *http.Request, logger *log.Entry) (ParsedRequ
 	delete(r.Header, UserAgentHeaderName)
 	delete(r.Header, APIKeyHeaderName)
 	delete(r.Header, HTTPVersionHeaderName)
+	delete(r.Header, TransactionIDHeaderName)
 
 	originalHTTPRequest := r.Clone(r.Context())
 	originalHTTPRequest.Body = io.NopCloser(bytes.NewBuffer(body))
@@ -394,7 +402,7 @@ func NewParsedRequestFromRequest(r *http.Request, logger *log.Entry) (ParsedRequ
 
 	return ParsedRequest{
 		RemoteAddr:           r.RemoteAddr,
-		UUID:                 uuid.New().String(),
+		UUID:                 transactionID,
 		ClientHost:           clientHost,
 		ClientIP:             clientIP,
 		URI:                  clientURI,


### PR DESCRIPTION
fix #3997

Allow incoming HTTP requests to provide a custom transaction ID via `X-Crowdsec-Appsec-Transaction-Id` header. This ID will be used for both inband and outband processing, enabling consistent request tracing across web server logs and CrowdSec logs.

- Extract transaction ID from `X-Crowdsec-Appsec-Transaction-Id` header if present
- Fall back to generating UUID if header is not provided (backward compatible)
- Remove header before passing to Coraza (consistent with other special headers)
- Same transaction ID used for both inband and outband Coraza transactions