### PR TITLE
Use environment proxy settings for notification-http

### DIFF
--- a/cmd/notification-http/main.go
+++ b/cmd/notification-http/main.go
@@ -95,6 +95,7 @@ func getTLSClient(c *PluginConfig) error {
 	}
 
 	transport := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: tlsConfig,
 	}
 


### PR DESCRIPTION
Make use of the http_proxy, https_proxy, and no_proxy environment variables (and their uppercase equivalents) when sending http notifications.