### PR TITLE
refactor(docker): modernize Dockerfile.debian with build optimizations

### DIFF
--- a/build/docker/Dockerfile.debian
+++ b/build/docker/Dockerfile.debian
@@ -1,8 +1,17 @@
-FROM docker.io/golang:1.25-bookworm AS build
+# syntax=docker.io/docker/dockerfile-upstream:1.23.0
+
+ARG GO_VERSION=1.25
+FROM docker.io/library/golang:${GO_VERSION}-trixie AS build
+
+# Platform args (auto-set by BuildKit with --platform)
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+USER root
+SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
 ARG BUILD_VERSION
-
-WORKDIR /go/src/crowdsec
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NOWARNINGS="yes"
@@ -11,60 +20,114 @@ ENV DEBCONF_NOWARNINGS="yes"
 ENV RE2_VERSION=2023-03-01
 ENV BUILD_VERSION=${BUILD_VERSION}
 
+# Setup & deps
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked <<-EOF
+echo "githubciXXXXXXXXXXXXXXXXXXXXXXXX" > /etc/machine-id
+go install github.com/mikefarah/yq/v4@v4.50.1
+
 # wizard.sh requires GNU coreutils
-RUN apt-get update && \
-    apt-get install -y -q git gcc libc-dev make bash gettext binutils-gold coreutils tzdata && \
-    wget https://github.com/google/re2/archive/refs/tags/${RE2_VERSION}.tar.gz && \
-    tar -xzf ${RE2_VERSION}.tar.gz && \
-    cd re2-${RE2_VERSION} && \
-    make && \
-    make install && \
-    echo "githubciXXXXXXXXXXXXXXXXXXXXXXXX" > /etc/machine-id && \
-    go install github.com/mikefarah/yq/v4@v4.50.1
+apt-get update -q
+apt-get install -y --no-install-recommends git build-essential gettext binutils-gold coreutils tzdata
+EOF
 
+# Deps from source (cache per architecture)
+RUN --mount=type=cache,target=/tmp/re2,id=re2-${TARGETARCH} <<-EOF
+cd /tmp/re2 || exit 1
+wget -q "https://github.com/google/re2/archive/refs/tags/${RE2_VERSION}.tar.gz"
+tar -xzf ${RE2_VERSION}.tar.gz
+cd re2-${RE2_VERSION} || exit 1
+make -j4
+make install
+EOF
+
+WORKDIR /go/src/crowdsec
+
+# CGO required for re2_cgo build tag
+ENV CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH}
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
+# Cache Go dependencies
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod,id=gomod-${TARGETARCH} <<-EOF
+go mod download
+go mod verify
+EOF
+
+# Build & install
 COPY . .
+RUN --mount=type=cache,target=/go/pkg/mod,id=gomod-${TARGETARCH} --mount=type=cache,target=/root/.cache/go-build,id=gobuild-${TARGETARCH} <<-EOF
+make clean release DOCKER_BUILD=1 BUILD_STATIC=1
 
-RUN make clean release DOCKER_BUILD=1 BUILD_STATIC=1 && \
-    cd crowdsec-v* && \
-    ./wizard.sh --docker-mode && \
-    cd - >/dev/null && \
-    cscli hub update --with-content && \
-    cscli collections install crowdsecurity/linux && \
-    cscli parsers install crowdsecurity/whitelists && \
-    echo '{"source": "file", "filename": "/does/not/exist", "labels": {"type": "syslog"}}' > /etc/crowdsec/acquis.yaml
+(
+    cd crowdsec-v* || exit 1
+    ./wizard.sh --docker-mode
+)
+EOF
 
-    # we create a useless acquis.yaml, which will be overridden by a mounted volume
-    # in most cases, but is still required for the container to start during tests
+# cscli install & update
+RUN <<-EOF
+cscli hub update --with-content
+cscli collections install crowdsecurity/linux
+cscli parsers install crowdsecurity/whitelists
+
+# We create a useless acquis.yaml, which will be overridden by a mounted volume
+# in most cases, but is still required for the container to start during tests
+#
+# In case we need to remove agents here..
+# ```bash
+# cscli machines list -o json | yq '.[].machineId' | xargs -r cscli machines delete
+# ```
+echo '{"source": "file", "filename": "/does/not/exist", "labels": {"type": "syslog"}}' > /etc/crowdsec/acquis.yaml
+EOF
 
 
-    # In case we need to remove agents here..
-    # cscli machines list -o json | yq '.[].machineId' | xargs -r cscli machines delete
+FROM docker.io/library/debian:trixie-slim AS slim
 
-FROM docker.io/debian:bookworm-slim AS slim
+# Platform args for arch-specific caches
+ARG TARGETARCH
+
+# OCI labels
+LABEL \
+    org.opencontainers.image.source="https://github.com/crowdsecurity/crowdsec" \
+    org.opencontainers.image.description="CrowdSec Security Engine" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.vendor="CrowdSec"
+
+# XXX Lot of things hardcoded to /etc/crowdsec and assuming we are root, can’t do rootless for now.
+USER root
+SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NOWARNINGS="yes"
 
-RUN apt-get update && \
-    apt-get install -y -q --install-recommends --no-install-suggests \
-    procps \
-    systemd \
-    iproute2 \
-    ca-certificates \
-    bash \
-    tzdata \
-    rsync && \
-    mkdir -p /staging/etc/crowdsec && \
-    mkdir -p /staging/etc/crowdsec/acquis.d && \
-    mkdir -p /staging/var/lib/crowdsec && \
-    mkdir -p /var/lib/crowdsec/data
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-${TARGETARCH} --mount=type=cache,target=/var/lib/apt,sharing=locked,id=aptlib-${TARGETARCH} <<-EOF
+apt-get update -q
+apt-get upgrade -y --no-install-recommends
+apt-get install -y --no-install-recommends procps systemd iproute2 ca-certificates bash tzdata rsync netcat-openbsd
+EOF
+
+RUN <<-EOF
+mkdir -p /staging/etc/crowdsec/acquis.d
+mkdir -p /staging/var/lib/crowdsec
+mkdir -p /var/lib/crowdsec/data
+EOF
 
 COPY --from=build /go/bin/yq /usr/local/bin/crowdsec /usr/local/bin/cscli /usr/local/bin/
 COPY --from=build /etc/crowdsec /staging/etc/crowdsec
 COPY --from=build /go/src/crowdsec/build/docker/docker_start.sh /
 COPY --from=build /go/src/crowdsec/build/docker/config.yaml /staging/etc/crowdsec/config.yaml
-RUN yq -n '.url="http://0.0.0.0:8080"' | install -m 0600 /dev/stdin /staging/etc/crowdsec/local_api_credentials.yaml && \
-    yq eval -i ".plugin_config.group = \"nogroup\"" /staging/etc/crowdsec/config.yaml
+
+RUN <<-EOF
+yq -n '.url="http://0.0.0.0:8080"' | install -m 0600 /dev/stdin /staging/etc/crowdsec/local_api_credentials.yaml
+yq eval -i ".plugin_config.group = \"nogroup\"" /staging/etc/crowdsec/config.yaml
+EOF
+
+# Prometheus metrics (6060), appsec (7422) and LAPI (8080)
+EXPOSE 6060 7422 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+    CMD cscli lapi status || exit 1
 
 ENTRYPOINT ["/bin/bash", "docker_start.sh"]
 


### PR DESCRIPTION
- Add BuildKit syntax directive and SHELL for proper error handling
- Upgrade base images from bookworm to trixie
- Add cache mounts for apt, re2, go modules, and go build (arch-specific)
- Split go mod download from build for better layer caching
- Use heredoc syntax for cleaner multi-line RUN commands
- Add apt-get upgrade for security patches in runtime image
- Use --no-install-recommends consistently to reduce image size
- Set CGO_ENABLED=1 with PKG_CONFIG_PATH/LD_LIBRARY_PATH for re2
- Add proper error handling with || exit 1 and subshells
- Add missing nc deps to debian image