### PR TITLE
CI: configure golangci-lint to run "nilaway"

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,0 +1,7 @@
+version: v2.10.1
+plugins:
+  - module: "go.uber.org/nilaway"
+    import: "go.uber.org/nilaway/cmd/gclplugin"
+    # Nilaway does not have, at the moment, stable tags or releases.
+    # Some versions can even crash during analysis, so we pin one that doesn't.
+    version: v0.0.0-20260213150243-937701de96c7

--- a/.github/workflows/go-tests-windows.yml
+++ b/.github/workflows/go-tests-windows.yml
@@ -58,6 +58,12 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
-        version: v2.9
+        version: v2.10
         args: --issues-exit-code=1 --timeout 10m
         only-new-issues: false
+
+    - name: Build custom-gcl (nilaway plugin)
+      run: golangci-lint custom -v
+
+    - name: nilaway
+      run: .\custom-gcl.exe run --issues-exit-code=1 --timeout 10m --enable-only=nilaway

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -214,6 +214,12 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
-        version: v2.9
+        version: v2.10
         args: --issues-exit-code=1 --timeout 10m
         only-new-issues: false
+
+    - name: Build custom-gcl (nilaway plugin)
+      run: golangci-lint custom -v
+
+    - name: nilaway
+      run: ./custom-gcl run --issues-exit-code=1 --timeout 10m --enable-only=nilaway

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,6 +78,13 @@ linters:
     - wsl_v5     # add or remove empty lines
 
   settings:
+    custom:
+      nilaway:
+        type: "module"
+        description: Static analysis tool to detect potential nil panics in Go code.
+        settings:
+          include-pkgs: "github.com/crowdsecurity/crowdsec"
+
 
     decorder:
       # Required order of `type`, `const`, `var` and `func` declarations inside a file.
@@ -664,6 +671,19 @@ linters:
           - staticcheck
         path: pkg/parser/(.+).go
         text: 'QF1008: could remove embedded field "NodeConfig" from selector'
+
+      - linters:
+         - nilaway
+        path: pkg/exprhelpers/(.+).go
+
+      - linters:
+         - nilaway
+        path: pkg/cticlient/ctiexpr/(.+).go
+
+      # global hubPtr
+      - linters:
+         - nilaway
+        path: cmd/crowdsec-cli/clihubtest/run.go
 
     paths:
       - third_party$


### PR DESCRIPTION
golangci-lint custom; ./custom-gcl run --enable-only nilaway