### PR TITLE
waf rules: allow arbitrary mix of AND and OR conditions

### DIFF
--- a/pkg/appsec/appsec_rule/modsec_rule_test.go
+++ b/pkg/appsec/appsec_rule/modsec_rule_test.go
@@ -121,8 +121,8 @@ func TestVPatchRuleString(t *testing.T) {
 					},
 				},
 			},
-			expected: `SecRule ARGS_GET:foo "@rx [^a-zA-Z]" "id:4145519614,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Basic AND',tag:'cs-custom-rule',severity:'emergency',t:lowercase,chain"
-SecRule ARGS_GET:bar "@rx [^a-zA-Z]" "id:1865217529,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Basic AND',tag:'cs-custom-rule',t:lowercase"`,
+			expected: `SecRule ARGS_GET:foo "@rx [^a-zA-Z]" "id:988489239,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Basic AND',tag:'cs-custom-rule',severity:'emergency',t:lowercase,chain"
+SecRule ARGS_GET:bar "@rx [^a-zA-Z]" "id:4145519614,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Basic AND',tag:'cs-custom-rule',t:lowercase"`,
 		},
 		{
 			name:        "Basic OR",
@@ -144,10 +144,11 @@ SecRule ARGS_GET:bar "@rx [^a-zA-Z]" "id:1865217529,phase:2,deny,log,msg:'test r
 					},
 				},
 			},
-			expected: `SecRule ARGS_GET:foo "@rx [^a-zA-Z]" "id:651140804,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Basic OR',tag:'cs-custom-rule',severity:'emergency',t:lowercase,skip:1"
-SecRule ARGS_GET:bar "@rx [^a-zA-Z]" "id:271441587,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Basic OR',tag:'cs-custom-rule',t:lowercase"`,
+			expected: `SecRule ARGS_GET:foo "@rx [^a-zA-Z]" "id:4061834901,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Basic OR',tag:'cs-custom-rule',severity:'emergency',t:lowercase,skip:1"
+SecRule ARGS_GET:bar "@rx [^a-zA-Z]" "id:651140804,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Basic OR',tag:'cs-custom-rule',t:lowercase"`,
 		},
 		{
+			// leaf(foo) AND (foo OR bar) → DNF: (foo AND foo) OR (foo AND bar) → 2 groups of 2
 			name:        "OR AND mix",
 			description: "test rule",
 
@@ -175,9 +176,162 @@ SecRule ARGS_GET:bar "@rx [^a-zA-Z]" "id:271441587,phase:2,deny,log,msg:'test ru
 					},
 				},
 			},
-			expected: `SecRule ARGS_GET:foo "@rx [^a-zA-Z]" "id:1714963250,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR AND mix',tag:'cs-custom-rule',severity:'emergency',t:lowercase,skip:1"
-SecRule ARGS_GET:bar "@rx [^a-zA-Z]" "id:1519945803,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR AND mix',tag:'cs-custom-rule',t:lowercase"
-SecRule ARGS_GET:foo "@rx [^a-zA-Z]" "id:1519945803,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR AND mix',tag:'cs-custom-rule',severity:'emergency',t:lowercase"`,
+			expected: `SecRule ARGS_GET:foo "@rx [^a-zA-Z]" "id:1061846204,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR AND mix',tag:'cs-custom-rule',severity:'emergency',t:lowercase,chain"
+SecRule ARGS_GET:foo "@rx [^a-zA-Z]" "id:2595762349,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR AND mix',tag:'cs-custom-rule',t:lowercase,skip:2"
+SecRule ARGS_GET:foo "@rx [^a-zA-Z]" "id:1714963250,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR AND mix',tag:'cs-custom-rule',t:lowercase,chain"
+SecRule ARGS_GET:bar "@rx [^a-zA-Z]" "id:1519945803,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR AND mix',tag:'cs-custom-rule',t:lowercase"`,
+		},
+		{
+			// (A OR B) AND C → DNF: (A AND C) OR (B AND C)
+			name:        "OR inside AND",
+			description: "test rule",
+
+			rule: CustomRule{
+				And: []CustomRule{
+					{
+						Or: []CustomRule{
+							{
+								Zones:     []string{"ARGS"},
+								Variables: []string{"a"},
+								Match:     Match{Type: "regex", Value: "x"},
+								Transform: []string{"lowercase"},
+							},
+							{
+								Zones:     []string{"ARGS"},
+								Variables: []string{"b"},
+								Match:     Match{Type: "regex", Value: "x"},
+								Transform: []string{"lowercase"},
+							},
+						},
+					},
+					{
+						Zones: []string{"METHOD"},
+						Match: Match{Type: "equals", Value: "GET"},
+					},
+				},
+			},
+			expected: `SecRule ARGS_GET:a "@rx x" "id:92468354,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR inside AND',tag:'cs-custom-rule',severity:'emergency',t:lowercase,chain"
+SecRule REQUEST_METHOD "@streq GET" "id:247410534,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR inside AND',tag:'cs-custom-rule',skip:2"
+SecRule ARGS_GET:b "@rx x" "id:1259128012,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR inside AND',tag:'cs-custom-rule',t:lowercase,chain"
+SecRule REQUEST_METHOD "@streq GET" "id:1682421760,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR inside AND',tag:'cs-custom-rule'"`,
+		},
+		{
+			// (A OR B) AND (C OR D) → DNF: (A,C) OR (A,D) OR (B,C) OR (B,D)
+			name:        "OR cross product",
+			description: "test rule",
+
+			rule: CustomRule{
+				And: []CustomRule{
+					{
+						Or: []CustomRule{
+							{
+								Zones:     []string{"ARGS"},
+								Variables: []string{"a"},
+								Match:     Match{Type: "regex", Value: "x"},
+							},
+							{
+								Zones:     []string{"ARGS"},
+								Variables: []string{"b"},
+								Match:     Match{Type: "regex", Value: "x"},
+							},
+						},
+					},
+					{
+						Or: []CustomRule{
+							{
+								Zones:     []string{"HEADERS"},
+								Variables: []string{"c"},
+								Match:     Match{Type: "contains", Value: "y"},
+							},
+							{
+								Zones:     []string{"HEADERS"},
+								Variables: []string{"d"},
+								Match:     Match{Type: "contains", Value: "y"},
+							},
+						},
+					},
+				},
+			},
+			expected: `SecRule ARGS_GET:a "@rx x" "id:1377665195,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR cross product',tag:'cs-custom-rule',severity:'emergency',chain"
+SecRule REQUEST_HEADERS:c "@contains y" "id:943662042,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR cross product',tag:'cs-custom-rule',skip:6"
+SecRule ARGS_GET:a "@rx x" "id:2583268057,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR cross product',tag:'cs-custom-rule',chain"
+SecRule REQUEST_HEADERS:d "@contains y" "id:4169811748,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR cross product',tag:'cs-custom-rule',skip:4"
+SecRule ARGS_GET:b "@rx x" "id:3596628535,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR cross product',tag:'cs-custom-rule',chain"
+SecRule REQUEST_HEADERS:c "@contains y" "id:1569541606,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR cross product',tag:'cs-custom-rule',skip:2"
+SecRule ARGS_GET:b "@rx x" "id:3129875829,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR cross product',tag:'cs-custom-rule',chain"
+SecRule REQUEST_HEADERS:d "@contains y" "id:2899769488,phase:2,deny,log,msg:'test rule',tag:'crowdsec-OR cross product',tag:'cs-custom-rule'"`,
+		},
+		{
+			// Same level and+or: POST AND (a OR b)
+			name:        "Same level AND OR",
+			description: "test rule",
+
+			rule: CustomRule{
+				And: []CustomRule{
+					{
+						Zones: []string{"METHOD"},
+						Match: Match{Type: "equals", Value: "POST"},
+					},
+				},
+				Or: []CustomRule{
+					{
+						Zones:     []string{"ARGS"},
+						Variables: []string{"a"},
+						Match:     Match{Type: "regex", Value: "x"},
+					},
+					{
+						Zones:     []string{"ARGS"},
+						Variables: []string{"b"},
+						Match:     Match{Type: "regex", Value: "x"},
+					},
+				},
+			},
+			expected: `SecRule REQUEST_METHOD "@streq POST" "id:2771836947,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Same level AND OR',tag:'cs-custom-rule',severity:'emergency',chain"
+SecRule ARGS_GET:a "@rx x" "id:477818162,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Same level AND OR',tag:'cs-custom-rule',skip:2"
+SecRule REQUEST_METHOD "@streq POST" "id:278067945,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Same level AND OR',tag:'cs-custom-rule',chain"
+SecRule ARGS_GET:b "@rx x" "id:1867070580,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Same level AND OR',tag:'cs-custom-rule'"`,
+		},
+		{
+			// A AND (B OR (C AND D)) → DNF: (A,B) OR (A,C,D)
+			name:        "Deep nesting",
+			description: "test rule",
+
+			rule: CustomRule{
+				And: []CustomRule{
+					{
+						Zones: []string{"METHOD"},
+						Match: Match{Type: "equals", Value: "POST"},
+					},
+					{
+						Or: []CustomRule{
+							{
+								Zones:     []string{"URI"},
+								Match:     Match{Type: "contains", Value: "/admin"},
+								Transform: []string{"lowercase"},
+							},
+							{
+								And: []CustomRule{
+									{
+										Zones:     []string{"ARGS"},
+										Variables: []string{"cmd"},
+										Match:     Match{Type: "regex", Value: "exec"},
+									},
+									{
+										Zones:     []string{"HEADERS"},
+										Variables: []string{"x-debug"},
+										Match:     Match{Type: "equals", Value: "true"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: `SecRule REQUEST_METHOD "@streq POST" "id:1367877911,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Deep nesting',tag:'cs-custom-rule',severity:'emergency',chain"
+SecRule REQUEST_FILENAME "@contains /admin" "id:889480160,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Deep nesting',tag:'cs-custom-rule',t:lowercase,skip:3"
+SecRule REQUEST_METHOD "@streq POST" "id:3660599789,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Deep nesting',tag:'cs-custom-rule',chain"
+SecRule ARGS_GET:cmd "@rx exec" "id:713704559,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Deep nesting',tag:'cs-custom-rule',chain"
+SecRule REQUEST_HEADERS:x-debug "@streq true" "id:625013554,phase:2,deny,log,msg:'test rule',tag:'crowdsec-Deep nesting',tag:'cs-custom-rule'"`,
 		},
 	}
 
@@ -191,5 +345,34 @@ SecRule ARGS_GET:foo "@rx [^a-zA-Z]" "id:1519945803,phase:2,deny,log,msg:'test r
 				t.Errorf("Expected:\n%s\nGot:\n%s", tt.expected, actual)
 			}
 		})
+	}
+}
+
+func TestDNFExpansionLimit(t *testing.T) {
+	// Create a rule that would produce too many DNF groups
+	// 3 OR-groups with 5 items each → 5*5*5 = 125 groups > 50 limit
+	makeOrGroup := func() CustomRule {
+		items := make([]CustomRule, 5)
+		for i := range items {
+			items[i] = CustomRule{
+				Zones:     []string{"ARGS"},
+				Variables: []string{string(rune('a' + i))},
+				Match:     Match{Type: "regex", Value: "x"},
+			}
+		}
+		return CustomRule{Or: items}
+	}
+
+	rule := CustomRule{
+		And: []CustomRule{
+			makeOrGroup(),
+			makeOrGroup(),
+			makeOrGroup(),
+		},
+	}
+
+	_, _, err := rule.Convert(ModsecurityRuleType, "test", "test")
+	if err == nil {
+		t.Error("Expected error for excessive DNF expansion, got nil")
 	}
 }

--- a/pkg/appsec/appsec_rule/modsecurity.go
+++ b/pkg/appsec/appsec_rule/modsecurity.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"slices"
 	"strings"
 
 	cztypes "github.com/corazawaf/coraza/v3/types"
@@ -70,103 +71,221 @@ var bodyTypeMatch = map[string]string{
 	"urlencoded": "URLENCODED",
 }
 
+const maxDNFGroups = 50
+
 func (m *ModsecurityRule) Build(rule *CustomRule, appsecRuleName string, appsecRuleDescription string) (string, []uint32, error) {
-	//Validate severity
 	if rule.Severity == "" {
 		rule.Severity = cztypes.RuleSeverityEmergency.String()
 	}
+
 	_, err := cztypes.ParseRuleSeverity(rule.Severity)
 	if err != nil {
 		return "", nil, err
 	}
 
-	rules, err := m.buildRules(rule, appsecRuleName, appsecRuleDescription, false, 0, 0, true)
+	dnf, err := flattenToDNF(rule)
 	if err != nil {
 		return "", nil, err
 	}
 
-	//We return the id of the first generated rule, as it's the interesting one in case of chain or skip
+	rules, err := m.buildFromDNF(dnf, rule.Severity, appsecRuleName, appsecRuleDescription)
+	if err != nil {
+		return "", nil, err
+	}
+
 	return strings.Join(rules, "\n"), m.ids, nil
 }
 
-func (m *ModsecurityRule) generateRuleID(rule *CustomRule, appsecRuleName string, depth int) uint32 {
+// leafCopy returns a shallow copy of the rule with And/Or cleared.
+func leafCopy(rule *CustomRule) *CustomRule {
+	cp := *rule
+	cp.And = nil
+	cp.Or = nil
+
+	return &cp
+}
+
+// flattenToDNF converts a CustomRule tree into Disjunctive Normal Form:
+// a list of AND-groups (conjunctions), where the outer list is OR.
+func flattenToDNF(rule *CustomRule) ([][]*CustomRule, error) {
+	// Leaf node: has zones, no children
+	if len(rule.And) == 0 && len(rule.Or) == 0 {
+		if rule.Zones == nil {
+			return nil, errors.New("leaf rule must have zones")
+		}
+
+		return [][]*CustomRule{{rule}}, nil
+	}
+
+	// Collect DNF parts to be AND-combined via cross-product
+	var parts [][][]*CustomRule
+
+	// If this node has zones alongside And/Or children, treat as implicit AND term
+	if rule.Zones != nil {
+		parts = append(parts, [][]*CustomRule{{leafCopy(rule)}})
+	}
+
+	// Each And child's DNF is cross-producted
+	for i := range rule.And {
+		childDNF, err := flattenToDNF(&rule.And[i])
+		if err != nil {
+			return nil, err
+		}
+
+		parts = append(parts, childDNF)
+	}
+
+	// All Or children's DNFs are concatenated into one, then treated as a single AND term
+	if len(rule.Or) > 0 {
+		var orDNF [][]*CustomRule
+
+		for i := range rule.Or {
+			childDNF, err := flattenToDNF(&rule.Or[i])
+			if err != nil {
+				return nil, err
+			}
+
+			orDNF = append(orDNF, childDNF...)
+		}
+
+		parts = append(parts, orDNF)
+	}
+
+	if len(parts) == 0 {
+		return nil, errors.New("rule has no zones, 'and', or 'or' children")
+	}
+
+	if len(parts) == 1 {
+		return parts[0], nil
+	}
+
+	// Multiple parts: cross-product them all
+	result := parts[0]
+
+	for i := 1; i < len(parts); i++ {
+		var err error
+
+		result, err = crossProduct(result, parts[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
+// crossProduct computes the AND-combination of two DNFs.
+// [[A],[B]] × [[C],[D]] = [[A,C],[A,D],[B,C],[B,D]]
+func crossProduct(a, b [][]*CustomRule) ([][]*CustomRule, error) {
+	result := make([][]*CustomRule, 0, len(a)*len(b))
+
+	for _, groupA := range a {
+		for _, groupB := range b {
+			combined := make([]*CustomRule, 0, len(groupA)+len(groupB))
+			combined = append(combined, groupA...)
+			combined = append(combined, groupB...)
+			result = append(result, combined)
+		}
+	}
+
+	if len(result) > maxDNFGroups {
+		return nil, fmt.Errorf("rule expansion produced %d groups, exceeding maximum of %d", len(result), maxDNFGroups)
+	}
+
+	return result, nil
+}
+
+func (m *ModsecurityRule) generateRuleID(rule *CustomRule, appsecRuleName string, position int) uint32 {
 	h := fnv.New32a()
 	h.Write([]byte(appsecRuleName))
 	h.Write([]byte(rule.Match.Type))
 	h.Write([]byte(rule.Match.Value))
-	h.Write([]byte(fmt.Sprintf("%d", depth)))
+	h.Write([]byte(fmt.Sprintf("%d", position)))
+
 	for _, zone := range rule.Zones {
 		h.Write([]byte(zone))
 	}
+
 	for _, transform := range rule.Transform {
+		if transform == "count" {
+			continue
+		}
+
 		h.Write([]byte(transform))
 	}
+
 	id := h.Sum32()
 	m.ids = append(m.ids, id)
+
 	return id
 }
 
-func (m *ModsecurityRule) buildRules(rule *CustomRule, appsecRuleName string, appsecRuleDescription string, and bool, toSkip int, depth int, isRoot bool) ([]string, error) {
-	ret := make([]string, 0)
-
-	if len(rule.And) != 0 && len(rule.Or) != 0 {
-		return nil, errors.New("cannot have both 'and' and 'or' in the same rule")
+// buildFromDNF generates ModSecurity SecRule directives from DNF groups.
+// Rules within each AND-group get ,chain (except the last).
+// Last rule of each group (except the final group) gets ,skip:N.
+func (m *ModsecurityRule) buildFromDNF(dnf [][]*CustomRule, severity string, appsecRuleName string, appsecRuleDescription string) ([]string, error) {
+	groupSizes := make([]int, len(dnf))
+	for i, group := range dnf {
+		groupSizes[i] = len(group)
 	}
 
-	if rule.And != nil {
-		for c, andRule := range rule.And {
-			depth++
-			andRule.Severity = rule.Severity
-			lastRule := c == len(rule.And)-1 // || len(rule.Or) == 0
-			root := c == 0
-			rules, err := m.buildRules(&andRule, appsecRuleName, appsecRuleDescription, !lastRule, 0, depth, root)
+	var rules []string
+
+	position := 0
+
+	for groupIdx, group := range dnf {
+		for leafIdx, leaf := range group {
+			isLastInGroup := leafIdx == len(group)-1
+			isLastGroup := groupIdx == len(dnf)-1
+
+			chain := !isLastInGroup
+
+			skip := 0
+			if isLastInGroup && !isLastGroup {
+				for k := groupIdx + 1; k < len(dnf); k++ {
+					skip += groupSizes[k]
+				}
+			}
+
+			isRoot := position == 0
+
+			ruleStr, err := m.buildSingleRule(leaf, severity, appsecRuleName, appsecRuleDescription, chain, skip, position, isRoot)
 			if err != nil {
 				return nil, err
 			}
-			ret = append(ret, rules...)
+
+			rules = append(rules, ruleStr)
+			position++
 		}
 	}
 
-	if rule.Or != nil {
-		for c, orRule := range rule.Or {
-			depth++
-			orRule.Severity = rule.Severity
-			skip := len(rule.Or) - c - 1
-			root := c == 0
-			rules, err := m.buildRules(&orRule, appsecRuleName, appsecRuleDescription, false, skip, depth, root)
-			if err != nil {
-				return nil, err
-			}
-			ret = append(ret, rules...)
-		}
-	}
+	return rules, nil
+}
 
+// buildSingleRule renders a single leaf CustomRule as a ModSecurity SecRule string.
+func (m *ModsecurityRule) buildSingleRule(rule *CustomRule, severity string, appsecRuleName string, appsecRuleDescription string, chain bool, skip int, position int, isRoot bool) (string, error) {
 	r := strings.Builder{}
 
 	r.WriteString("SecRule ")
 
-	if rule.Zones == nil {
-		return ret, nil
+	zonePrefix := ""
+	variablePrefix := ""
+
+	hasCount := slices.Contains(rule.Transform, "count")
+	if hasCount {
+		zonePrefix = "&"
 	}
 
-	zone_prefix := ""
-	variable_prefix := ""
-	if rule.Transform != nil {
-		for tidx, transform := range rule.Transform {
-			if transform == "count" {
-				zone_prefix = "&"
-				rule.Transform[tidx] = ""
-			}
-		}
-	}
 	for idx, zone := range rule.Zones {
 		if idx > 0 {
 			r.WriteByte('|')
 		}
+
 		mappedZone, ok := zonesMap[zone]
 		if !ok {
-			return nil, fmt.Errorf("unknown zone '%s'", zone)
+			return "", fmt.Errorf("unknown zone '%s'", zone)
 		}
+
 		if len(rule.Variables) == 0 {
 			r.WriteString(mappedZone)
 		} else {
@@ -174,21 +293,25 @@ func (m *ModsecurityRule) buildRules(rule *CustomRule, appsecRuleName string, ap
 				if j > 0 {
 					r.WriteByte('|')
 				}
-				r.WriteString(fmt.Sprintf("%s%s:%s%s", zone_prefix, mappedZone, variable_prefix, variable))
+
+				r.WriteString(fmt.Sprintf("%s%s:%s%s", zonePrefix, mappedZone, variablePrefix, variable))
 			}
 		}
 	}
+
 	r.WriteByte(' ')
 
 	if rule.Match.Type != "" {
 		match, ok := matchMap[rule.Match.Type]
 		if !ok {
-			return nil, fmt.Errorf("unknown match type '%s'", rule.Match.Type)
+			return "", fmt.Errorf("unknown match type '%s'", rule.Match.Type)
 		}
+
 		prefix := ""
 		if rule.Match.Not {
 			prefix = "!"
 		}
+
 		r.WriteString(fmt.Sprintf(`"%s%s %s"`, prefix, match, rule.Match.Value))
 	}
 
@@ -199,45 +322,45 @@ func (m *ModsecurityRule) buildRules(rule *CustomRule, appsecRuleName string, ap
 		msg = appsecRuleName
 	}
 
-	//Should phase:2 be configurable?
-	r.WriteString(fmt.Sprintf(` "id:%d,phase:2,deny,log,msg:'%s',tag:'crowdsec-%s',tag:'cs-custom-rule'`, m.generateRuleID(rule, appsecRuleName, depth), msg, appsecRuleName))
+	r.WriteString(fmt.Sprintf(` "id:%d,phase:2,deny,log,msg:'%s',tag:'crowdsec-%s',tag:'cs-custom-rule'`, m.generateRuleID(rule, appsecRuleName, position), msg, appsecRuleName))
 
-	if rule.Severity != "" && isRoot { // Only put severity on the root rule
-		r.WriteString(fmt.Sprintf(`,severity:'%s'`, rule.Severity))
+	if severity != "" && isRoot {
+		r.WriteString(fmt.Sprintf(`,severity:'%s'`, severity))
 	}
 
-	if rule.Transform != nil {
-		for _, transform := range rule.Transform {
-			if transform == "" {
-				continue
-			}
-			r.WriteByte(',')
-			mappedTransform, ok := transformMap[transform]
-			if !ok {
-				return nil, fmt.Errorf("unknown transform '%s'", transform)
-			}
-			r.WriteString(mappedTransform)
+	for _, transform := range rule.Transform {
+		if transform == "" || (hasCount && transform == "count") {
+			continue
 		}
+
+		r.WriteByte(',')
+
+		mappedTransform, ok := transformMap[transform]
+		if !ok {
+			return "", fmt.Errorf("unknown transform '%s'", transform)
+		}
+
+		r.WriteString(mappedTransform)
 	}
 
 	if rule.BodyType != "" {
 		mappedBodyType, ok := bodyTypeMatch[rule.BodyType]
 		if !ok {
-			return nil, fmt.Errorf("unknown body type '%s'", rule.BodyType)
+			return "", fmt.Errorf("unknown body type '%s'", rule.BodyType)
 		}
+
 		r.WriteString(fmt.Sprintf(",ctl:requestBodyProcessor=%s", mappedBodyType))
 	}
 
-	if and {
+	if chain {
 		r.WriteString(",chain")
 	}
 
-	if toSkip > 0 {
-		r.WriteString(fmt.Sprintf(",skip:%d", toSkip))
+	if skip > 0 {
+		r.WriteString(fmt.Sprintf(",skip:%d", skip))
 	}
 
 	r.WriteByte('"')
 
-	ret = append(ret, r.String())
-	return ret, nil
+	return r.String(), nil
 }


### PR DESCRIPTION
Allow mixing `or` and `and` conditions in waf rules.

Complex rules are converted to a disjunctive normal form so that conditions can be expressed as ORs of ANDs (groups of `chain` with `skip` to jump between the groups).

This can leads to duplications in the rules (eg, a top-level condition will be repeated multiple times in the generated rules if there's a bunch of `OR` afterwards), but it shouldn't have any meaningful impact on the performance. 