### PR TITLE
enhance: Reload cert if 401 response from LAPI

### DIFF
--- a/pkg/csconfig/api.go
+++ b/pkg/csconfig/api.go
@@ -216,6 +216,9 @@ func (l *LocalApiClientCfg) Load() error {
 		}
 
 		apiclient.Cert = &cert
+		// Store the paths so the certificate can be reloaded if it expires and is renewed on disk
+		apiclient.CertPath = l.Credentials.CertPath
+		apiclient.KeyPath = l.Credentials.KeyPath
 	}
 
 	return nil


### PR DESCRIPTION
fixes: #2810

Quick fix for now till a better solution could be achieved, if the response code from LAPI is 401 and we have certs configured simply re-read them even if they have expired and havent been updated on disk, the retry method will continue to backoff and fail if ultimately if the setup is errored.