### PR TITLE
fix: avoid unused fsnotify watchers in file cat mode

### DIFF
--- a/pkg/acquisition/modules/file/config.go
+++ b/pkg/acquisition/modules/file/config.go
@@ -85,9 +85,23 @@ func (s *Source) Configure(_ context.Context, yamlConfig []byte, logger *log.Ent
 	s.tailMapMutex = &sync.RWMutex{}
 	s.tails = make(map[string]bool)
 
-	s.watcher, err = fsnotify.NewWatcher()
-	if err != nil {
-		return fmt.Errorf("could not create fsnotify watcher: %w", err)
+	if s.config.Mode == configuration.TAIL_MODE {
+		s.watcher, err = fsnotify.NewWatcher()
+		if err != nil {
+			return fmt.Errorf("could not create fsnotify watcher: %w", err)
+		}
+
+		defer func() {
+			if err == nil || s.watcher == nil {
+				return
+			}
+
+			if closeErr := s.watcher.Close(); closeErr != nil {
+				s.logger.Errorf("could not close fsnotify watcher after configure failure: %s", closeErr)
+			}
+
+			s.watcher = nil
+		}()
 	}
 
 	s.logger.Tracef("Actual FileAcquisition Configuration %+v", s.config)

--- a/pkg/acquisition/modules/file/config_internal_test.go
+++ b/pkg/acquisition/modules/file/config_internal_test.go
@@ -1,0 +1,45 @@
+package fileacquisition
+
+import (
+	"testing"
+
+	"github.com/fsnotify/fsnotify"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/crowdsecurity/crowdsec/pkg/metrics"
+)
+
+func TestConfigureCatModeDoesNotCreateWatcher(t *testing.T) {
+	ctx := t.Context()
+	f := &Source{}
+
+	err := f.Configure(ctx, []byte(`
+mode: cat
+filename: testdata/test.log
+`), log.NewEntry(log.New()), metrics.AcquisitionMetricsLevelNone)
+	require.NoError(t, err)
+
+	assert.Nil(t, f.watcher)
+}
+
+func TestConfigureClosesWatcherOnTailModeError(t *testing.T) {
+	ctx := t.Context()
+	f := &Source{}
+
+	probe, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Skipf("cannot allocate fsnotify watcher in this environment: %v", err)
+	}
+
+	require.NoError(t, probe.Close())
+
+	err = f.Configure(ctx, []byte(`
+mode: tail
+filename: "[*-.log"
+`), log.NewEntry(log.New()), metrics.AcquisitionMetricsLevelNone)
+	require.ErrorContains(t, err, "glob failure: syntax error in pattern")
+
+	assert.Nil(t, f.watcher)
+}


### PR DESCRIPTION
## Summary

`mode: cat` was still creating an `fsnotify` watcher, even though oneshot reads dont use it.
On boxes that are already close to `fs.inotify.max_user_instances`, that can fail early with:

`could not create fsnotify watcher: couldn't initialize inotify: too many open files`

This keeps watcher creation in tail mode only, and closes it if tail config bails early. small fix, real footgun.

## Repro

1. Run on a host that's close to the inotify instance ceiling. Linux exposes it in `/proc/sys/fs/inotify/max_user_instances`.
2. Call the file datasource configure path with `mode: cat`.
3. Before this patch it can fail before reading anything, just because it grabs an inotify instance for no reason.
4. After this patch, cat mode does not touch inotify, so the same path keeps working.

## Checks

- `go test ./pkg/acquisition/modules/file -run 'TestConfigure|TestOneShot' -count=1`

related-ish: #2605 #4074

/kind fix