### PR TITLE
refactor(apic): reduce LAPI client debug log verbosity

### DIFF
--- a/pkg/apiclient/auth_jwt.go
+++ b/pkg/apiclient/auth_jwt.go
@@ -49,7 +49,7 @@ func (t *JWTTransport) refreshJwtToken(ctx context.Context) error {
 			return fmt.Errorf("can't update scenario list: %w", err)
 		}
 
-		log.Debugf("scenarios list updated for '%s'", *t.MachineID)
+		log.Tracef("scenarios list updated for '%s'", *t.MachineID)
 	}
 
 	auth := models.WatcherAuthRequest{
@@ -117,7 +117,7 @@ func (t *JWTTransport) refreshJwtToken(ctx context.Context) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		log.Debugf("received response status %q when fetching %v", resp.Status, req.URL)
+		log.Tracef("received response status %q when fetching %v", resp.Status, req.URL)
 
 		err = CheckResponse(resp)
 		if err != nil {
@@ -144,7 +144,9 @@ func (t *JWTTransport) refreshJwtToken(ctx context.Context) error {
 		}
 	}
 
-	log.Debugf("token %s will expire on %s", t.Token, t.Expiration.String())
+	if log.IsLevelEnabled(log.TraceLevel) {
+		log.Tracef("token %s will expire on %s", t.Token, t.Expiration.String())
+	}
 
 	select {
 	case t.TokenRefreshChan <- struct{}{}:
@@ -211,7 +213,7 @@ func (t *JWTTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 
 		if resp != nil {
-			log.Debugf("resp-jwt: %d", resp.StatusCode)
+			log.Debugf("resp-jwt: http %d", resp.StatusCode)
 		}
 
 		config, shouldRetry := t.RetryConfig.StatusCodeConfig[resp.StatusCode]

--- a/pkg/apiclient/client_http.go
+++ b/pkg/apiclient/client_http.go
@@ -114,14 +114,14 @@ func (c *ApiClient) Do(ctx context.Context, req *http.Request, v any) (*Response
 		return newResponse(resp), err
 	}
 
-	if log.IsLevelEnabled(log.DebugLevel) {
+	if log.IsLevelEnabled(log.TraceLevel) {
 		for k, v := range resp.Header {
-			log.Debugf("[headers] %s: %s", k, v)
+			log.Tracef("[headers] %s: %s", k, v)
 		}
 
 		dump, err := httputil.DumpResponse(resp, true)
 		if err == nil {
-			log.Debugf("Response: %s", string(dump))
+			log.Tracef("Response: %s", string(dump))
 		}
 	}
 


### PR DESCRIPTION
Move verbose debug logs to trace level:
- Headers loop and full response dumps in client_http.go
- Token expiration and scenario update messages in auth_jwt.go
- Error response status messages in auth_jwt.go

Keep essential debug info (request URLs, response codes) visible. Standardize response code format to 'http %d' for consistency.