### PR TITLE
Add dedup Param to apiClient

### DIFF
--- a/pkg/apiclient/decisions_service.go
+++ b/pkg/apiclient/decisions_service.go
@@ -33,6 +33,7 @@ type DecisionsStreamOpts struct {
 	Startup                bool   `url:"startup,omitempty"`
 	CommunityPull          bool   `url:"community_pull"`
 	AdditionalPull         bool   `url:"additional_pull"`
+	Dedup                  bool   `url:"dedup"`
 	Scopes                 string `url:"scopes,omitempty"`
 	ScenariosContaining    string `url:"scenarios_containing,omitempty"`
 	ScenariosNotContaining string `url:"scenarios_not_containing,omitempty"`
@@ -45,7 +46,7 @@ func (o *DecisionsStreamOpts) addQueryParamsToURL(url string) (string, error) {
 		return "", err
 	}
 
-	// Those 2 are a bit different
+	// Those 3 are a bit different
 	// They default to true, and we only want to include them if they are false
 
 	if params.Get("community_pull") == "true" {
@@ -54,6 +55,10 @@ func (o *DecisionsStreamOpts) addQueryParamsToURL(url string) (string, error) {
 
 	if params.Get("additional_pull") == "true" {
 		params.Del("additional_pull")
+	}
+
+	if params.Get("dedup") == "true" {
+		params.Del("dedup")
 	}
 
 	return fmt.Sprintf("%s?%s", url, params.Encode()), nil

--- a/pkg/apiclient/decisions_service_test.go
+++ b/pkg/apiclient/decisions_service_test.go
@@ -447,6 +447,7 @@ func TestDecisionsStreamOpts_addQueryParamsToURL(t *testing.T) {
 		ScenariosNotContaining string
 		CommunityPull          bool
 		AdditionalPull         bool
+		Dedup                  bool
 	}
 
 	tests := []struct {
@@ -461,6 +462,7 @@ func TestDecisionsStreamOpts_addQueryParamsToURL(t *testing.T) {
 			fields: fields{
 				CommunityPull:  true,
 				AdditionalPull: true,
+				Dedup:          true,
 			},
 		},
 		{
@@ -469,6 +471,7 @@ func TestDecisionsStreamOpts_addQueryParamsToURL(t *testing.T) {
 				Startup:        true,
 				CommunityPull:  true,
 				AdditionalPull: true,
+				Dedup:          true,
 			},
 			expected: baseURLString + "?startup=true",
 		},
@@ -481,6 +484,7 @@ func TestDecisionsStreamOpts_addQueryParamsToURL(t *testing.T) {
 				ScenariosNotContaining: "bf",
 				CommunityPull:          true,
 				AdditionalPull:         true,
+				Dedup:                  true,
 			},
 			expected: baseURLString + "?scenarios_containing=ssh&scenarios_not_containing=bf&scopes=ip%2Crange&startup=true",
 		},
@@ -489,8 +493,27 @@ func TestDecisionsStreamOpts_addQueryParamsToURL(t *testing.T) {
 			fields: fields{
 				CommunityPull:  false,
 				AdditionalPull: false,
+				Dedup:          true,
 			},
 			expected: baseURLString + "?additional_pull=false&community_pull=false",
+		},
+		{
+			name: "dedup=false",
+			fields: fields{
+				CommunityPull:  true,
+				AdditionalPull: true,
+				Dedup:          false,
+			},
+			expected: baseURLString + "?dedup=false",
+		},
+		{
+			name: "all pull options false",
+			fields: fields{
+				CommunityPull:  false,
+				AdditionalPull: false,
+				Dedup:          false,
+			},
+			expected: baseURLString + "?additional_pull=false&community_pull=false&dedup=false",
 		},
 	}
 
@@ -503,6 +526,7 @@ func TestDecisionsStreamOpts_addQueryParamsToURL(t *testing.T) {
 				ScenariosNotContaining: tt.fields.ScenariosNotContaining,
 				CommunityPull:          tt.fields.CommunityPull,
 				AdditionalPull:         tt.fields.AdditionalPull,
+				Dedup:                  tt.fields.Dedup,
 			}
 
 			got, err := o.addQueryParamsToURL(baseURLString)

--- a/pkg/modelscapi/centralapi_swagger.yaml
+++ b/pkg/modelscapi/centralapi_swagger.yaml
@@ -68,6 +68,12 @@ paths:
           default: true
           required: false
           description: "Fetch additional blocklists content"
+        - in: query
+          name: "dedup"
+          type: "boolean"
+          default: true
+          required: false
+          description: "Enable deduplication of decisions"
       responses:
         "200":
           description: "200 response"


### PR DESCRIPTION
With #3373 it was discussed that the dedup option can be used to prevent deduplication.
This option was added to the server with #687

Exposing this would help other client use this query param properly.