### PR TITLE
Avoid correlated SQLite plans for alert decision filters

### DIFF
--- a/pkg/database/alertfilter.go
+++ b/pkg/database/alertfilter.go
@@ -220,9 +220,9 @@ func alertPredicatesFromFilter(filter map[string][]string) ([]predicate.Alert, e
 				return nil, err
 			}
 		case "decision_type":
-			predicates = append(predicates, alert.HasDecisionsWith(decision.TypeEQ(value[0])))
+			predicates = append(predicates, alert.HasDecisionsMatching(decision.TypeEQ(value[0])))
 		case "origin":
-			predicates = append(predicates, alert.HasDecisionsWith(decision.OriginEQ(value[0])))
+			predicates = append(predicates, alert.HasDecisionsMatching(decision.OriginEQ(value[0])))
 		case "include_capi": // allows to exclude one or more specific origins
 			if err = handleIncludeCapiFilter(value[0], &predicates); err != nil {
 				return nil, err
@@ -233,7 +233,7 @@ func alertPredicatesFromFilter(filter map[string][]string) ([]predicate.Alert, e
 			}
 
 			if hasActiveDecision {
-				predicates = append(predicates, alert.HasDecisionsWith(decision.UntilGTE(time.Now().UTC())))
+				predicates = append(predicates, alert.HasDecisionsMatching(decision.UntilGTE(time.Now().UTC())))
 			} else {
 				predicates = append(predicates, alert.Not(alert.HasDecisions()))
 			}

--- a/pkg/database/ent/alert/decision_predicates.go
+++ b/pkg/database/ent/alert/decision_predicates.go
@@ -1,0 +1,19 @@
+package alert
+
+import (
+	"entgo.io/ent/dialect/sql"
+
+	"github.com/crowdsecurity/crowdsec/pkg/database/ent/predicate"
+)
+
+// HasDecisionsMatching keeps independent decision filters as independent subqueries,
+// but avoids correlated EXISTS plans that are expensive for SQLite on large decision sets.
+func HasDecisionsMatching(preds ...predicate.Decision) predicate.Alert {
+	return predicate.Alert(func(selector *sql.Selector) {
+		decisions := sql.Select(DecisionsColumn).From(sql.Table(DecisionsTable))
+		for _, pred := range preds {
+			pred(decisions)
+		}
+		selector.Where(sql.In(selector.C(FieldID), decisions))
+	})
+}


### PR DESCRIPTION
### Summary

This changes the positive `/v1/alerts` decision filters from Ent's generated `HasDecisionsWith(...)` predicate to a small helper that emits independent `IN` subqueries.

The affected filters are:

- `decision_type`
- `origin`
- `has_active_decision=true`

The intent is to keep the existing filter semantics while avoiding SQLite plans that repeatedly probe `decisions` for each candidate alert.

### Rationale

The current Ent shape is a correlated `EXISTS`, roughly:

```sql
WHERE EXISTS (
  SELECT 1
  FROM decisions
  WHERE decisions.alert_decisions = alerts.id
    AND decisions.origin = ?
)
```

When several decision filters are combined, SQLite plans this as an alert scan plus repeated correlated probes into `decisions`. That gets expensive when a matching alert has thousands of linked decisions, which is the shape seen in #4464 and #4470.

The new helper keeps each decision filter independent, but emits:

```sql
WHERE alerts.id IN (
  SELECT alert_decisions
  FROM decisions
  WHERE decisions.origin = ?
)
```

This lets SQLite build matching alert IDs from `decisions` first, then look up alerts by primary key. It is intentionally not a semantic change: different linked decision rows may still satisfy different filters, just like with the previous separate `HasDecisionsWith(...)` predicates.

### Implementation Notes

- Scoped to positive decision filters only.
- `include_capi=false` is unchanged because it uses negative `NOT EXISTS` predicates. A naive `NOT IN` rewrite is not null-safe when `decisions.alert_decisions` contains `NULL`; I verified this with unlinked `CAPI`/`lists` decisions.
- `scenario` and `ip`/`range` are unchanged. They have similar correlated shapes, but fixture testing did not show the same benefit; the `IN` form for IP/range made SQLite scan larger parts of `decisions`.
- The helper lives in a handwritten `alert` package file, so generated Ent files stay untouched and call sites remain `alert.HasDecisionsMatching(...)`.
- The composite indexes proposed in #4468 do not appear necessary for this fix.

### Testing

Validated on the reproduced SQLite DB from #4464, an expanded #4470-style SQLite fixture, a fresh production SQLite copy with WAL disabled, and the live production Postgres backend.

Result sets:

- Compared current `EXISTS` SQL with new `IN` SQL using `EXCEPT` in both directions.
- Alert IDs matched for the tested #4464/#4470 `/v1/alerts` cases.
- Expanded fixture covered nonzero `cscli`, `lists`, and `CAPI` origins.

SQLite/API behavior:

- On the reproduced DB, the Homepage-style query `decision_type=ban&origin=crowdsec&has_active_decision=1` moved from a 50s+ path to roughly tens of milliseconds in the local reproducer.
- On the expanded #4470 fixture, current code timed out at 35s for `origin=cscli`, `origin=lists`, and a large synthetic origin; the new shape returned those cases in ~160-410ms.
- On a fresh production SQLite copy with WAL disabled (`PRAGMA journal_mode=delete`), current code still timed out on affected alert filters; the new shape returned quickly.

Expanded fixture comparison:

```text
current code / WAL:
origin_cscli     timeout at 35s
origin_lists     timeout at 35s
origin_fixture   timeout at 35s

new IN-subquery shape / WAL:
origin_cscli     161ms
origin_lists     407ms
origin_fixture   413ms
```

Fresh DB / DELETE journal comparison:

```text
current code / fresh DB / DELETE journal:
homepage_bans           timeout at 35s
origin_crowdsec    timeout at 35s
origin_CAPI        1068ms

new IN-subquery shape / same DB / DELETE journal:
homepage_bans       61ms
origin_crowdsec      29ms
origin_CAPI           568ms
```

I also reran the result-set comparison on that fresh DB; the current and new query shapes returned the same alert IDs for the tested cases.

Postgres check:

- Live production Postgres does not reproduce the SQLite timeout behavior.
- Postgres planned both shapes as similar semi-join queries.
- Result sets matched for tested `homepage_bans`, `origin=lists`, `origin=CAPI`, and `origin=cscli` cases.

```text
Postgres EXPLAIN ANALYZE:
homepage_bans       EXISTS 43.181ms   IN 37.270ms
origin=lists   EXISTS 31.990ms   IN 31.730ms
origin=CAPI    EXISTS 24.060ms   IN 23.021ms
```

Go checks:

```text
go test ./pkg/database
go test ./pkg/apiserver -run '^$'
```

Both pass locally.

Refs #4464
Refs #4470
Supersedes the index-only approach explored in #4468
