### PR TITLE
refact cmd/crowdsec: remove redundant global variable

### DIFF
--- a/cmd/crowdsec/crowdsec.go
+++ b/cmd/crowdsec/crowdsec.go
@@ -127,7 +127,7 @@ func startLPMetrics(ctx context.Context, cConfig *csconfig.Config, apiClient *ap
 			aggregated = true
 		}
 
-		if err := acquisition.GetMetrics(dataSources, aggregated); err != nil {
+		if err := acquisition.GetMetrics(datasources, aggregated); err != nil {
 			return fmt.Errorf("while fetching prometheus metrics for datasources: %w", err)
 		}
 	}
@@ -167,7 +167,7 @@ func runCrowdsec(
 
 	log.Info("Starting processing data")
 
-	if err := acquisition.StartAcquisition(ctx, dataSources, logLines, &acquisTomb); err != nil {
+	if err := acquisition.StartAcquisition(ctx, datasources, logLines, &acquisTomb); err != nil {
 		return fmt.Errorf("starting acquisition error: %w", err)
 	}
 
@@ -212,7 +212,7 @@ func serveCrowdsec(
 		waitOnTomb()
 		log.Debugf("Shutting down crowdsec routines")
 
-		if err := ShutdownCrowdsecRoutines(cancel, &g); err != nil {
+		if err := ShutdownCrowdsecRoutines(cancel, &g, datasources); err != nil {
 			return fmt.Errorf("unable to shutdown crowdsec routines: %w", err)
 		}
 

--- a/cmd/crowdsec/main.go
+++ b/cmd/crowdsec/main.go
@@ -39,8 +39,6 @@ var (
 
 	flags Flags
 
-	// the state of acquisition
-	dataSources []acquisitionTypes.DataSource
 	// the state of the buckets
 	holders []leakybucket.BucketFactory
 
@@ -66,6 +64,8 @@ func LoadBuckets(cConfig *csconfig.Config, hub *cwhub.Hub) error {
 }
 
 func LoadAcquisition(ctx context.Context, cConfig *csconfig.Config, hub *cwhub.Hub) ([]acquisitionTypes.DataSource, error) {
+	var datasources []acquisitionTypes.DataSource
+
 	if flags.SingleFileType != "" && flags.OneShotDSN != "" {
 		flags.Labels["type"] = flags.SingleFileType
 
@@ -73,20 +73,20 @@ func LoadAcquisition(ctx context.Context, cConfig *csconfig.Config, hub *cwhub.H
 		if err != nil {
 			return nil, err
 		}
-		dataSources = append(dataSources, ds)
+		datasources = append(datasources, ds)
 	} else {
 		dss, err := acquisition.LoadAcquisitionFromFiles(ctx, cConfig.Crowdsec, cConfig.Prometheus, hub)
 		if err != nil {
 			return nil, err
 		}
-		dataSources = dss
+		datasources = dss
 	}
 
-	if len(dataSources) == 0 {
+	if len(datasources) == 0 {
 		return nil, errors.New("no datasource enabled")
 	}
 
-	return dataSources, nil
+	return datasources, nil
 }
 
 // LoadConfig returns a configuration parsed from configuration file

--- a/cmd/crowdsec/serve.go
+++ b/cmd/crowdsec/serve.go
@@ -16,6 +16,7 @@ import (
 	"github.com/crowdsecurity/go-cs-lib/csdaemon"
 	"github.com/crowdsecurity/go-cs-lib/trace"
 
+	acquisitionTypes "github.com/crowdsecurity/crowdsec/pkg/acquisition/types"
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cticlient/ctiexpr"
@@ -99,12 +100,12 @@ func waitErrGroup(g *errgroup.Group, timeout time.Duration) error {
 	}
 }
 
-func ShutdownCrowdsecRoutines(cancel context.CancelFunc, g *errgroup.Group) error {
+func ShutdownCrowdsecRoutines(cancel context.CancelFunc, g *errgroup.Group, datasources []acquisitionTypes.DataSource) error {
 	var reterr error
 
 	log.Debugf("Shutting down crowdsec sub-routines")
 
-	if len(dataSources) > 0 {
+	if len(datasources) > 0 {
 		acquisTomb.Kill(nil)
 		log.Debugf("waiting for acquisition to finish")
 		drainChan(logLines)


### PR DESCRIPTION
we already have datasources a function parameter - there's no need to use the global, as long as we pass it again where needed