### PR TITLE
db: add some missing indexes

### DIFF
--- a/pkg/database/ent/migrate/schema.go
+++ b/pkg/database/ent/migrate/schema.go
@@ -57,6 +57,16 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{AlertsColumns[0]},
 			},
+			{
+				Name:    "alert_uuid",
+				Unique:  false,
+				Columns: []*schema.Column{AlertsColumns[23]},
+			},
+			{
+				Name:    "alert_scenario",
+				Unique:  false,
+				Columns: []*schema.Column{AlertsColumns[3]},
+			},
 		},
 	}
 	// AllowListsColumns holds the columns for the "allow_lists" table.
@@ -84,6 +94,11 @@ var (
 				Name:    "allowlist_name",
 				Unique:  true,
 				Columns: []*schema.Column{AllowListsColumns[3]},
+			},
+			{
+				Name:    "allowlist_allowlist_id",
+				Unique:  false,
+				Columns: []*schema.Column{AllowListsColumns[6]},
 			},
 		},
 	}
@@ -117,6 +132,11 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{AllowListItemsColumns[6], AllowListItemsColumns[7]},
 			},
+			{
+				Name:    "allowlistitem_expires_at",
+				Unique:  false,
+				Columns: []*schema.Column{AllowListItemsColumns[3]},
+			},
 		},
 	}
 	// BouncersColumns holds the columns for the "bouncers" table.
@@ -143,6 +163,23 @@ var (
 		Name:       "bouncers",
 		Columns:    BouncersColumns,
 		PrimaryKey: []*schema.Column{BouncersColumns[0]},
+		Indexes: []*schema.Index{
+			{
+				Name:    "bouncer_api_key_auth_type",
+				Unique:  false,
+				Columns: []*schema.Column{BouncersColumns[4], BouncersColumns[10]},
+			},
+			{
+				Name:    "bouncer_api_key_ip_address",
+				Unique:  false,
+				Columns: []*schema.Column{BouncersColumns[4], BouncersColumns[6]},
+			},
+			{
+				Name:    "bouncer_last_pull_created_at",
+				Unique:  false,
+				Columns: []*schema.Column{BouncersColumns[9], BouncersColumns[1]},
+			},
+		},
 	}
 	// ConfigItemsColumns holds the columns for the "config_items" table.
 	ConfigItemsColumns = []*schema.Column{
@@ -282,6 +319,18 @@ var (
 		Name:       "machines",
 		Columns:    MachinesColumns,
 		PrimaryKey: []*schema.Column{MachinesColumns[0]},
+		Indexes: []*schema.Index{
+			{
+				Name:    "machine_last_heartbeat_created_at",
+				Unique:  false,
+				Columns: []*schema.Column{MachinesColumns[4], MachinesColumns[1]},
+			},
+			{
+				Name:    "machine_is_validated",
+				Unique:  false,
+				Columns: []*schema.Column{MachinesColumns[10]},
+			},
+		},
 	}
 	// MetaColumns holds the columns for the "meta" table.
 	MetaColumns = []*schema.Column{

--- a/pkg/database/ent/schema/alert.go
+++ b/pkg/database/ent/schema/alert.go
@@ -79,5 +79,7 @@ func (Alert) Edges() []ent.Edge {
 func (Alert) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("id"),
+		index.Fields("uuid"),
+		index.Fields("scenario"),
 	}
 }

--- a/pkg/database/ent/schema/allowlist.go
+++ b/pkg/database/ent/schema/allowlist.go
@@ -32,6 +32,7 @@ func (AllowList) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("id").Unique(),
 		index.Fields("name").Unique(),
+		index.Fields("allowlist_id"),
 	}
 }
 

--- a/pkg/database/ent/schema/allowlist_item.go
+++ b/pkg/database/ent/schema/allowlist_item.go
@@ -38,6 +38,7 @@ func (AllowListItem) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("id"),
 		index.Fields("start_ip", "end_ip"),
+		index.Fields("expires_at"),
 	}
 }
 

--- a/pkg/database/ent/schema/bouncer.go
+++ b/pkg/database/ent/schema/bouncer.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
 
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
@@ -42,4 +43,12 @@ func (Bouncer) Fields() []ent.Field {
 // Edges of the Bouncer.
 func (Bouncer) Edges() []ent.Edge {
 	return nil
+}
+
+func (Bouncer) Indexes() []ent.Index {
+	return []ent.Index{
+		index.Fields("api_key", "auth_type"),
+		index.Fields("api_key", "ip_address"),
+		index.Fields("last_pull", "created_at"),
+	}
 }

--- a/pkg/database/ent/schema/machine.go
+++ b/pkg/database/ent/schema/machine.go
@@ -4,6 +4,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
 
 	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
@@ -57,5 +58,12 @@ func (Machine) Fields() []ent.Field {
 func (Machine) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("alerts", Alert.Type),
+	}
+}
+
+func (Machine) Indexes() []ent.Index {
+	return []ent.Index{
+		index.Fields("last_heartbeat", "created_at"),
+		index.Fields("isValidated"),
 	}
 }


### PR DESCRIPTION
Somes indexes were missing.
While some of them were on tables with very little rows (machines, bouncers, ...), other can have a measurable impact (alert scenario or allowlist expiration).

Indexes added:
 - `Bouncer(api_key, auth_type)`: runs on every bouncer request. Small table but cleaner
 - `Bouncer(api_key, ip_address)`
 - `Bouncer(last_pull, created_at)`: used when flushing inactive bouncers from the DB
 - `Machine(last_heartbeat, created_at)`: same for agents
 - `Alert(uuid)`: used by PAPI when inserting a new alert from the console
 - `Alert(scenario)`: used on the `/alerts` endpoint when filtering per scenario (`cscli alerts list --scenario XX`)
 - `AllowListItem(expires_at)`: Used to flush expired allowlist items or when updating blocklists from CAPI
 - `AllowList(allowlist_id)`