### PR TITLE
cscli hubtest: extract method finalizeRun()

### DIFF
--- a/cmd/crowdsec-cli/clihubtest/run.go
+++ b/cmd/crowdsec-cli/clihubtest/run.go
@@ -74,6 +74,101 @@ func (cli *cliHubTest) run(ctx context.Context, all bool, nucleiTargetHost strin
 	return eg.Wait()
 }
 
+func (cli *cliHubTest) finalizeRun(noClean bool, forceClean bool, reportSuccess bool) error {
+	cfg := cli.cfg()
+
+	success := true
+	testMap := make(map[string]*hubtest.HubTestItem)
+
+	for _, test := range hubPtr.Tests {
+		if test.AutoGen && !isAppsecTest {
+			if test.ParserAssert.AutoGenAssert {
+			log.Warningf("Assert file '%s' is empty, generating assertion:", test.ParserAssert.File)
+				fmt.Fprintln(os.Stdout)
+				fmt.Fprintln(os.Stdout, test.ParserAssert.AutoGenAssertData)
+			}
+
+			if test.ScenarioAssert.AutoGenAssert {
+				log.Warningf("Assert file '%s' is empty, generating assertion:", test.ScenarioAssert.File)
+				fmt.Fprintln(os.Stdout)
+				fmt.Fprintln(os.Stdout, test.ScenarioAssert.AutoGenAssertData)
+			}
+
+			if !noClean {
+				test.Clean()
+			}
+
+			return fmt.Errorf("please fill your assert file(s) for test '%s', exiting", test.Name)
+		}
+
+		testMap[test.Name] = test
+
+		if test.Success {
+			if !noClean {
+				test.Clean()
+			}
+		} else {
+			success = false
+			cleanTestEnv := false
+
+			if cfg.Cscli.Output == "human" {
+				printParserFailures(test)
+				printScenarioFailures(test)
+
+				if !forceClean && !noClean {
+					prompt := &survey.Confirm{
+						Message: fmt.Sprintf("Do you want to remove runtime and result folder for '%s'?", test.Name),
+						Default: true,
+					}
+					if err := survey.AskOne(prompt, &cleanTestEnv); err != nil {
+						return fmt.Errorf("unable to ask to remove runtime folder: %w", err)
+					}
+				}
+			}
+
+			if cleanTestEnv || forceClean {
+				test.Clean()
+			}
+		}
+	}
+
+	switch cfg.Cscli.Output {
+	case "human":
+		hubTestResultTable(color.Output, cfg.Cscli.Color, testMap, reportSuccess)
+	case "json":
+		jsonResult := make(map[string][]string, 0)
+		jsonResult["success"] = make([]string, 0)
+		jsonResult["fail"] = make([]string, 0)
+
+		for testName, test := range testMap {
+			if test.Success {
+				jsonResult["success"] = append(jsonResult["success"], testName)
+			} else {
+				jsonResult["fail"] = append(jsonResult["fail"], testName)
+			}
+		}
+
+		jsonStr, err := json.Marshal(jsonResult)
+		if err != nil {
+			return fmt.Errorf("unable to json test result: %w", err)
+		}
+
+		fmt.Fprintln(os.Stdout, string(jsonStr))
+	default:
+		return errors.New("only human/json output modes are supported")
+	}
+
+	if !success {
+		if reportSuccess {
+			return errors.New("some tests failed")
+		}
+
+		return errors.New("some tests failed, use --report-success to show them all")
+	}
+
+	return nil
+}
+
 func printParserFailures(test *hubtest.HubTestItem) {
 	if len(test.ParserAssert.Fails) == 0 {
 		return
@@ -135,101 +230,11 @@ func (cli *cliHubTest) newRunCmd() *cobra.Command {
 				fmt.Fprintf(os.Stdout, "Running all tests (max_jobs: %d)\n", maxJobs)
 			}
 
-			return cli.run(cmd.Context(), all, nucleiTargetHost, appSecHost, args, maxJobs)
-		},
-		PersistentPostRunE: func(_ *cobra.Command, _ []string) error {
-			cfg := cli.cfg()
-
-			success := true
-			testMap := make(map[string]*hubtest.HubTestItem)
-
-			for _, test := range hubPtr.Tests {
-				if test.AutoGen && !isAppsecTest {
-					if test.ParserAssert.AutoGenAssert {
-						log.Warningf("Assert file '%s' is empty, generating assertion:", test.ParserAssert.File)
-						fmt.Fprintln(os.Stdout)
-						fmt.Fprintln(os.Stdout, test.ParserAssert.AutoGenAssertData)
-					}
-
-					if test.ScenarioAssert.AutoGenAssert {
-						log.Warningf("Assert file '%s' is empty, generating assertion:", test.ScenarioAssert.File)
-						fmt.Fprintln(os.Stdout)
-						fmt.Fprintln(os.Stdout, test.ScenarioAssert.AutoGenAssertData)
-					}
-
-					if !noClean {
-						test.Clean()
-					}
-
-					return fmt.Errorf("please fill your assert file(s) for test '%s', exiting", test.Name)
-				}
-
-				testMap[test.Name] = test
-
-				if test.Success {
-					if !noClean {
-						test.Clean()
-					}
-				} else {
-					success = false
-					cleanTestEnv := false
-
-					if cfg.Cscli.Output == "human" {
-						printParserFailures(test)
-						printScenarioFailures(test)
-
-						if !forceClean && !noClean {
-							prompt := &survey.Confirm{
-								Message: fmt.Sprintf("Do you want to remove runtime and result folder for '%s'?", test.Name),
-								Default: true,
-							}
-							if err := survey.AskOne(prompt, &cleanTestEnv); err != nil {
-								return fmt.Errorf("unable to ask to remove runtime folder: %w", err)
-							}
-						}
-					}
-
-					if cleanTestEnv || forceClean {
-						test.Clean()
-					}
-				}
+			if err := cli.run(cmd.Context(), all, nucleiTargetHost, appSecHost, args, maxJobs); err != nil {
+				return err
 			}
 
-			switch cfg.Cscli.Output {
-			case "human":
-				hubTestResultTable(color.Output, cfg.Cscli.Color, testMap, reportSuccess)
-			case "json":
-				jsonResult := make(map[string][]string, 0)
-				jsonResult["success"] = make([]string, 0)
-				jsonResult["fail"] = make([]string, 0)
-
-				for testName, test := range testMap {
-					if test.Success {
-						jsonResult["success"] = append(jsonResult["success"], testName)
-					} else {
-						jsonResult["fail"] = append(jsonResult["fail"], testName)
-					}
-				}
-
-				jsonStr, err := json.Marshal(jsonResult)
-				if err != nil {
-					return fmt.Errorf("unable to json test result: %w", err)
-				}
-
-				fmt.Fprintln(os.Stdout, string(jsonStr))
-			default:
-				return errors.New("only human/json output modes are supported")
-			}
-
-			if !success {
-				if reportSuccess {
-					return errors.New("some tests failed")
-				}
-
-				return errors.New("some tests failed, use --report-success to show them all")
-			}
-
-			return nil
+			return cli.finalizeRun(noClean, forceClean, reportSuccess)
 		},
 	}
 


### PR DESCRIPTION
there's no reason for it to be a persistent hook, "run" does not have subcommands