### PR TITLE
feat: add NATS notification plugin

### DIFF
--- a/cmd/notification-nats/Makefile
+++ b/cmd/notification-nats/Makefile
@@ -1,0 +1,17 @@
+ifeq ($(OS), Windows_NT)
+	SHELL := pwsh.exe
+	.SHELLFLAGS := -NoProfile -Command
+	EXT = .exe
+endif
+
+GO = go
+GOBUILD = $(GO) build
+
+BINARY_NAME = notification-nats$(EXT)
+
+build: clean
+	$(GOBUILD) $(LD_OPTS) -o $(BINARY_NAME)
+
+.PHONY: clean
+clean:
+	@$(RM) $(BINARY_NAME) $(WIN_IGNORE_ERR)

--- a/cmd/notification-nats/main.go
+++ b/cmd/notification-nats/main.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	plugin "github.com/hashicorp/go-plugin"
+	nats "github.com/nats-io/nats.go"
+	"gopkg.in/yaml.v3"
+
+	"github.com/crowdsecurity/crowdsec/pkg/csplugin"
+	"github.com/crowdsecurity/crowdsec/pkg/protobufs"
+)
+
+type PluginConfig struct {
+	Name        string     `yaml:"name"`
+	LogLevel    string     `yaml:"log_level"`
+	URL         string     `yaml:"url"`
+	Subject     string     `yaml:"subject"`
+	Token       string     `yaml:"token"`
+	Credentials string     `yaml:"credentials"`
+	Conn        *nats.Conn `yaml:"-"` // persistent connection, established in Configure()
+}
+
+type NatsPlugin struct {
+	protobufs.UnimplementedNotifierServer
+	ConfigByName map[string]PluginConfig
+}
+
+var logger hclog.Logger = hclog.New(&hclog.LoggerOptions{
+	Name:       "nats-plugin",
+	Level:      hclog.LevelFromString("INFO"),
+	Output:     os.Stderr,
+	JSONFormat: true,
+})
+
+func buildNatsConn(cfg PluginConfig) (*nats.Conn, error) {
+	opts := []nats.Option{
+		nats.Name("crowdsec-notification-nats"),
+		nats.Timeout(10 * time.Second),
+		nats.ReconnectWait(2 * time.Second),
+		nats.MaxReconnects(-1),
+		nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {
+			logger.Warn("NATS disconnected event", "err", fmt.Sprintf("%v", err))
+		}),
+		nats.ReconnectHandler(func(nc *nats.Conn) {
+			logger.Debug("NATS reconnected event")
+		}),
+	}
+
+	if cfg.Credentials != "" {
+		opts = append(opts, nats.UserCredentials(cfg.Credentials))
+	}
+
+	if cfg.Token != "" {
+		opts = append(opts, nats.Token(cfg.Token))
+	}
+
+	nc, err := nats.Connect(cfg.URL, opts...)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Failed to connect to NATS : %s", err))
+		return nil, fmt.Errorf("failed to connect to NATS at %s: %w", cfg.URL, err)
+	}
+	logger.Debug(fmt.Sprintf("NATS connection established to %s", cfg.URL))
+
+	return nc, nil
+}
+
+func (n *NatsPlugin) Notify(ctx context.Context, notification *protobufs.Notification) (*protobufs.Empty, error) {
+	name := notification.GetName()
+	cfg, ok := n.ConfigByName[name]
+
+	if !ok {
+		return nil, fmt.Errorf("invalid plugin config name %s", name)
+	}
+
+	if cfg.LogLevel != "" {
+		logger.SetLevel(hclog.LevelFromString(cfg.LogLevel))
+	}
+
+	logger.Debug(fmt.Sprintf("received signal for %s config", name))
+
+	text := notification.GetText()
+
+	if cfg.Conn == nil {
+		// Lazy connect: Configure stored the config but couldn't connect at startup.
+		// Try to establish the connection now. If it fails, return error so the
+		// broker's retry-with-backoff can try again later.
+		logger.Warn(fmt.Sprintf("NATS connection missing for %s, attempting lazy connect", name))
+		nc, err := buildNatsConn(cfg)
+		if err != nil {
+			return &protobufs.Empty{}, fmt.Errorf("lazy connect to NATS failed for plugin %s: %w", name, err)
+		}
+		cfg.Conn = nc
+		n.ConfigByName[name] = cfg
+	}
+
+	logger.Debug(fmt.Sprintf("making NATS publish to %s", cfg.Subject))
+
+	// Publish is fire-and-forget in NATS. No Flush() needed — it blocks
+	// indefinitely during reconnect and is not context-aware, causing
+	// goroutine leaks when NATS is down.
+	if err := cfg.Conn.Publish(cfg.Subject, []byte(text)); err != nil {
+		logger.Error(fmt.Sprintf("Failed to make NATS publish : %s", err))
+		return &protobufs.Empty{}, err
+	}
+
+	logger.Debug(fmt.Sprintf("notification published successfully to %s", cfg.Subject))
+
+	return &protobufs.Empty{}, nil
+}
+
+func (n *NatsPlugin) Configure(_ context.Context, config *protobufs.Config) (*protobufs.Empty, error) {
+	rawConfig := config.GetConfig()
+
+	d := PluginConfig{}
+
+	if err := yaml.Unmarshal(rawConfig, &d); err != nil {
+		return nil, err
+	}
+
+	if d.URL == "" {
+		return nil, fmt.Errorf("NATS plugin '%s': url is required", d.Name)
+	}
+
+	if d.Subject == "" {
+		return nil, fmt.Errorf("NATS plugin '%s': subject is required", d.Name)
+	}
+
+	// Try to establish persistent NATS connection now, but don't fail
+	// if NATS is currently down — store the config anyway and retry
+	// on the first Notify() call.
+	nc, err := buildNatsConn(d)
+	if err != nil {
+		logger.Warn(fmt.Sprintf("NATS connection failed for %s, will retry on first notification", d.Name))
+	} else {
+		d.Conn = nc
+	}
+
+	n.ConfigByName[d.Name] = d
+	logger.Debug(fmt.Sprintf("NATS plugin '%s' configured for URL '%s'", d.Name, d.URL))
+
+	return &protobufs.Empty{}, nil
+}
+
+func main() {
+	handshake := plugin.HandshakeConfig{
+		ProtocolVersion:  1,
+		MagicCookieKey:   "CROWDSEC_PLUGIN_KEY",
+		MagicCookieValue: os.Getenv("CROWDSEC_PLUGIN_KEY"),
+	}
+
+	sp := &NatsPlugin{ConfigByName: make(map[string]PluginConfig)}
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: handshake,
+		Plugins: map[string]plugin.Plugin{
+			"nats": &csplugin.NotifierPlugin{
+				Impl: sp,
+			},
+		},
+		GRPCServer: plugin.DefaultGRPCServer,
+		Logger:     logger,
+	})
+}

--- a/cmd/notification-nats/nats.yaml
+++ b/cmd/notification-nats/nats.yaml
@@ -1,0 +1,34 @@
+type: nats          # Don't change
+name: nats_default  # Must match the registered plugin in the profile
+
+# One of "trace", "debug", "info", "warn", "error", "off"
+log_level: info
+
+# group_wait:         # Time to wait collecting alerts before relaying a message to this plugin, eg "30s"
+# group_threshold:    # Amount of alerts that triggers a message before <group_wait> has expired, eg "10"
+# max_retry:          # Number of attempts to relay messages to plugins in case of error
+# timeout:            # Time to wait for response from the plugin before considering the attempt a failure, eg "10s"
+
+#-------------------------
+# plugin-specific options
+
+# The following template receives a list of models.Alert objects
+# The output goes in the NATS message body
+format: |
+  {{.|toJson}}
+
+# NATS server URL (required)
+url: nats://localhost:4222
+
+# NATS subject to publish to (required)
+subject: notify.crowdsec
+
+# Authentication: use token or credentials file (at least one required if server has auth)
+# token: <NATS_AUTH_TOKEN>
+# credentials: /path/to/nats.creds
+
+---
+# 
+# type: nats
+# name: nats_second_notification
+# ...

--- a/go.mod
+++ b/go.mod
@@ -205,6 +205,9 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nats-io/nats.go v1.52.0 // indirect
+	github.com/nats-io/nkeys v0.4.15 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/oasdiff/yaml v0.0.9 // indirect
 	github.com/oasdiff/yaml3 v0.0.12 // indirect

--- a/go.mod
+++ b/go.mod
@@ -212,6 +212,9 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nats-io/nats.go v1.52.0 // indirect
+	github.com/nats-io/nkeys v0.4.15 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/oasdiff/yaml v0.1.1 // indirect
 	github.com/oasdiff/yaml3 v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -472,6 +472,12 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/nats-io/nats.go v1.52.0 h1:n3avV4VBsCgsdwh71TppsTwtv+QdPs7ntSKM8qJLGsc=
+github.com/nats-io/nats.go v1.52.0/go.mod h1:26HypzazeOkyO3/mqd1zZd53STJN0EjCYF9Uy2ZOBno=
+github.com/nats-io/nkeys v0.4.15 h1:JACV5jRVO9V856KOapQ7x+EY8Jo3qw1vJt/9Jpwzkk4=
+github.com/nats-io/nkeys v0.4.15/go.mod h1:CpMchTXC9fxA5zrMo4KpySxNjiDVvr8ANOSZdiNfUrs=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=

--- a/go.sum
+++ b/go.sum
@@ -474,6 +474,12 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/nats-io/nats.go v1.52.0 h1:n3avV4VBsCgsdwh71TppsTwtv+QdPs7ntSKM8qJLGsc=
+github.com/nats-io/nats.go v1.52.0/go.mod h1:26HypzazeOkyO3/mqd1zZd53STJN0EjCYF9Uy2ZOBno=
+github.com/nats-io/nkeys v0.4.15 h1:JACV5jRVO9V856KOapQ7x+EY8Jo3qw1vJt/9Jpwzkk4=
+github.com/nats-io/nkeys v0.4.15/go.mod h1:CpMchTXC9fxA5zrMo4KpySxNjiDVvr8ANOSZdiNfUrs=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=

--- a/pkg/apiserver/alerts_test.go
+++ b/pkg/apiserver/alerts_test.go
@@ -178,7 +178,7 @@ func TestCreateAllowlistedAlert(t *testing.T) {
 	// We should have no alert as the IP is allowlisted
 	w = lapi.RecordResponse(t, ctx, "GET", "/v1/alerts", emptyBody, "password")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "null", w.Body.String())
+	assert.Equal(t, "[]", w.Body.String())
 
 	// Create Alert with expired allowlisted IP
 	alertContent = GetAlertReaderFromFile(t, "./tests/alert_allowlisted_expired.json")
@@ -261,7 +261,7 @@ func TestAlertListFilters(t *testing.T) {
 
 	w = lapi.RecordResponse(t, ctx, "GET", "/v1/alerts?decision_type=ratata", emptyBody, "password")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "null", w.Body.String())
+	assert.Equal(t, "[]", w.Body.String())
 
 	// test scope (ok)
 
@@ -274,7 +274,7 @@ func TestAlertListFilters(t *testing.T) {
 
 	w = lapi.RecordResponse(t, ctx, "GET", "/v1/alerts?scope=rarara", emptyBody, "password")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "null", w.Body.String())
+	assert.Equal(t, "[]", w.Body.String())
 
 	// test scenario (ok)
 
@@ -287,7 +287,7 @@ func TestAlertListFilters(t *testing.T) {
 
 	w = lapi.RecordResponse(t, ctx, "GET", "/v1/alerts?scenario=crowdsecurity/nope", emptyBody, "password")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "null", w.Body.String())
+	assert.Equal(t, "[]", w.Body.String())
 
 	// test ip (ok)
 
@@ -300,7 +300,7 @@ func TestAlertListFilters(t *testing.T) {
 
 	w = lapi.RecordResponse(t, ctx, "GET", "/v1/alerts?ip=99.122.77.195", emptyBody, "password")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "null", w.Body.String())
+	assert.Equal(t, "[]", w.Body.String())
 
 	// test ip (invalid value)
 
@@ -319,7 +319,7 @@ func TestAlertListFilters(t *testing.T) {
 
 	w = lapi.RecordResponse(t, ctx, "GET", "/v1/alerts?range=99.122.77.0/24&contains=false", emptyBody, "password")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "null", w.Body.String())
+	assert.Equal(t, "[]", w.Body.String())
 
 	// test range (invalid value)
 
@@ -338,7 +338,7 @@ func TestAlertListFilters(t *testing.T) {
 
 	w = lapi.RecordResponse(t, ctx, "GET", "/v1/alerts?since=1ns", emptyBody, "password")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "null", w.Body.String())
+	assert.Equal(t, "[]", w.Body.String())
 
 	// test since (invalid value)
 
@@ -357,7 +357,7 @@ func TestAlertListFilters(t *testing.T) {
 
 	w = lapi.RecordResponse(t, ctx, "GET", "/v1/alerts?until=1m", emptyBody, "password")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "null", w.Body.String())
+	assert.Equal(t, "[]", w.Body.String())
 
 	// test until (invalid value)
 
@@ -390,7 +390,7 @@ func TestAlertListFilters(t *testing.T) {
 
 	w = lapi.RecordResponse(t, ctx, "GET", "/v1/alerts?has_active_decision=false", emptyBody, "password")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "null", w.Body.String())
+	assert.Equal(t, "[]", w.Body.String())
 
 	// test has active decision (invalid value)
 

--- a/pkg/apiserver/controllers/v1/alerts.go
+++ b/pkg/apiserver/controllers/v1/alerts.go
@@ -99,7 +99,8 @@ func FormatOneAlert(alert *ent.Alert) *models.Alert {
 
 // FormatAlerts : Format results from the database to be swagger model compliant
 func FormatAlerts(result []*ent.Alert) models.AddAlertsRequest {
-	var data models.AddAlertsRequest
+	// not "var data ...": the swagger says array, a nil slice would marshal to null
+	data := make(models.AddAlertsRequest, 0, len(result))
 	for _, alertItem := range result {
 		data = append(data, FormatOneAlert(alertItem))
 	}

--- a/pkg/appsec/appsec.go
+++ b/pkg/appsec/appsec.go
@@ -245,6 +245,11 @@ type AppsecRequestState struct {
 	// the allowlist cookie itself, not by this flag.
 	ChallengeBypassed bool
 
+	// ChallengeCookieValid is set when the request presented a cookie that
+	// passed ValidCookie. Not cleared by ResetResponse: it stays true for
+	// the whole request, out-of-band included.
+	ChallengeCookieValid bool
+
 	// ChallengeExempt is set by the ExemptFromChallenge expr helper to exempt
 	// the current request from the bot challenge: SendChallenge becomes a no-op
 	// once it is set. It only affects the current request and doesn't mint a
@@ -300,6 +305,14 @@ func (s *AppsecRequestState) ResetResponse(cfg *AppsecConfig) {
 	s.SubmissionRejection = nil
 	s.ChallengeBypassed = false
 	s.HooksHalted = false
+}
+
+// HasValidChallengeCookie reports whether the request has cleared the
+// challenge: either it presented a valid cookie, or a hook exempted it. A
+// cookie minted during this request (submission, GrantChallengeCookie)
+// doesn't count — the visitor presents it on the next hop.
+func (s *AppsecRequestState) HasValidChallengeCookie() bool {
+	return s.ChallengeCookieValid || s.ChallengeExempt
 }
 
 func (s *AppsecRequestState) DropInfo(request *ParsedRequest) *AppsecDropInfo {
@@ -1244,6 +1257,7 @@ func (w *AppsecRuntimeConfig) ProcessOnChallengeRules(ctx context.Context, state
 			fp.AllowlistReason = cookieData.AllowlistReason
 			state.Fingerprint = &fp
 			state.CookiePowDifficulty = cookieData.PowDifficulty
+			state.ChallengeCookieValid = true
 			// An allowlist cookie minted on a prior request must short-circuit
 			// SendChallenge on every replay, exactly like a GrantChallengeCookie
 			// call within the current request would. Without this, the visitor

--- a/pkg/appsec/appsec_challenge_test.go
+++ b/pkg/appsec/appsec_challenge_test.go
@@ -1,6 +1,7 @@
 package appsec
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"sync"
@@ -437,4 +438,93 @@ func TestGenerateResponseChallengeNilHeaders(t *testing.T) {
 		require.NotNil(t, body.UserHeaders)
 		assert.Equal(t, []string{challenge.DefaultChallengeCSP}, body.UserHeaders["Content-Security-Policy"])
 	})
+}
+
+func TestHasValidChallengeCookie(t *testing.T) {
+	rt := newChallengeTestRuntime(t, nil)
+
+	mintReq := newInBandRequest(http.MethodGet, "/", nil)
+	ck, err := rt.ChallengeRuntime.SealAllowlistCookie(mintReq.HTTPRequest, "has-valid-cookie", nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		cookie   string
+		expected bool
+	}{
+		{name: "no cookie", expected: false},
+		{name: "invalid cookie", cookie: "garbage", expected: false},
+		{name: "valid cookie", cookie: ck.Val, expected: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := newInBandRequest(http.MethodGet, "/protected", nil)
+			if tc.cookie != "" {
+				req.HTTPRequest.Header.Set("Cookie", challenge.ChallengeCookieName+"="+tc.cookie)
+			}
+
+			state := &AppsecRequestState{}
+			state.ResetResponse(rt.Config)
+
+			require.NoError(t, rt.ProcessOnChallengeRules(t.Context(), state, req))
+			assert.Equal(t, tc.expected, state.HasValidChallengeCookie())
+		})
+	}
+}
+
+func TestHasValidChallengeCookieOnExempt(t *testing.T) {
+	rt := newChallengeTestRuntime(t, nil)
+
+	state := &AppsecRequestState{}
+	state.ResetResponse(rt.Config)
+
+	req := newInBandRequest(http.MethodGet, "/protected", nil)
+
+	require.False(t, state.HasValidChallengeCookie())
+	require.NoError(t, rt.ExemptFromChallenge(state, req, "verified-bot"))
+	assert.True(t, state.HasValidChallengeCookie())
+}
+
+func TestHasValidChallengeCookieFalseOnGrant(t *testing.T) {
+	rt := newChallengeTestRuntime(t, nil)
+
+	state := &AppsecRequestState{}
+	state.ResetResponse(rt.Config)
+
+	req := newInBandRequest(http.MethodGet, "/protected", nil)
+
+	require.NoError(t, rt.GrantChallengeCookie(state, req, "granted", nil))
+	assert.False(t, state.HasValidChallengeCookie())
+}
+
+func TestHasValidChallengeCookieInPreEval(t *testing.T) {
+	rt := newChallengeTestRuntime(t, nil)
+
+	compiled, err := buildHookList(t.Context(), []Hook{
+		{
+			Filter: "HasValidChallengeCookie()",
+			Apply:  []string{"SetRemediation('allow')"},
+		},
+	}, hookPreEval, &appsecExprPatcher{})
+	require.NoError(t, err)
+
+	for _, valid := range []bool{false, true} {
+		t.Run(fmt.Sprintf("valid=%t", valid), func(t *testing.T) {
+			state := &AppsecRequestState{HookVars: map[string]string{}}
+			state.ResetResponse(rt.Config)
+			state.ChallengeCookieValid = valid
+
+			req := newInBandRequest(http.MethodGet, "/protected", nil)
+
+			require.NoError(t, rt.processHooks(compiled, GetPreEvalEnv(t.Context(), rt, state, req), "pre_eval", state))
+
+			if valid {
+				require.NotNil(t, state.PendingAction)
+				assert.Equal(t, AllowRemediation, *state.PendingAction)
+			} else {
+				assert.Nil(t, state.PendingAction)
+			}
+		})
+	}
 }

--- a/pkg/appsec/challenge/fingerprint.go
+++ b/pkg/appsec/challenge/fingerprint.go
@@ -2,6 +2,7 @@
 // returns: FlexInt / FlexBool tolerant primitives and the nested
 // FingerprintData / fingerprintBotAlias structures that mirror the JSON
 // payload one-to-one. Handwritten accessors live in fingerprint_helpers.go,
+// tolerant decoding of the object-shaped signals in fingerprint_flex.go,
 // proto ↔ struct conversion in fingerprint_proto.go, and mismatch detection
 // methods in fingerprint_mismatch.go.
 

--- a/pkg/appsec/challenge/fingerprint_flex.go
+++ b/pkg/appsec/challenge/fingerprint_flex.go
@@ -1,0 +1,136 @@
+// fingerprint_flex.go holds the tolerant decoding of object-shaped signals.
+// The bundle wraps every collector in a try/catch and substitutes a sentinel
+// string — "ERROR", "SKIPPED", "NA" or "INIT" — for whatever the collector was
+// supposed to return. FlexBool / FlexInt (fingerprint.go) absorb that for
+// scalars; flexStruct does it for the signals that are whole objects.
+
+package challenge
+
+import (
+	"encoding/json"
+)
+
+// flexStruct decodes an object-shaped signal, tolerating the sentinel string
+// the bundle substitutes when the collector threw: dst is left zero and no
+// error is reported, so one blown collector no longer rejects the whole
+// submission. Anything else decodes normally — malformed payloads still fail.
+//
+// dst must point at a method-stripped copy of the target type (declare
+// `type alias T` in the caller and convert); passing the target type itself
+// recurses back into its own UnmarshalJSON.
+func flexStruct[T any](data []byte, dst *T) error {
+	var sentinel string
+	if err := json.Unmarshal(data, &sentinel); err == nil {
+		return nil
+	}
+
+	return json.Unmarshal(data, dst)
+}
+
+func (v *fingerprintScreenResolution) UnmarshalJSON(data []byte) error {
+	type alias fingerprintScreenResolution
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintMultimediaDevices) UnmarshalJSON(data []byte) error {
+	type alias fingerprintMultimediaDevices
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintDeviceMediaQueries) UnmarshalJSON(data []byte) error {
+	type alias fingerprintDeviceMediaQueries
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintDeviceKeyboard) UnmarshalJSON(data []byte) error {
+	type alias fingerprintDeviceKeyboard
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintBrowserFeatures) UnmarshalJSON(data []byte) error {
+	type alias fingerprintBrowserFeatures
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintBrowserPlugins) UnmarshalJSON(data []byte) error {
+	type alias fingerprintBrowserPlugins
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintBrowserExtensions) UnmarshalJSON(data []byte) error {
+	type alias fingerprintBrowserExtensions
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintBrowserHighEntropyValues) UnmarshalJSON(data []byte) error {
+	type alias fingerprintBrowserHighEntropyValues
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintBrowserToSourceError) UnmarshalJSON(data []byte) error {
+	type alias fingerprintBrowserToSourceError
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintBrowserAI) UnmarshalJSON(data []byte) error {
+	type alias fingerprintBrowserAI
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintGraphicsWebGL) UnmarshalJSON(data []byte) error {
+	type alias fingerprintGraphicsWebGL
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintGraphicsWebGPU) UnmarshalJSON(data []byte) error {
+	type alias fingerprintGraphicsWebGPU
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintGraphicsCanvas) UnmarshalJSON(data []byte) error {
+	type alias fingerprintGraphicsCanvas
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (c *fingerprintCodecs) UnmarshalJSON(data []byte) error {
+	type alias fingerprintCodecs
+
+	return flexStruct(data, (*alias)(c))
+}
+
+func (v *fingerprintLocaleInternationalization) UnmarshalJSON(data []byte) error {
+	type alias fingerprintLocaleInternationalization
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintLocaleLanguages) UnmarshalJSON(data []byte) error {
+	type alias fingerprintLocaleLanguages
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintIframeContext) UnmarshalJSON(data []byte) error {
+	type alias fingerprintIframeContext
+
+	return flexStruct(data, (*alias)(v))
+}
+
+func (v *fingerprintWebWorkerContext) UnmarshalJSON(data []byte) error {
+	type alias fingerprintWebWorkerContext
+
+	return flexStruct(data, (*alias)(v))
+}

--- a/pkg/appsec/challenge/fingerprint_flex_test.go
+++ b/pkg/appsec/challenge/fingerprint_flex_test.go
@@ -1,0 +1,199 @@
+package challenge
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A collector that throws is reported as a bare sentinel string where the
+// object was expected. Decoding must drop that one signal, not the payload.
+func TestFlexStructSentinel(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		assertFP func(t *testing.T, fp *FingerprintData)
+	}{
+		{
+			name: "screenResolution",
+			raw:  `{"signals": {"device": {"cpuCount": 14, "screenResolution": "ERROR"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintScreenResolution{}, fp.Signals.Device.ScreenResolution)
+				assert.Equal(t, FlexInt(14), fp.Signals.Device.CPUCount)
+			},
+		},
+		{
+			name: "multimediaDevices",
+			raw:  `{"signals": {"device": {"multimediaDevices": "NA"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintMultimediaDevices{}, fp.Signals.Device.MultimediaDevices)
+			},
+		},
+		{
+			name: "mediaQueries",
+			raw:  `{"signals": {"device": {"mediaQueries": "ERROR"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintDeviceMediaQueries{}, fp.Signals.Device.MediaQueries)
+			},
+		},
+		{
+			name: "keyboard",
+			raw:  `{"signals": {"device": {"keyboard": "ERROR"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintDeviceKeyboard{}, fp.Signals.Device.Keyboard)
+			},
+		},
+		{
+			name: "browser features",
+			raw:  `{"signals": {"browser": {"userAgent": "curl/8", "features": "ERROR"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintBrowserFeatures{}, fp.Signals.Browser.Features)
+				assert.Equal(t, "curl/8", fp.Signals.Browser.UserAgent)
+			},
+		},
+		{
+			name: "plugins",
+			raw:  `{"signals": {"browser": {"plugins": "NA"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintBrowserPlugins{}, fp.Signals.Browser.Plugins)
+			},
+		},
+		{
+			name: "extensions",
+			raw:  `{"signals": {"browser": {"extensions": "ERROR"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintBrowserExtensions{}, fp.Signals.Browser.Extensions)
+			},
+		},
+		{
+			name: "highEntropyValues",
+			raw:  `{"signals": {"browser": {"highEntropyValues": "NA"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintBrowserHighEntropyValues{}, fp.Signals.Browser.HighEntropyValues)
+			},
+		},
+		{
+			name: "toSourceError",
+			raw:  `{"signals": {"browser": {"toSourceError": "ERROR"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintBrowserToSourceError{}, fp.Signals.Browser.ToSourceError)
+			},
+		},
+		{
+			name: "ai",
+			raw:  `{"signals": {"browser": {"ai": "NA"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintBrowserAI{}, fp.Signals.Browser.AI)
+			},
+		},
+		{
+			name: "webGL",
+			raw:  `{"signals": {"graphics": {"webGL": "ERROR", "canvas": {"canvasFingerprint": "-421c84e0"}}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintGraphicsWebGL{}, fp.Signals.Graphics.WebGL)
+				assert.Equal(t, "-421c84e0", fp.Signals.Graphics.Canvas.CanvasFingerprint)
+			},
+		},
+		{
+			name: "webgpu",
+			raw:  `{"signals": {"graphics": {"webgpu": "NA"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintGraphicsWebGPU{}, fp.Signals.Graphics.WebGPU)
+			},
+		},
+		{
+			name: "canvas",
+			raw:  `{"signals": {"graphics": {"canvas": "ERROR"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintGraphicsCanvas{}, fp.Signals.Graphics.Canvas)
+			},
+		},
+		{
+			name: "codecs",
+			raw:  `{"signals": {"codecs": "ERROR"}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintCodecs{}, fp.Signals.Codecs)
+			},
+		},
+		{
+			name: "internationalization",
+			raw:  `{"signals": {"locale": {"internationalization": "ERROR", "languages": {"language": "en"}}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintLocaleInternationalization{}, fp.Signals.Locale.Internationalization)
+				assert.Equal(t, "en", fp.Signals.Locale.Languages.Language)
+			},
+		},
+		{
+			name: "languages",
+			raw:  `{"signals": {"locale": {"languages": "ERROR"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintLocaleLanguages{}, fp.Signals.Locale.Languages)
+			},
+		},
+		{
+			name: "iframe",
+			raw:  `{"signals": {"contexts": {"iframe": "ERROR"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintIframeContext{}, fp.Signals.Contexts.Iframe)
+			},
+		},
+		{
+			name: "webWorker",
+			raw:  `{"signals": {"contexts": {"webWorker": "SKIPPED"}}}`,
+			assertFP: func(t *testing.T, fp *FingerprintData) {
+				assert.Equal(t, fingerprintWebWorkerContext{}, fp.Signals.Contexts.WebWorker)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fp := &FingerprintData{}
+			require.NoError(t, json.Unmarshal([]byte(tc.raw), fp))
+			tc.assertFP(t, fp)
+		})
+	}
+}
+
+// Only the sentinel string is tolerated: anything else in an object slot is
+// still a malformed payload.
+func TestFlexStructRejectsNonString(t *testing.T) {
+	fp := &FingerprintData{}
+	require.Error(t, json.Unmarshal([]byte(`{"signals": {"device": {"screenResolution": 42}}}`), fp))
+}
+
+// The whole-object sentinel and the per-field sentinels the collectors emit
+// (setObjectValues) have to survive together.
+func TestFlexStructKeepsSiblingSignals(t *testing.T) {
+	fp := mustUnmarshal(t, `{"signals": {"device": {
+		"cpuCount": "ERROR",
+		"platform": "MacIntel",
+		"screenResolution": "ERROR",
+		"keyboard": {"layout": "NA", "layoutSize": "NA"}
+	}}, "fsid": "FS1_x", "fastBotDetection": true}`)
+
+	assert.Equal(t, FlexInt(0), fp.Signals.Device.CPUCount)
+	assert.Equal(t, "MacIntel", fp.Signals.Device.Platform)
+	assert.Equal(t, fingerprintScreenResolution{}, fp.Signals.Device.ScreenResolution)
+	assert.Equal(t, "NA", fp.Signals.Device.Keyboard.Layout)
+	assert.Equal(t, "FS1_x", fp.FSID)
+	assert.True(t, fp.IsBot())
+}
+
+// A dropped signal is the zero value of an unchanged struct, so it survives
+// the cookie envelope like any other zero value — no proto shape change.
+func TestFlexStructProtoRoundTrip(t *testing.T) {
+	fp := mustUnmarshal(t, `{"signals": {
+		"device": {"platform": "MacIntel", "screenResolution": "ERROR"},
+		"graphics": {"webgpu": "NA"},
+		"browser": {"highEntropyValues": "ERROR", "features": "ERROR"},
+		"locale": {"languages": "ERROR"},
+		"contexts": {"webWorker": "SKIPPED"}
+	}}`)
+
+	got := fingerprintDataFromProto(fp.ToProto())
+
+	assert.Equal(t, fp.Signals, got.Signals)
+}

--- a/pkg/appsec/patcher.go
+++ b/pkg/appsec/patcher.go
@@ -15,6 +15,8 @@ var challengeRuntimeCallees = map[string]struct{}{
 	"GrantChallengeCookie": {},
 	"RejectSubmission":     {},
 	"LogAccepted":          {},
+	// no runtime, no cookie validation: the helper would always return false
+	"HasValidChallengeCookie": {},
 }
 
 func (p *appsecExprPatcher) Visit(node *ast.Node) { //nolint:gocritic // signature fixed by expr-lang ast.Visitor interface

--- a/pkg/appsec/patcher_test.go
+++ b/pkg/appsec/patcher_test.go
@@ -46,3 +46,22 @@ func TestAppsecConfigBuildDoesNotDetectRequireValidChallengeWhenUnused(t *testin
 	require.NoError(t, err)
 	assert.False(t, runtimeCfg.NeedWASMVM)
 }
+
+func TestAppsecConfigBuildDetectsHasValidChallengeCookie(t *testing.T) {
+	logger := log.New()
+	logger.SetOutput(io.Discard)
+
+	cfg := AppsecConfig{
+		Logger: log.NewEntry(logger),
+		PreEval: []Hook{
+			{
+				Filter: "HasValidChallengeCookie()",
+				Apply:  []string{"SetRemediation(\"allow\")"},
+			},
+		},
+	}
+
+	runtimeCfg, err := cfg.Build(t.Context(), nil)
+	require.NoError(t, err)
+	assert.True(t, runtimeCfg.NeedWASMVM)
+}

--- a/pkg/appsec/waf_helpers.go
+++ b/pkg/appsec/waf_helpers.go
@@ -127,7 +127,8 @@ func GetPreEvalEnv(ctx context.Context, w *AppsecRuntimeConfig, state *AppsecReq
 			}
 			return w.GrantChallengeCookie(state, request, reason, ttlOverride)
 		},
-		"fingerprint": state.Fingerprint,
+		"fingerprint":             state.Fingerprint,
+		"HasValidChallengeCookie": state.HasValidChallengeCookie,
 		"ValidateRequestWithSchema": func(ref string) bool {
 			return w.ValidateRequestWithSchema(ctx, state, request, ref)
 		},
@@ -165,9 +166,10 @@ func GetPostEvalEnv(ctx context.Context, w *AppsecRuntimeConfig, state *AppsecRe
 		"DumpFingerprint": func(label string) string {
 			return DumpFingerprint(w.FingerprintDumpDir, label, state.Fingerprint, request)
 		},
-		"fingerprint":         state.Fingerprint,
-		"hook_vars":           state.HookVars,
-		"ExemptFromChallenge": func(reason string) error { return w.ExemptFromChallenge(state, request, reason) },
+		"fingerprint":             state.Fingerprint,
+		"hook_vars":               state.HookVars,
+		"HasValidChallengeCookie": state.HasValidChallengeCookie,
+		"ExemptFromChallenge":     func(reason string) error { return w.ExemptFromChallenge(state, request, reason) },
 		"AddRequestScore": func(points int, reason string) error {
 			return w.AddRequestScore(state, points, reason)
 		},
@@ -309,22 +311,23 @@ func GetOnChallengeSubmitEnv(w *AppsecRuntimeConfig, state *AppsecRequestState, 
 
 func GetOnMatchEnv(w *AppsecRuntimeConfig, state *AppsecRequestState, request *ParsedRequest, evt pipeline.Event) map[string]interface{} {
 	return map[string]interface{}{
-		"evt":                 evt,
-		"req":                 request.HTTPRequest,
-		"hook_vars":           state.HookVars,
-		"IsInBand":            request.IsInBand,
-		"IsOutBand":           request.IsOutBand,
-		"SetRemediation":      func(action string) error { return w.SetAction(state, action) },
-		"SetReturnCode":       func(code int) error { return w.SetHTTPCode(state, code) },
-		"CancelEvent":         func() error { return w.CancelEvent(state) },
-		"SendEvent":           func() error { return w.SendEvent(state) },
-		"CancelAlert":         func() error { return w.CancelAlert(state) },
-		"SendAlert":           func() error { return w.SendAlert(state) },
-		"DumpRequest":         request.DumpRequest,
-		"SetChallengeBody":    func(body string) error { return w.SetChallengeBody(state, body) },
-		"SetChallengeCookie":  func(cookie cookie.AppsecCookie) error { return w.SetChallengeCookie(state, cookie) },
-		"AppsecCookie":        cookie.NewAppsecCookie,
-		"ExemptFromChallenge": func(reason string) error { return w.ExemptFromChallenge(state, request, reason) },
+		"evt":                     evt,
+		"req":                     request.HTTPRequest,
+		"hook_vars":               state.HookVars,
+		"IsInBand":                request.IsInBand,
+		"IsOutBand":               request.IsOutBand,
+		"SetRemediation":          func(action string) error { return w.SetAction(state, action) },
+		"SetReturnCode":           func(code int) error { return w.SetHTTPCode(state, code) },
+		"CancelEvent":             func() error { return w.CancelEvent(state) },
+		"SendEvent":               func() error { return w.SendEvent(state) },
+		"CancelAlert":             func() error { return w.CancelAlert(state) },
+		"SendAlert":               func() error { return w.SendAlert(state) },
+		"DumpRequest":             request.DumpRequest,
+		"SetChallengeBody":        func(body string) error { return w.SetChallengeBody(state, body) },
+		"SetChallengeCookie":      func(cookie cookie.AppsecCookie) error { return w.SetChallengeCookie(state, cookie) },
+		"AppsecCookie":            cookie.NewAppsecCookie,
+		"ExemptFromChallenge":     func(reason string) error { return w.ExemptFromChallenge(state, request, reason) },
+		"HasValidChallengeCookie": state.HasValidChallengeCookie,
 		"AddRequestScore": func(points int, reason string) error {
 			return w.AddRequestScore(state, points, reason)
 		},


### PR DESCRIPTION
Introduce `notification-nats`, a native plugin that publishes CrowdSec alert notifications to a NATS subject.

- main.go: go-plugin implementing the NotifierServer interface using the nats-io/nats.go client library with token/credentials auth support
- nats.yaml: reference configuration with url, subject, and auth fields
- go.mod / go.sum: add github.com/nats-io/nats.go dependency