### PR TITLE
docker: add default healthcheck to container images

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -49,6 +49,9 @@ COPY --from=build /go/src/crowdsec/build/docker/config.yaml /staging/etc/crowdse
 COPY --from=build /var/lib/crowdsec /staging/var/lib/crowdsec
 RUN yq -n '.url="http://0.0.0.0:8080"' | install -m 0600 /dev/stdin /staging/etc/crowdsec/local_api_credentials.yaml
 
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 --start-period=30s \
+    CMD cscli lapi status
+
 ENTRYPOINT ["/bin/bash", "/docker_start.sh"]
 
 FROM slim AS full

--- a/build/docker/Dockerfile.debian
+++ b/build/docker/Dockerfile.debian
@@ -66,6 +66,9 @@ COPY --from=build /go/src/crowdsec/build/docker/config.yaml /staging/etc/crowdse
 RUN yq -n '.url="http://0.0.0.0:8080"' | install -m 0600 /dev/stdin /staging/etc/crowdsec/local_api_credentials.yaml && \
     yq eval -i ".plugin_config.group = \"nogroup\"" /staging/etc/crowdsec/config.yaml
 
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 --start-period=30s \
+    CMD cscli lapi status
+
 ENTRYPOINT ["/bin/bash", "docker_start.sh"]
 
 FROM slim AS plugins


### PR DESCRIPTION
Adds HEALTHCHECK instruction using `cscli lapi status` to verify the local API is responding.

Related to #4160
Related to #3603