### PR TITLE
CI: avoid using nolint with revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -337,6 +337,8 @@ linters:
       severity: error
       enable-all-rules: true
       rules:
+        - name: argument-limit
+          arguments: [9]
         - name: add-constant
           disabled: true
         - name: cognitive-complexity
@@ -596,6 +598,11 @@ linters:
         text: 'deep-exit: .*'
 
       - linters:
+          - revive
+        path: cmd/crowdsec-cli/clisetup/setup/systemd_test.go
+        text: 'deep-exit: .*'
+
+      - linters:
           - gocritic
         path: cmd/crowdsec-cli
         text: 'rangeValCopy: .*'
@@ -614,11 +621,6 @@ linters:
           - gocritic
         path: pkg/(appsec|acquisition|dumps|alertcontext|leakybucket|exprhelpers)
         text: 'rangeValCopy: .*'
-
-      - linters:
-          - revive
-        path: pkg/logging/configure.go
-        text: 'argument-limit: .*'
 
       - linters:
           - usetesting

--- a/cmd/crowdsec-cli/clidecision/decisions.go
+++ b/cmd/crowdsec-cli/clidecision/decisions.go
@@ -261,7 +261,6 @@ cscli decisions list --origin lists --scenario list_name
 	return cmd
 }
 
-//nolint:revive // we'll reduce the number of args later
 func (cli *cliDecisions) add(ctx context.Context, addIP, addRange, addDuration, addValue, addScope, addReason, addType string, bypassAllowlist bool) error {
 	alerts := models.AddAlertsRequest{}
 	origin := types.CscliOrigin

--- a/cmd/crowdsec-cli/clisetup/setup/systemd_test.go
+++ b/cmd/crowdsec-cli/clisetup/setup/systemd_test.go
@@ -38,7 +38,7 @@ func TestHelperProcess(_ *testing.T) {
 	}
 
 	if i >= len(args) {
-		os.Exit(2) //nolint:revive
+		os.Exit(2)
 	}
 
 	if args[i] == "systemctl" && i+1 < len(args) {
@@ -54,7 +54,7 @@ func TestHelperProcess(_ *testing.T) {
 			fmt.Fprint(os.Stdout, "Names="+unit+"\n")
 			fmt.Fprint(os.Stdout, "StandardOutput=journal\n")
 			fmt.Fprint(os.Stdout, "StandardError=journal\n")
-			os.Exit(0) //nolint:revive
+			os.Exit(0)
 		case "list-unit-files":
 			// systemctl list-unit-files --type=service
 			//nolint:dupword
@@ -64,7 +64,7 @@ apache2.service                           enabled  enabled
 apparmor.service                          enabled  enabled
 
 3 unit files listed.`)
-			os.Exit(0) //nolint:revive
+			os.Exit(0)
 		}
 	}
 }

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -81,7 +81,8 @@ func isBrokenConnection(maybeError any) bool {
 }
 
 func recoverFromPanic(c *gin.Context) {
-	err := recover() //nolint:revive
+	//revive:disable-next-line:defer
+	err := recover()
 	if err == nil {
 		return
 	}

--- a/pkg/apiserver/middlewares/v1/cache.go
+++ b/pkg/apiserver/middlewares/v1/cache.go
@@ -52,7 +52,8 @@ func (rc *RevocationCache) purgeExpired() {
 	}
 }
 
-func (rc *RevocationCache) Get(cert *x509.Certificate) (error, bool) { //nolint:revive
+//revive:disable-next-line:error-return
+func (rc *RevocationCache) Get(cert *x509.Certificate) (error, bool) {
 	rc.purgeExpired()
 	key := rc.generateKey(cert)
 	rc.mu.RLock()

--- a/pkg/apiserver/middlewares/v1/tls_auth.go
+++ b/pkg/apiserver/middlewares/v1/tls_auth.go
@@ -37,7 +37,8 @@ func (ta *TLSAuth) isExpired(cert *x509.Certificate) bool {
 }
 
 // checkRevocationPath checks a single chain against OCSP and CRL
-func (ta *TLSAuth) checkRevocationPath(ctx context.Context, chain []*x509.Certificate) (error, bool) { //nolint:revive
+//revive:disable-next-line:error-return
+func (ta *TLSAuth) checkRevocationPath(ctx context.Context, chain []*x509.Certificate) (error, bool) {
 	// if we ever fail to check OCSP or CRL, we should not cache the result
 	couldCheck := true
 

--- a/pkg/csplugin/hclog_adapter.go
+++ b/pkg/csplugin/hclog_adapter.go
@@ -234,5 +234,7 @@ func safeString(str fmt.Stringer) (s string) {
 	} else {
 		s = str.String()
 	}
-	return //nolint:revive // bare return for the defer
+
+	//revive:disable-next-line:bare-return
+	return // bare return is required for the defer
 }

--- a/pkg/dumps/parser_dump.go
+++ b/pkg/dumps/parser_dump.go
@@ -225,7 +225,8 @@ func (t *tree) displayResults(opts DumpOpts) {
 						case "update":
 							detailsDisplay += fmt.Sprintf("\t%s\t\t%s %s evt.%s : %s -> %s\n", presep, sep, change.Type, strings.Join(change.Path, "."), change.From, yellow(change.To))
 
-							if change.Path[0] == "Whitelisted" && change.To == true { //nolint:revive
+							//revive:disable-next-line:bool-literal-in-expr
+							if change.Path[0] == "Whitelisted" && change.To == true {
 								whitelisted = true
 
 								if whitelistReason == "" {

--- a/pkg/leakybucket/overflows.go
+++ b/pkg/leakybucket/overflows.go
@@ -361,7 +361,8 @@ func NewAlert(leaky *Leaky, queue *pipeline.Queue) (pipeline.RuntimeAlert, error
 		srcCopy := srcValue
 		newApiAlert.Source = &srcCopy
 
-		if v, ok := leaky.BucketConfig.Labels["remediation"]; ok && v == true { //nolint:revive
+		//revive:disable-next-line:bool-literal-in-expr
+		if v, ok := leaky.BucketConfig.Labels["remediation"]; ok && v == true {
 			newApiAlert.Remediation = true
 		}
 


### PR DESCRIPTION
The "nolinlint" checks are flaky with revive checks, triggering false positives.
So we use revive-specific comments or exclusions in .golangci.yml