### PR TITLE
pkg/acquisition: method docs, deduplicate module names

### DIFF
--- a/pkg/acquisition/modules/appsec/init.go
+++ b/pkg/acquisition/modules/appsec/init.go
@@ -14,7 +14,9 @@ var (
 	_ types.LAPIClientAware = (*Source)(nil)
 )
 
+const ModuleName = "appsec"
+
 //nolint:gochecknoinits
 func init() {
-	registry.RegisterFactory("appsec", func() types.DataSource { return &Source{} })
+	registry.RegisterFactory(ModuleName, func() types.DataSource { return &Source{} })
 }

--- a/pkg/acquisition/modules/appsec/source.go
+++ b/pkg/acquisition/modules/appsec/source.go
@@ -78,7 +78,7 @@ func (w *Source) GetMode() string {
 }
 
 func (*Source) GetName() string {
-	return "appsec"
+	return ModuleName
 }
 
 func (*Source) CanRun() error {

--- a/pkg/acquisition/modules/appsec/utils.go
+++ b/pkg/acquisition/modules/appsec/utils.go
@@ -305,8 +305,8 @@ func EventFromRequest(r *appsec.ParsedRequest, labels map[string]string, txUuid 
 		// should we add some info like listen addr/port/path ?
 		Labels:  labels,
 		Process: true,
-		Module:  "appsec",
-		Src:     "appsec",
+		Module:  ModuleName,
+		Src:     ModuleName,
 		Raw:     "dummy-appsec-data", // we discard empty Line.Raw items :)
 	}
 	evt.Appsec = pipeline.AppsecEvent{}
@@ -322,19 +322,19 @@ func LogAppsecEvent(evt *pipeline.Event, logger *log.Entry) {
 
 	if evt.Meta["appsec_interrupted"] == "true" {
 		logger.WithFields(log.Fields{
-			"module":     "appsec",
+			"module":     ModuleName,
 			"source":     evt.Parsed["source_ip"],
 			"target_uri": req,
 		}).Infof("%s blocked on %s (%d rules) [%v]", evt.Parsed["source_ip"], req, len(evt.Appsec.MatchedRules), evt.Appsec.GetRuleIDs())
 	} else if evt.Parsed["outofband_interrupted"] == "true" {
 		logger.WithFields(log.Fields{
-			"module":     "appsec",
+			"module":     ModuleName,
 			"source":     evt.Parsed["source_ip"],
 			"target_uri": req,
 		}).Infof("%s out-of-band blocking rules on %s (%d rules) [%v]", evt.Parsed["source_ip"], req, len(evt.Appsec.MatchedRules), evt.Appsec.GetRuleIDs())
 	} else {
 		logger.WithFields(log.Fields{
-			"module":     "appsec",
+			"module":     ModuleName,
 			"source":     evt.Parsed["source_ip"],
 			"target_uri": req,
 		}).Debugf("%s triggered non-blocking rules on %s (%d rules) [%v]", evt.Parsed["source_ip"], req, len(evt.Appsec.MatchedRules), evt.Appsec.GetRuleIDs())

--- a/pkg/acquisition/modules/cloudwatch/init.go
+++ b/pkg/acquisition/modules/cloudwatch/init.go
@@ -14,7 +14,9 @@ var (
 	_ types.MetricsProvider = (*Source)(nil)
 )
 
+const ModuleName = "cloudwatch"
+
 //nolint:gochecknoinits
 func init() {
-	registry.RegisterFactory("cloudwatch", func() types.DataSource { return &Source{} })
+	registry.RegisterFactory(ModuleName, func() types.DataSource { return &Source{} })
 }

--- a/pkg/acquisition/modules/cloudwatch/source.go
+++ b/pkg/acquisition/modules/cloudwatch/source.go
@@ -29,7 +29,7 @@ func (s *Source) GetMode() string {
 }
 
 func (*Source) GetName() string {
-	return "cloudwatch"
+	return ModuleName
 }
 
 func (*Source) CanRun() error {

--- a/pkg/acquisition/modules/docker/docker_test.go
+++ b/pkg/acquisition/modules/docker/docker_test.go
@@ -126,7 +126,7 @@ service_id_regexp:
 		},
 	}
 
-	subLogger := log.WithField("type", "docker")
+	subLogger := log.WithField("type", ModuleName)
 
 	for _, tc := range tests {
 		t.Run(tc.config, func(t *testing.T) {
@@ -186,7 +186,7 @@ func TestConfigureDSN(t *testing.T) {
 			expectedErr: "",
 		},
 	}
-	subLogger := log.WithField("type", "docker")
+	subLogger := log.WithField("type", ModuleName)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -335,7 +335,7 @@ service_name_regexp:
 
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			subLogger := log.WithField("type", "docker")
+			subLogger := log.WithField("type", ModuleName)
 
 			dockerTomb := tomb.Tomb{}
 			out := make(chan pipeline.Event)
@@ -486,7 +486,7 @@ use_service_labels: true`,
 		},
 	}
 
-	subLogger := log.WithField("type", "docker")
+	subLogger := log.WithField("type", ModuleName)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -563,7 +563,7 @@ service_name:
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			subLogger := log.WithField("type", "docker")
+			subLogger := log.WithField("type", ModuleName)
 			f := Source{
 				Client: &mockDockerCli{},
 			}
@@ -690,7 +690,7 @@ func TestOneShot(t *testing.T) {
 
 	for _, ts := range tests {
 		t.Run(ts.dsn, func(t *testing.T) {
-			subLogger := log.WithField("type", "docker")
+			subLogger := log.WithField("type", ModuleName)
 
 			dockerClient := &Source{}
 			labels := make(map[string]string)

--- a/pkg/acquisition/modules/docker/init.go
+++ b/pkg/acquisition/modules/docker/init.go
@@ -14,7 +14,9 @@ var (
 	_ types.MetricsProvider = (*Source)(nil)
 )
 
+const ModuleName = "docker"
+
 //nolint:gochecknoinits
 func init() {
-	registry.RegisterFactory("docker", func() types.DataSource { return &Source{} })
+	registry.RegisterFactory(ModuleName, func() types.DataSource { return &Source{} })
 }

--- a/pkg/acquisition/modules/docker/run.go
+++ b/pkg/acquisition/modules/docker/run.go
@@ -97,7 +97,7 @@ func (d *Source) OneShotAcquisition(ctx context.Context, out chan pipeline.Event
 					l.Module = d.GetName()
 
 					if d.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-						metrics.DockerDatasourceLinesRead.With(prometheus.Labels{"source": containerConfig.Name, "acquis_type": l.Labels["type"], "datasource_type": "docker"}).Inc()
+						metrics.DockerDatasourceLinesRead.With(prometheus.Labels{"source": containerConfig.Name, "acquis_type": l.Labels["type"], "datasource_type": ModuleName}).Inc()
 					}
 
 					evt := pipeline.MakeEvent(true, pipeline.LOG, true)
@@ -668,7 +668,7 @@ func (d *Source) tailContainerAttempt(ctx context.Context, container *ContainerC
 			evt.Line = l
 
 			if d.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-				metrics.DockerDatasourceLinesRead.With(prometheus.Labels{"source": container.Name, "datasource_type": "docker", "acquis_type": evt.Line.Labels["type"]}).Inc()
+				metrics.DockerDatasourceLinesRead.With(prometheus.Labels{"source": container.Name, "datasource_type": ModuleName, "acquis_type": evt.Line.Labels["type"]}).Inc()
 			}
 
 			outChan <- evt
@@ -787,7 +787,7 @@ func (d *Source) tailServiceAttempt(ctx context.Context, service *ContainerConfi
 			evt.Line = l
 
 			if d.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-				metrics.DockerDatasourceLinesRead.With(prometheus.Labels{"source": service.Name, "acquis_type": l.Labels["type"], "datasource_type": "docker"}).Inc()
+				metrics.DockerDatasourceLinesRead.With(prometheus.Labels{"source": service.Name, "acquis_type": l.Labels["type"], "datasource_type": ModuleName}).Inc()
 			}
 
 			outChan <- evt

--- a/pkg/acquisition/modules/docker/source.go
+++ b/pkg/acquisition/modules/docker/source.go
@@ -50,7 +50,7 @@ func (d *Source) GetMode() string {
 }
 
 func (*Source) GetName() string {
-	return "docker"
+	return ModuleName
 }
 
 func (*Source) CanRun() error {

--- a/pkg/acquisition/modules/file/file_test.go
+++ b/pkg/acquisition/modules/file/file_test.go
@@ -58,7 +58,7 @@ filenames: ["ase.log"]`,
 		},
 	}
 
-	subLogger := log.WithField("type", "file")
+	subLogger := log.WithField("type", fileacquisition.ModuleName)
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestConfigureDSN(t *testing.T) {
 		},
 	}
 
-	subLogger := log.WithField("type", "file")
+	subLogger := log.WithField("type", fileacquisition.ModuleName)
 
 	for _, tc := range tests {
 		t.Run(tc.dsn, func(t *testing.T) {
@@ -219,7 +219,7 @@ filename: %s`, deletedFile),
 			logger, hook := test.NewNullLogger()
 			logger.SetLevel(tc.logLevel)
 
-			subLogger := logger.WithField("type", "file")
+			subLogger := logger.WithField("type", fileacquisition.ModuleName)
 
 			out := make(chan pipeline.Event, 100)
 			f := fileacquisition.Source{}
@@ -385,7 +385,7 @@ force_inotify: true`, testPattern),
 			logger, hook := test.NewNullLogger()
 			logger.SetLevel(tc.logLevel)
 
-			subLogger := logger.WithField("type", "file")
+			subLogger := logger.WithField("type", fileacquisition.ModuleName)
 
 			tomb := tomb.Tomb{}
 			out := make(chan pipeline.Event)
@@ -493,7 +493,7 @@ func TestExclusion(t *testing.T) {
 exclude_regexps: ["\\.gz$"]`
 	logger, hook := test.NewNullLogger()
 	// logger.SetLevel(ts.logLevel)
-	subLogger := logger.WithField("type", "file")
+	subLogger := logger.WithField("type", fileacquisition.ModuleName)
 
 	f := fileacquisition.Source{}
 	err := f.Configure(ctx, []byte(config), subLogger, metrics.AcquisitionMetricsLevelNone)

--- a/pkg/acquisition/modules/file/init.go
+++ b/pkg/acquisition/modules/file/init.go
@@ -14,7 +14,9 @@ var (
 	_ types.MetricsProvider = (*Source)(nil)
 )
 
+const ModuleName = "file"
+
 //nolint:gochecknoinits
 func init() {
-	registry.RegisterFactory("file", func() types.DataSource { return &Source{} })
+	registry.RegisterFactory(ModuleName, func() types.DataSource { return &Source{} })
 }

--- a/pkg/acquisition/modules/file/run.go
+++ b/pkg/acquisition/modules/file/run.go
@@ -339,7 +339,7 @@ func (s *Source) tailFile(out chan pipeline.Event, t *tomb.Tomb, tail *tail.Tail
 			}
 
 			if s.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-				metrics.FileDatasourceLinesRead.With(prometheus.Labels{"source": tail.Filename, "datasource_type": "file", "acquis_type": s.config.Labels["type"]}).Inc()
+				metrics.FileDatasourceLinesRead.With(prometheus.Labels{"source": tail.Filename, "datasource_type": ModuleName, "acquis_type": s.config.Labels["type"]}).Inc()
 			}
 
 			src := tail.Filename
@@ -418,7 +418,7 @@ func (s *Source) readFile(ctx context.Context, filename string, out chan pipelin
 				Module:  s.GetName(),
 			}
 			logger.Debugf("line %s", l.Raw)
-			metrics.FileDatasourceLinesRead.With(prometheus.Labels{"source": filename, "datasource_type": "file", "acquis_type": l.Labels["type"]}).Inc()
+			metrics.FileDatasourceLinesRead.With(prometheus.Labels{"source": filename, "datasource_type": ModuleName, "acquis_type": l.Labels["type"]}).Inc()
 
 			// we're reading logs at once, it must be time-machine buckets
 			out <- pipeline.Event{Line: l, Process: true, Type: pipeline.LOG, ExpectMode: pipeline.TIMEMACHINE, Unmarshaled: make(map[string]any)}

--- a/pkg/acquisition/modules/file/source.go
+++ b/pkg/acquisition/modules/file/source.go
@@ -31,7 +31,7 @@ func (s *Source) GetMode() string {
 }
 
 func (*Source) GetName() string {
-	return "file"
+	return ModuleName
 }
 
 func (*Source) CanRun() error {

--- a/pkg/acquisition/modules/http/http_test.go
+++ b/pkg/acquisition/modules/http/http_test.go
@@ -175,9 +175,7 @@ custom_status_code: 999`,
 		},
 	}
 
-	subLogger := log.WithFields(log.Fields{
-		"type": "http",
-	})
+	subLogger := log.WithField("type", ModuleName)
 
 	for _, test := range tests {
 		h := Source{}
@@ -215,9 +213,7 @@ func TestGetName(t *testing.T) {
 
 func SetupAndRunHTTPSource(t *testing.T, h *Source, config []byte, metricLevel metrics.AcquisitionMetricsLevel) (chan pipeline.Event, *prometheus.Registry, *tomb.Tomb) {
 	ctx := t.Context()
-	subLogger := log.WithFields(log.Fields{
-		"type": "http",
-	})
+	subLogger := log.WithField("type", ModuleName)
 	err := h.Configure(ctx, config, subLogger, metricLevel)
 	require.NoError(t, err)
 

--- a/pkg/acquisition/modules/http/init.go
+++ b/pkg/acquisition/modules/http/init.go
@@ -12,7 +12,9 @@ var (
 	_ types.MetricsProvider = (*Source)(nil)
 )
 
+const ModuleName = "http"
+
 //nolint:gochecknoinits
 func init() {
-	registry.RegisterFactory("http", func() types.DataSource { return &Source{} })
+	registry.RegisterFactory(ModuleName, func() types.DataSource { return &Source{} })
 }

--- a/pkg/acquisition/modules/http/run.go
+++ b/pkg/acquisition/modules/http/run.go
@@ -115,9 +115,9 @@ func (s *Source) processRequest(w http.ResponseWriter, r *http.Request, hc *Conf
 
 		switch s.metricsLevel {
 		case metrics.AcquisitionMetricsLevelAggregated:
-			metrics.HTTPDataSourceLinesRead.With(prometheus.Labels{"path": hc.Path, "src": "", "datasource_type": "http", "acquis_type": hc.Labels["type"]}).Inc()
+			metrics.HTTPDataSourceLinesRead.With(prometheus.Labels{"path": hc.Path, "src": "", "datasource_type": ModuleName, "acquis_type": hc.Labels["type"]}).Inc()
 		case metrics.AcquisitionMetricsLevelFull:
-			metrics.HTTPDataSourceLinesRead.With(prometheus.Labels{"path": hc.Path, "src": srcHost, "datasource_type": "http", "acquis_type": hc.Labels["type"]}).Inc()
+			metrics.HTTPDataSourceLinesRead.With(prometheus.Labels{"path": hc.Path, "src": srcHost, "datasource_type": ModuleName, "acquis_type": hc.Labels["type"]}).Inc()
 		case metrics.AcquisitionMetricsLevelNone:
 			// No metrics for this level
 		}

--- a/pkg/acquisition/modules/http/source.go
+++ b/pkg/acquisition/modules/http/source.go
@@ -24,7 +24,7 @@ func (s *Source) GetMode() string {
 }
 
 func (*Source) GetName() string {
-	return "http"
+	return ModuleName
 }
 
 func (*Source) CanRun() error {

--- a/pkg/acquisition/modules/journalctl/init.go
+++ b/pkg/acquisition/modules/journalctl/init.go
@@ -14,7 +14,9 @@ var (
 	_ types.MetricsProvider     = (*Source)(nil)
 )
 
+const ModuleName = "journalctl"
+
 //nolint:gochecknoinits
 func init() {
-	registry.RegisterFactory("journalctl", func() types.DataSource { return &Source{} })
+	registry.RegisterFactory(ModuleName, func() types.DataSource { return &Source{} })
 }

--- a/pkg/acquisition/modules/journalctl/run.go
+++ b/pkg/acquisition/modules/journalctl/run.go
@@ -153,7 +153,7 @@ func (s *Source) runJournalCtl(ctx context.Context, out chan pipeline.Event) err
 			s.logger.Debugf("getting one line: %s", line.Raw)
 
 			if s.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-				metrics.JournalCtlDataSourceLinesRead.With(prometheus.Labels{"source": s.src, "datasource_type": "journalctl", "acquis_type": line.Labels["type"]}).Inc()
+				metrics.JournalCtlDataSourceLinesRead.With(prometheus.Labels{"source": s.src, "datasource_type": ModuleName, "acquis_type": line.Labels["type"]}).Inc()
 			}
 
 			evt := pipeline.MakeEvent(s.config.UseTimeMachine, pipeline.LOG, true)

--- a/pkg/acquisition/modules/journalctl/source.go
+++ b/pkg/acquisition/modules/journalctl/source.go
@@ -25,7 +25,7 @@ func (s *Source) GetMode() string {
 }
 
 func (*Source) GetName() string {
-	return "journalctl"
+	return ModuleName
 }
 
 func (*Source) CanRun() error {

--- a/pkg/acquisition/modules/kafka/init.go
+++ b/pkg/acquisition/modules/kafka/init.go
@@ -12,7 +12,9 @@ var (
 	_ types.MetricsProvider = (*Source)(nil)
 )
 
+const ModuleName = "kafka"
+
 //nolint:gochecknoinits
 func init() {
-	registry.RegisterFactory("kafka", func() types.DataSource { return &Source{} })
+	registry.RegisterFactory(ModuleName, func() types.DataSource { return &Source{} })
 }

--- a/pkg/acquisition/modules/kafka/kafka_test.go
+++ b/pkg/acquisition/modules/kafka/kafka_test.go
@@ -72,7 +72,7 @@ group_id: crowdsec`,
 		},
 	}
 
-	subLogger := log.WithField("type", "kafka")
+	subLogger := log.WithField("type", ModuleName)
 
 	for _, test := range tests {
 		k := Source{}
@@ -150,7 +150,7 @@ func TestStreamingAcquisition(t *testing.T) {
 		},
 	}
 
-	subLogger := log.WithField("type", "kafka")
+	subLogger := log.WithField("type", ModuleName)
 
 	createTopic("crowdsecplaintext", "localhost:9092")
 
@@ -223,7 +223,7 @@ func TestStreamingAcquisitionWithSSL(t *testing.T) {
 		},
 	}
 
-	subLogger := log.WithField("type", "kafka")
+	subLogger := log.WithField("type", ModuleName)
 
 	createTopic("crowdsecssl", "localhost:9092")
 

--- a/pkg/acquisition/modules/kafka/run.go
+++ b/pkg/acquisition/modules/kafka/run.go
@@ -50,7 +50,7 @@ func (s *Source) ReadMessage(ctx context.Context, out chan pipeline.Event) error
 		s.logger.Tracef("line with message read from topic '%s': %+v", s.Config.Topic, l)
 
 		if s.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-			metrics.KafkaDataSourceLinesRead.With(prometheus.Labels{"topic": s.Config.Topic, "datasource_type": "kafka", "acquis_type": l.Labels["type"]}).Inc()
+			metrics.KafkaDataSourceLinesRead.With(prometheus.Labels{"topic": s.Config.Topic, "datasource_type": ModuleName, "acquis_type": l.Labels["type"]}).Inc()
 		}
 
 		evt := pipeline.MakeEvent(s.Config.UseTimeMachine, pipeline.LOG, true)

--- a/pkg/acquisition/modules/kafka/source.go
+++ b/pkg/acquisition/modules/kafka/source.go
@@ -23,7 +23,7 @@ func (s *Source) GetMode() string {
 }
 
 func (*Source) GetName() string {
-	return "kafka"
+	return ModuleName
 }
 
 func (*Source) CanRun() error {

--- a/pkg/acquisition/modules/kinesis/init.go
+++ b/pkg/acquisition/modules/kinesis/init.go
@@ -12,7 +12,9 @@ var (
 	_ types.MetricsProvider = (*Source)(nil)
 )
 
+const ModuleName = "kinesis"
+
 //nolint:gochecknoinits
 func init() {
-	registry.RegisterFactory("kinesis", func() types.DataSource { return &Source{} })
+	registry.RegisterFactory(ModuleName, func() types.DataSource { return &Source{} })
 }

--- a/pkg/acquisition/modules/kinesis/kinesis_test.go
+++ b/pkg/acquisition/modules/kinesis/kinesis_test.go
@@ -139,7 +139,7 @@ stream_arn: arn:aws:kinesis:eu-west-1:123456789012:stream/my-stream`,
 		},
 	}
 
-	subLogger := log.WithField("type", "kinesis")
+	subLogger := log.WithField("type", ModuleName)
 
 	for _, test := range tests {
 		t.Run(test.config, func(t *testing.T) {
@@ -172,7 +172,7 @@ stream_name: stream-1-shard`,
 	for _, test := range tests {
 		f := Source{}
 		config := fmt.Sprintf(test.config, endpoint)
-		err := f.Configure(ctx, []byte(config), log.WithField("type", "kinesis"), metrics.AcquisitionMetricsLevelNone)
+		err := f.Configure(ctx, []byte(config), log.WithField("type", ModuleName), metrics.AcquisitionMetricsLevelNone)
 		require.NoError(t, err)
 
 		tomb := &tomb.Tomb{}
@@ -217,7 +217,7 @@ stream_name: stream-2-shards`,
 	for _, test := range tests {
 		f := Source{}
 		config := fmt.Sprintf(test.config, endpoint)
-		err := f.Configure(ctx, []byte(config), log.WithField("type", "kinesis"), metrics.AcquisitionMetricsLevelNone)
+		err := f.Configure(ctx, []byte(config), log.WithField("type", ModuleName), metrics.AcquisitionMetricsLevelNone)
 		require.NoError(t, err)
 
 		tomb := &tomb.Tomb{}
@@ -266,7 +266,7 @@ from_subscription: true`,
 	for _, test := range tests {
 		f := Source{}
 		config := fmt.Sprintf(test.config, endpoint)
-		err := f.Configure(ctx, []byte(config), log.WithField("type", "kinesis"), metrics.AcquisitionMetricsLevelNone)
+		err := f.Configure(ctx, []byte(config), log.WithField("type", ModuleName), metrics.AcquisitionMetricsLevelNone)
 		require.NoError(t, err)
 
 		tomb := &tomb.Tomb{}
@@ -310,7 +310,7 @@ use_enhanced_fanout: true`,
 	for _, test := range tests {
 		f := KinesisSource{}
 		config := fmt.Sprintf(test.config, endpoint)
-		err := f.Configure([]byte(config), log.WithField("type", "kinesis"))
+		err := f.Configure([]byte(config), log.WithField("type", ModuleName))
 		require.NoError(t, err)
 		tomb := &tomb.Tomb{}
 		out := make(chan types.Event)

--- a/pkg/acquisition/modules/kinesis/run.go
+++ b/pkg/acquisition/modules/kinesis/run.go
@@ -160,12 +160,12 @@ func (s *Source) ParseAndPushRecords(records []kinTypes.Record, out chan pipelin
 		if s.Config.StreamARN != "" {
 			if s.metricsLevel != metrics.AcquisitionMetricsLevelNone {
 				metrics.KinesisDataSourceLinesReadShards.With(prometheus.Labels{"stream": s.Config.StreamARN, "shard": shardID}).Inc()
-				metrics.KinesisDataSourceLinesRead.With(prometheus.Labels{"stream": s.Config.StreamARN, "datasource_type": "kinesis", "acquis_type": s.Config.Labels["type"]}).Inc()
+				metrics.KinesisDataSourceLinesRead.With(prometheus.Labels{"stream": s.Config.StreamARN, "datasource_type": ModuleName, "acquis_type": s.Config.Labels["type"]}).Inc()
 			}
 		} else {
 			if s.metricsLevel != metrics.AcquisitionMetricsLevelNone {
 				metrics.KinesisDataSourceLinesReadShards.With(prometheus.Labels{"stream": s.Config.StreamName, "shard": shardID}).Inc()
-				metrics.KinesisDataSourceLinesRead.With(prometheus.Labels{"stream": s.Config.StreamName, "datasource_type": "kinesis", "acquis_type": s.Config.Labels["type"]}).Inc()
+				metrics.KinesisDataSourceLinesRead.With(prometheus.Labels{"stream": s.Config.StreamName, "datasource_type": ModuleName, "acquis_type": s.Config.Labels["type"]}).Inc()
 			}
 		}
 

--- a/pkg/acquisition/modules/kinesis/source.go
+++ b/pkg/acquisition/modules/kinesis/source.go
@@ -26,7 +26,7 @@ func (s *Source) GetMode() string {
 }
 
 func (*Source) GetName() string {
-	return "kinesis"
+	return ModuleName
 }
 
 func (*Source) CanRun() error {

--- a/pkg/acquisition/modules/kubernetesaudit/init.go
+++ b/pkg/acquisition/modules/kubernetesaudit/init.go
@@ -12,7 +12,9 @@ var (
 	_ types.MetricsProvider = (*Source)(nil)
 )
 
+const ModuleName = "k8s-audit"
+
 //nolint:gochecknoinits
 func init() {
-	registry.RegisterFactory("k8s-audit", func() types.DataSource { return &Source{} })
+	registry.RegisterFactory(ModuleName, func() types.DataSource { return &Source{} })
 }

--- a/pkg/acquisition/modules/kubernetesaudit/k8s_audit_test.go
+++ b/pkg/acquisition/modules/kubernetesaudit/k8s_audit_test.go
@@ -79,7 +79,7 @@ webhook_path: /k8s-audit`,
 		},
 	}
 
-	subLogger := log.WithField("type", "k8s-audit")
+	subLogger := log.WithField("type", ModuleName)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -225,7 +225,7 @@ func TestHandler(t *testing.T) {
 		},
 	}
 
-	subLogger := log.WithField("type", "k8s-audit")
+	subLogger := log.WithField("type", ModuleName)
 
 	for idx, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/acquisition/modules/kubernetesaudit/run.go
+++ b/pkg/acquisition/modules/kubernetesaudit/run.go
@@ -83,7 +83,7 @@ func (s *Source) webhookHandler(w http.ResponseWriter, r *http.Request) {
 
 	for idx := range auditEvents.Items {
 		if s.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-			metrics.K8SAuditDataSourceEventCount.With(prometheus.Labels{"source": s.addr, "datasource_type": "k8s-audit", "acquis_type": s.config.Labels["type"]}).Inc()
+			metrics.K8SAuditDataSourceEventCount.With(prometheus.Labels{"source": s.addr, "datasource_type": ModuleName, "acquis_type": s.config.Labels["type"]}).Inc()
 		}
 
 		bytesEvent, err := json.Marshal(auditEvents.Items[idx])

--- a/pkg/acquisition/modules/kubernetesaudit/source.go
+++ b/pkg/acquisition/modules/kubernetesaudit/source.go
@@ -28,7 +28,7 @@ func (s *Source) GetMode() string {
 }
 
 func (*Source) GetName() string {
-	return "k8s-audit"
+	return ModuleName
 }
 
 func (*Source) CanRun() error {

--- a/pkg/acquisition/modules/loki/init.go
+++ b/pkg/acquisition/modules/loki/init.go
@@ -14,7 +14,9 @@ var (
 	_ types.MetricsProvider = (*Source)(nil)
 )
 
+const ModuleName = "loki"
+
 //nolint:gochecknoinits
 func init() {
-	registry.RegisterFactory("loki", func() types.DataSource { return &Source{} })
+	registry.RegisterFactory(ModuleName, func() types.DataSource { return &Source{} })
 }

--- a/pkg/acquisition/modules/loki/loki_test.go
+++ b/pkg/acquisition/modules/loki/loki_test.go
@@ -145,7 +145,7 @@ no_ready_check: 37
 			testName:    "type mismatch",
 		},
 	}
-	subLogger := log.WithField("type", "loki")
+	subLogger := log.WithField("type", loki.ModuleName)
 
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
@@ -246,7 +246,7 @@ func TestConfigureDSN(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			subLogger := log.WithFields(log.Fields{
-				"type": "loki",
+				"type": loki.ModuleName,
 				"name": test.name,
 			})
 
@@ -373,7 +373,7 @@ since: 1h
 	for _, ts := range tests {
 		t.Run(ts.config, func(t *testing.T) {
 			logger := log.New()
-			subLogger := logger.WithField("type", "loki")
+			subLogger := logger.WithField("type", loki.ModuleName)
 			lokiSource := loki.Source{}
 
 			if err := lokiSource.Configure(ctx, []byte(ts.config), subLogger, metrics.AcquisitionMetricsLevelNone); err != nil {
@@ -455,7 +455,7 @@ query: >
 		t.Run(ts.name, func(t *testing.T) {
 			logger := log.New()
 			subLogger := logger.WithFields(log.Fields{
-				"type": "loki",
+				"type": loki.ModuleName,
 				"name": ts.name,
 			})
 
@@ -535,7 +535,7 @@ query: >
   {server="demo"}
 `
 	logger := log.New()
-	subLogger := logger.WithField("type", "loki")
+	subLogger := logger.WithField("type", loki.ModuleName)
 	title := time.Now().String()
 	lokiSource := loki.Source{}
 

--- a/pkg/acquisition/modules/loki/run.go
+++ b/pkg/acquisition/modules/loki/run.go
@@ -66,7 +66,7 @@ func (l *Source) readOneEntry(entry lokiclient.Entry, labels map[string]string, 
 	ll.Module = l.GetName()
 
 	if l.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-		metrics.LokiDataSourceLinesRead.With(prometheus.Labels{"source": l.Config.URL, "datasource_type": "loki", "acquis_type": ll.Labels["type"]}).Inc()
+		metrics.LokiDataSourceLinesRead.With(prometheus.Labels{"source": l.Config.URL, "datasource_type": ModuleName, "acquis_type": ll.Labels["type"]}).Inc()
 	}
 
 	evt := pipeline.MakeEvent(l.Config.UseTimeMachine, pipeline.LOG, true)

--- a/pkg/acquisition/modules/loki/source.go
+++ b/pkg/acquisition/modules/loki/source.go
@@ -22,7 +22,7 @@ func (l *Source) GetMode() string {
 }
 
 func (*Source) GetName() string {
-	return "loki"
+	return ModuleName
 }
 
 func (*Source) CanRun() error {

--- a/pkg/acquisition/modules/s3/init.go
+++ b/pkg/acquisition/modules/s3/init.go
@@ -14,7 +14,9 @@ var (
 	_ types.MetricsProvider = (*Source)(nil)
 )
 
+const ModuleName = "s3"
+
 //nolint:gochecknoinits
 func init() {
-	registry.RegisterFactory("s3", func() types.DataSource { return &Source{} })
+	registry.RegisterFactory(ModuleName, func() types.DataSource { return &Source{} })
 }

--- a/pkg/acquisition/modules/s3/run.go
+++ b/pkg/acquisition/modules/s3/run.go
@@ -393,7 +393,7 @@ func (s *Source) readFile(bucket string, key string) error {
 			logger.Tracef("Read line %s", text)
 
 			if s.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-				metrics.S3DataSourceLinesRead.With(prometheus.Labels{"bucket": bucket, "datasource_type": "s3", "acquis_type": s.Config.Labels["type"]}).Inc()
+				metrics.S3DataSourceLinesRead.With(prometheus.Labels{"bucket": bucket, "datasource_type": ModuleName, "acquis_type": s.Config.Labels["type"]}).Inc()
 			}
 
 			l := pipeline.Line{}

--- a/pkg/acquisition/modules/s3/source.go
+++ b/pkg/acquisition/modules/s3/source.go
@@ -44,7 +44,7 @@ func (s *Source) GetMode() string {
 }
 
 func (*Source) GetName() string {
-	return "s3"
+	return ModuleName
 }
 
 func (s *Source) GetUuid() string {

--- a/pkg/acquisition/modules/syslog/init.go
+++ b/pkg/acquisition/modules/syslog/init.go
@@ -12,7 +12,9 @@ var (
 	_ types.MetricsProvider     = (*Source)(nil)
 )
 
+const ModuleName = "syslog"
+
 //nolint:gochecknoinits
 func init() {
-	registry.RegisterFactory("syslog", func() types.DataSource { return &Source{} })
+	registry.RegisterFactory(ModuleName, func() types.DataSource { return &Source{} })
 }

--- a/pkg/acquisition/modules/syslog/run.go
+++ b/pkg/acquisition/modules/syslog/run.go
@@ -200,7 +200,7 @@ func (s *Source) parseLine(syslogLine syslogserver.SyslogMessage) (string, error
 	logger.Tracef("raw: %s", syslogLine)
 
 	if s.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-		metrics.SyslogDataSourceLinesReceived.With(prometheus.Labels{"source": syslogLine.Client, "datasource_type": "syslog", "acquis_type": s.config.Labels["type"]}).Inc()
+		metrics.SyslogDataSourceLinesReceived.With(prometheus.Labels{"source": syslogLine.Client, "datasource_type": ModuleName, "acquis_type": s.config.Labels["type"]}).Inc()
 	}
 
 	if s.config.DisableRFCParser {
@@ -233,12 +233,12 @@ func (s *Source) parseLine(syslogLine syslogserver.SyslogMessage) (string, error
 
 		line = s.buildLogFromSyslog(p2.Timestamp, p2.Hostname, p2.Tag, p2.PID, p2.Message)
 		if s.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-			metrics.SyslogDataSourceLinesParsed.With(prometheus.Labels{"source": syslogLine.Client, "type": "rfc5424", "datasource_type": "syslog", "acquis_type": s.config.Labels["type"]}).Inc()
+			metrics.SyslogDataSourceLinesParsed.With(prometheus.Labels{"source": syslogLine.Client, "type": "rfc5424", "datasource_type": ModuleName, "acquis_type": s.config.Labels["type"]}).Inc()
 		}
 	} else {
 		line = s.buildLogFromSyslog(p.Timestamp, p.Hostname, p.Tag, p.PID, p.Message)
 		if s.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-			metrics.SyslogDataSourceLinesParsed.With(prometheus.Labels{"source": syslogLine.Client, "type": "rfc3164", "datasource_type": "syslog", "acquis_type": s.config.Labels["type"]}).Inc()
+			metrics.SyslogDataSourceLinesParsed.With(prometheus.Labels{"source": syslogLine.Client, "type": "rfc3164", "datasource_type": ModuleName, "acquis_type": s.config.Labels["type"]}).Inc()
 		}
 	}
 

--- a/pkg/acquisition/modules/syslog/source.go
+++ b/pkg/acquisition/modules/syslog/source.go
@@ -17,7 +17,7 @@ func (s *Source) GetUuid() string {
 }
 
 func (*Source) GetName() string {
-	return "syslog"
+	return ModuleName
 }
 
 func (s *Source) GetMode() string {

--- a/pkg/acquisition/modules/syslog/syslog_test.go
+++ b/pkg/acquisition/modules/syslog/syslog_test.go
@@ -55,7 +55,7 @@ listen_addr: 10.0.0`,
 		},
 	}
 
-	subLogger := log.WithField("type", "syslog")
+	subLogger := log.WithField("type", ModuleName)
 
 	for _, test := range tests {
 		t.Run(test.config, func(t *testing.T) {
@@ -166,7 +166,7 @@ disable_rfc_parser: true`,
 
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
-			subLogger := log.WithField("type", "syslog")
+			subLogger := log.WithField("type", ModuleName)
 			s := Source{}
 
 			err := s.Configure(ctx, []byte(ts.config), subLogger, metrics.AcquisitionMetricsLevelNone)

--- a/pkg/acquisition/modules/victorialogs/init.go
+++ b/pkg/acquisition/modules/victorialogs/init.go
@@ -14,7 +14,9 @@ var (
 	_ types.MetricsProvider = (*Source)(nil)
 )
 
+const ModuleName = "victorialogs"
+
 //nolint:gochecknoinits
 func init() {
-	registry.RegisterFactory("victorialogs", func() types.DataSource { return &Source{} })
+	registry.RegisterFactory(ModuleName, func() types.DataSource { return &Source{} })
 }

--- a/pkg/acquisition/modules/victorialogs/run.go
+++ b/pkg/acquisition/modules/victorialogs/run.go
@@ -60,7 +60,7 @@ func (s *Source) readOneEntry(entry *vlclient.Log, labels map[string]string, out
 	ll.Module = s.GetName()
 
 	if s.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-		metrics.VictorialogsDataSourceLinesRead.With(prometheus.Labels{"source": s.Config.URL, "datasource_type": "victorialogs", "acquis_type": s.Config.Labels["type"]}).Inc()
+		metrics.VictorialogsDataSourceLinesRead.With(prometheus.Labels{"source": s.Config.URL, "datasource_type": ModuleName, "acquis_type": s.Config.Labels["type"]}).Inc()
 	}
 
 	expectMode := pipeline.LIVE

--- a/pkg/acquisition/modules/victorialogs/source.go
+++ b/pkg/acquisition/modules/victorialogs/source.go
@@ -21,7 +21,7 @@ func (s *Source) GetMode() string {
 }
 
 func (*Source) GetName() string {
-	return "victorialogs"
+	return ModuleName
 }
 
 func (*Source) CanRun() error {

--- a/pkg/acquisition/modules/victorialogs/victorialogs_test.go
+++ b/pkg/acquisition/modules/victorialogs/victorialogs_test.go
@@ -111,7 +111,7 @@ query: >
 			testName:    "Correct config with password",
 		},
 	}
-	subLogger := log.WithField("type", "victorialogs")
+	subLogger := log.WithField("type", victorialogs.ModuleName)
 
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
@@ -194,7 +194,7 @@ func TestConfigureDSN(t *testing.T) {
 
 	for _, test := range tests {
 		subLogger := log.WithFields(log.Fields{
-			"type": "victorialogs",
+			"type": victorialogs.ModuleName,
 			"name": test.name,
 		})
 
@@ -296,7 +296,7 @@ since: 1h
 
 	for _, ts := range tests {
 		logger := log.New()
-		subLogger := logger.WithField("type", "victorialogs")
+		subLogger := logger.WithField("type", victorialogs.ModuleName)
 		vlSource := victorialogs.Source{}
 
 		err := vlSource.Configure(ctx, []byte(ts.config), subLogger, metrics.AcquisitionMetricsLevelNone)
@@ -377,7 +377,7 @@ query: >
 		t.Run(ts.name, func(t *testing.T) {
 			logger := log.New()
 			subLogger := logger.WithFields(log.Fields{
-				"type": "victorialogs",
+				"type": victorialogs.ModuleName,
 				"name": ts.name,
 			})
 
@@ -455,7 +455,7 @@ query: >
   server:"demo"
 `
 	logger := log.New()
-	subLogger := logger.WithField("type", "victorialogs")
+	subLogger := logger.WithField("type", victorialogs.ModuleName)
 	title := time.Now().String()
 	vlSource := victorialogs.Source{}
 

--- a/pkg/acquisition/modules/wineventlog/init.go
+++ b/pkg/acquisition/modules/wineventlog/init.go
@@ -14,7 +14,9 @@ var (
 	_ types.MetricsProvider = (*Source)(nil)
 )
 
+const ModuleName = "wineventlog"
+
 //nolint:gochecknoinits
 func init() {
-	registry.RegisterFactory("wineventlog", func() types.DataSource { return &Source{} })
+	registry.RegisterFactory(ModuleName, func() types.DataSource { return &Source{} })
 }

--- a/pkg/acquisition/modules/wineventlog/run_windows.go
+++ b/pkg/acquisition/modules/wineventlog/run_windows.go
@@ -98,7 +98,7 @@ func (s *Source) getEvents(out chan pipeline.Event, t *tomb.Tomb) error {
 				}
 				for _, event := range renderedEvents {
 					if s.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-						metrics.WineventlogDataSourceLinesRead.With(prometheus.Labels{"source": s.name, "datasource_type": "wineventlog", "acquis_type": s.config.Labels["type"]}).Inc()
+						metrics.WineventlogDataSourceLinesRead.With(prometheus.Labels{"source": s.name, "datasource_type": ModuleName, "acquis_type": s.config.Labels["type"]}).Inc()
 					}
 					l := pipeline.Line{}
 					l.Raw = event
@@ -152,7 +152,7 @@ OUTER_LOOP:
 			for _, evt := range evts {
 				s.logger.Tracef("Event: %s", evt)
 				if s.metricsLevel != metrics.AcquisitionMetricsLevelNone {
-					metrics.WineventlogDataSourceLinesRead.With(prometheus.Labels{"source": s.name, "datasource_type": "wineventlog", "acquis_type": s.config.Labels["type"]}).Inc()
+					metrics.WineventlogDataSourceLinesRead.With(prometheus.Labels{"source": s.name, "datasource_type": ModuleName, "acquis_type": s.config.Labels["type"]}).Inc()
 				}
 				l := pipeline.Line{}
 				l.Raw = evt

--- a/pkg/acquisition/modules/wineventlog/source_windows.go
+++ b/pkg/acquisition/modules/wineventlog/source_windows.go
@@ -28,7 +28,7 @@ func (s *Source) GetMode() string {
 }
 
 func (*Source) GetName() string {
-	return "wineventlog"
+	return ModuleName
 }
 
 func (*Source) CanRun() error {

--- a/pkg/acquisition/modules/wineventlog/stub.go
+++ b/pkg/acquisition/modules/wineventlog/stub.go
@@ -54,7 +54,7 @@ func (*Source) GetAggregMetrics() []prometheus.Collector {
 }
 
 func (*Source) GetName() string {
-	return "wineventlog"
+	return ModuleName
 }
 
 func (*Source) CanRun() error {

--- a/pkg/acquisition/modules/wineventlog/wineventlog_windows_test.go
+++ b/pkg/acquisition/modules/wineventlog/wineventlog_windows_test.go
@@ -292,7 +292,7 @@ func TestOneShot(t *testing.T) {
 			c := make(chan pipeline.Event)
 			f := Source{}
 
-			err := f.ConfigureByDSN(ctx, test.dsn, map[string]string{"type": "wineventlog"}, log.WithField("type", "windowseventlog"), "")
+			err := f.ConfigureByDSN(ctx, test.dsn, map[string]string{"type": "wineventlog"}, log.WithField("type", ModuleName), "")
 			cstest.RequireErrorContains(t, err, test.expectedConfigureErr)
 			if test.expectedConfigureErr != "" {
 				return


### PR DESCRIPTION
Also prevent mistyping and make it clear when a string refers to a module name vs type label.