### PR TITLE
downgrade github.com/mattn/go-sqlite3 to v1.14.32

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.7.10
 	github.com/jszwec/csvutil v1.10.0
 	github.com/mattn/go-isatty v0.0.22
-	github.com/mattn/go-sqlite3 v1.14.44
+	github.com/mattn/go-sqlite3 v1.14.32
 	github.com/moby/moby/api v1.54.2
 	github.com/moby/moby/client v0.4.1
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826

--- a/go.sum
+++ b/go.sum
@@ -441,8 +441,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-runewidth v0.0.22 h1:76lXsPn6FyHtTY+jt2fTTvsMUCZq1k0qwRsAMuxzKAk=
 github.com/mattn/go-runewidth v0.0.22/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
-github.com/mattn/go-sqlite3 v1.14.44 h1:3VSe+xafpbzsLbdr2AWlAZk9yRHiBhTBakioXaCKTF8=
-github.com/mattn/go-sqlite3 v1.14.44/go.mod h1:pjEuOr8IwzLJP2MfGeTb0A35jauH+C2kbHKBr7yXKVQ=
+github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
+github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/maxatome/go-testdeep v1.14.0 h1:rRlLv1+kI8eOI3OaBXZwb3O7xY3exRzdW5QyX48g9wI=
 github.com/maxatome/go-testdeep v1.14.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=


### PR DESCRIPTION
Should fix the underlying regression for #4470 and #4464 (in addition to #4471 which does seem to help).

After investigation, the regression came from the update of github.com/mattn/go-sqlite3 from `v1.14.23` to `1.14.44` (in this PR #4453 for the final update).

After testing the various releases of the go library, it seems the regression was introduced in `v1.14.33`.

I'm not sure *what* the regression is exactly (claude points to [this commit](https://sqlite.org/src/info/e33da6d5dc), but I didn't looked at it in details).

So for now, let's just downgrade sqlite to get back to the performance we had before the release, and we will also improve the queries themselves (with at least #4471, and I've also identified potential gains in the way we perform the pagination for `/v1/alerts`, but that will come later)