### PR TITLE
Created endpoint GET /scenarios on LAPI

### DIFF
--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -89,27 +88,7 @@ func randomDuration(d time.Duration, delta time.Duration) time.Duration {
 }
 
 func (a *apic) FetchScenariosListFromDB(ctx context.Context) ([]string, error) {
-	scenarios := make([]string, 0)
-
-	machines, err := a.dbClient.ListMachines(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("while listing machines: %w", err)
-	}
-	// merge all scenarios together
-	for _, v := range machines {
-		machineScenarios := strings.Split(v.Scenarios, ",")
-		log.Debugf("%d scenarios for machine %d", len(machineScenarios), v.ID)
-
-		for _, sv := range machineScenarios {
-			if !slices.Contains(scenarios, sv) && sv != "" {
-				scenarios = append(scenarios, sv)
-			}
-		}
-	}
-
-	log.Debugf("Returning list of scenarios : %+v", scenarios)
-
-	return scenarios, nil
+	return a.dbClient.FetchScenariosListFromDB(ctx)
 }
 
 func decisionsToAPIDecisions(decisions []*models.Decision) models.AddSignalsRequestItemDecisions {

--- a/pkg/apiserver/controllers/controller.go
+++ b/pkg/apiserver/controllers/controller.go
@@ -128,6 +128,7 @@ func (c *Controller) NewV1() error {
 		jwtAuth.DELETE("/decisions", c.HandlerV1.DeleteDecisions)
 		jwtAuth.DELETE("/decisions/:decision_id", c.HandlerV1.DeleteDecisionById)
 		jwtAuth.GET("/heartbeat", c.HandlerV1.HeartBeat)
+		jwtAuth.GET("/scenarios", c.HandlerV1.GetScenarios)
 		jwtAuth.GET("/allowlists", c.HandlerV1.GetAllowlists)
 		jwtAuth.GET("/allowlists/:allowlist_name", c.HandlerV1.GetAllowlist)
 		jwtAuth.GET("/allowlists/check/:ip_or_range", c.HandlerV1.CheckInAllowlist)

--- a/pkg/apiserver/controllers/v1/scenarios.go
+++ b/pkg/apiserver/controllers/v1/scenarios.go
@@ -1,0 +1,19 @@
+package v1
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (c *Controller) GetScenarios(gctx *gin.Context) {
+	ctx := gctx.Request.Context()
+
+	scenarios, err := c.DBClient.FetchScenariosListFromDB(ctx)
+	if err != nil {
+		c.HandleDBErrors(gctx, err)
+		return
+	}
+
+	gctx.JSON(http.StatusOK, scenarios)
+}

--- a/pkg/apiserver/scenarios_test.go
+++ b/pkg/apiserver/scenarios_test.go
@@ -1,0 +1,94 @@
+package apiserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/crowdsecurity/go-cs-lib/ptr"
+
+	"github.com/crowdsecurity/crowdsec/pkg/types"
+)
+
+func TestGetScenarios(t *testing.T) {
+	ctx := t.Context()
+	lapi := SetupLAPITest(t, ctx)
+
+	// Create first machine with some scenarios
+	machine1, err := lapi.DBClient.CreateMachine(ctx,
+		ptr.Of("machine1"),
+		&testPassword,
+		"1.2.3.4",
+		true,
+		false,
+		types.PasswordAuthType,
+	)
+	require.NoError(t, err)
+
+	err = lapi.DBClient.UpdateMachineScenarios(ctx, "crowdsecurity/ssh-bf,crowdsecurity/http-bf", machine1.ID)
+	require.NoError(t, err)
+
+	// Create second machine with overlapping and unique scenarios
+	machine2, err := lapi.DBClient.CreateMachine(ctx,
+		ptr.Of("machine2"),
+		&testPassword,
+		"1.2.3.5",
+		true,
+		false,
+		types.PasswordAuthType,
+	)
+	require.NoError(t, err)
+
+	err = lapi.DBClient.UpdateMachineScenarios(ctx, "crowdsecurity/http-bf,custom/test", machine2.ID)
+	require.NoError(t, err)
+
+	// Test GET /scenarios with valid JWT
+	w := lapi.RecordResponse(t, ctx, http.MethodGet, "/v1/scenarios", emptyBody, passwordAuthType)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var scenarios []string
+	err = json.Unmarshal(w.Body.Bytes(), &scenarios)
+	require.NoError(t, err)
+
+	// Should contain all unique scenarios
+	assert.Contains(t, scenarios, "crowdsecurity/ssh-bf")
+	assert.Contains(t, scenarios, "crowdsecurity/http-bf")
+	assert.Contains(t, scenarios, "custom/test")
+	assert.Len(t, scenarios, 3) // should remove duplicates
+}
+
+func TestGetScenariosUnauthorized(t *testing.T) {
+	ctx := t.Context()
+	lapi := SetupLAPITest(t, ctx)
+
+	// Request without authentication
+	w := httptest.NewRecorder()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/v1/scenarios", emptyBody)
+	require.NoError(t, err)
+	req.RemoteAddr = "127.0.0.1:1234"
+	lapi.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestGetScenariosEmpty(t *testing.T) {
+	ctx := t.Context()
+	lapi := SetupLAPITest(t, ctx)
+
+	// Test with no additional machines having scenarios
+	w := lapi.RecordResponse(t, ctx, http.MethodGet, "/v1/scenarios", emptyBody, passwordAuthType)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var scenarios []string
+	err := json.Unmarshal(w.Body.Bytes(), &scenarios)
+	require.NoError(t, err)
+
+	// Should return a valid array (may be empty or contain scenarios from test machine)
+	assert.NotNil(t, scenarios)
+}


### PR DESCRIPTION
This PR adds a new endpoint to LAPI. It returns a list with the scenarios that have been added to Crowdsec. It uses the same code that was already available for CAPI and returns the same data on LAPI.

**Endpoint**
GET /v1/scenarios

**Response example**
```
[
    "crowdsecurity/ssh-bf",
    "crowdsecurity/ssh-cve-2024-6387",
    "crowdsecurity/ssh-generic-test",
    "crowdsecurity/ssh-refused-conn",
    "crowdsecurity/ssh-slow-bf",
]
```
