### PR TITLE
cscli detect: set log type for caddy unit to "syslog"

### DIFF
--- a/config/detect.yaml
+++ b/config/detect.yaml
@@ -85,7 +85,7 @@ detect:
       datasource:
         source: journalctl
         labels:
-          type: caddy
+          type: syslog
         journalctl_filter:
           - "_SYSTEMD_UNIT=caddy.service"
 


### PR DESCRIPTION
fix https://github.com/crowdsecurity/crowdsec/issues/4098