### PR TITLE
Fix obfuscator prng

### DIFF
--- a/pkg/appsec/challenge/obfuscator.go
+++ b/pkg/appsec/challenge/obfuscator.go
@@ -9,6 +9,7 @@ package challenge
 import (
 	"bytes"
 	"context"
+	crand "crypto/rand"
 	_ "embed"
 	"fmt"
 	"sync"
@@ -28,6 +29,18 @@ var (
 // wasm module and returns the obfuscated output. Thread-safe: wazero allows
 // concurrent module instantiations from the same compiled module, which is
 // what makes the dynamic-module singleflight pattern work.
+//
+// The wazero ModuleConfig must opt in to real entropy and real time:
+// wazero defaults `WithRandSource` to a *deterministic* source and the
+// walltime/nanotime to fixed values. javascript-obfuscator's high-
+// obfuscation preset seeds its identifier mangler from QuickJS's
+// `Math.random()` and `Date.now()`, both of which ultimately resolve to
+// WASI calls into these host hooks. With the defaults, every invocation
+// produces byte-identical output — silently collapsing the per-epoch
+// variant pool (see TestCryptoObfuscationPoolSize) to a single variant
+// regardless of the configured cryptoPoolSize, defeating the whole
+// point of pooling. Use crypto/rand + real wall/nano time so each
+// invocation gets distinct output.
 func (c *ChallengeRuntime) ObfuscateJS(ctx context.Context, inputJS string) (string, error) {
 	stdin := bytes.NewReader([]byte(inputJS))
 	var stdout bytes.Buffer
@@ -36,7 +49,10 @@ func (c *ChallengeRuntime) ObfuscateJS(ctx context.Context, inputJS string) (str
 	config := wazero.NewModuleConfig().
 		WithStdin(stdin).
 		WithStdout(&stdout).
-		WithStderr(&stderr)
+		WithStderr(&stderr).
+		WithRandSource(crand.Reader).
+		WithSysWalltime().
+		WithSysNanotime()
 
 	mod, err := c.r.InstantiateModule(ctx, c.obfuscatorMod, config)
 	if err != nil {

--- a/pkg/appsec/fingerprint_dump.go
+++ b/pkg/appsec/fingerprint_dump.go
@@ -64,15 +64,24 @@ func sanitizeFpLabel(label string) string {
 // fpDumpEntry is the on-disk record shape: one of these per line in the
 // labeled JSONL file. Field order is fixed by the struct so downstream
 // consumers can rely on the JSON layout.
+//
+// IP-naming convention matches the rest of the appsec package: ClientIP
+// (json:"client_ip") is the *real* visitor address as the bouncer sees
+// it — the field operators actually want when triaging a sample.
+// RemoteAddr / RemoteAddrNormalized are the bouncer's own TCP peer,
+// preserved for completeness (logged as "bouncer" elsewhere in this
+// package — see appsec.go and challenge/fingerprint_helpers.go).
 type fpDumpEntry struct {
-	Label       string                     `json:"label"`
-	Timestamp   time.Time                  `json:"timestamp"`
-	RemoteAddr  string                     `json:"remote_addr,omitempty"`
-	UserAgent   string                     `json:"user_agent,omitempty"`
-	Host        string                     `json:"host,omitempty"`
-	URI         string                     `json:"uri,omitempty"`
-	Method      string                     `json:"method,omitempty"`
-	Fingerprint *challenge.FingerprintData `json:"fingerprint"`
+	Label                string                     `json:"label"`
+	Timestamp            time.Time                  `json:"timestamp"`
+	ClientIP             string                     `json:"client_ip,omitempty"`
+	RemoteAddr           string                     `json:"remote_addr,omitempty"`
+	RemoteAddrNormalized string                     `json:"normalized_remote_addr,omitempty"`
+	UserAgent            string                     `json:"user_agent,omitempty"`
+	Host                 string                     `json:"host,omitempty"`
+	URI                  string                     `json:"uri,omitempty"`
+	Method               string                     `json:"method,omitempty"`
+	Fingerprint          *challenge.FingerprintData `json:"fingerprint"`
 }
 
 // DumpFingerprint appends one compact JSON object (JSONL) describing the
@@ -102,7 +111,9 @@ func DumpFingerprint(label string, fp *challenge.FingerprintData, req *ParsedReq
 		Fingerprint: fp,
 	}
 	if req != nil {
+		entry.ClientIP = req.ClientIP
 		entry.RemoteAddr = req.RemoteAddr
+		entry.RemoteAddrNormalized = req.RemoteAddrNormalized
 		entry.UserAgent = req.Headers.Get("User-Agent")
 		entry.Host = req.Host
 		entry.URI = req.URI

--- a/pkg/appsec/fingerprint_dump.go
+++ b/pkg/appsec/fingerprint_dump.go
@@ -1,0 +1,134 @@
+package appsec
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/crowdsecurity/crowdsec/pkg/appsec/challenge"
+)
+
+// Per-output-path mutexes so concurrent requests appending to the same
+// labeled JSONL file can't interleave half-lines, while distinct labels
+// never contend with each other. The outer mutex only guards the map
+// itself; the per-path mutex guards the actual write.
+var (
+	fpDumpMapMu sync.Mutex
+	fpDumpLocks = map[string]*sync.Mutex{}
+)
+
+func fpDumpLockFor(path string) *sync.Mutex {
+	fpDumpMapMu.Lock()
+	defer fpDumpMapMu.Unlock()
+	m, ok := fpDumpLocks[path]
+	if !ok {
+		m = &sync.Mutex{}
+		fpDumpLocks[path] = m
+	}
+	return m
+}
+
+var fpLabelSanitizer = regexp.MustCompile(`[^a-z0-9]+`)
+
+// sanitizeFpLabel returns a filesystem-safe slug for the supplied label:
+// lowercase, runs of non-alphanumerics collapsed to a single underscore,
+// leading/trailing underscores trimmed, capped at 40 chars. An empty or
+// all-junk label collapses to "unlabeled".
+//
+// Two labels that differ only in non-alphanumeric content (e.g. "bot-1"
+// and "bot_1") will share the same file; the original label is always
+// preserved verbatim inside every JSON line so disambiguation downstream
+// is still possible.
+func sanitizeFpLabel(label string) string {
+	s := fpLabelSanitizer.ReplaceAllString(strings.ToLower(label), "_")
+	s = strings.Trim(s, "_")
+	if s == "" {
+		return "unlabeled"
+	}
+	if len(s) > 40 {
+		s = strings.Trim(s[:40], "_")
+		if s == "" {
+			return "unlabeled"
+		}
+	}
+	return s
+}
+
+// fpDumpEntry is the on-disk record shape: one of these per line in the
+// labeled JSONL file. Field order is fixed by the struct so downstream
+// consumers can rely on the JSON layout.
+type fpDumpEntry struct {
+	Label       string                     `json:"label"`
+	Timestamp   time.Time                  `json:"timestamp"`
+	RemoteAddr  string                     `json:"remote_addr,omitempty"`
+	UserAgent   string                     `json:"user_agent,omitempty"`
+	Host        string                     `json:"host,omitempty"`
+	URI         string                     `json:"uri,omitempty"`
+	Method      string                     `json:"method,omitempty"`
+	Fingerprint *challenge.FingerprintData `json:"fingerprint"`
+}
+
+// DumpFingerprint appends one compact JSON object (JSONL) describing the
+// supplied human label, a server-side UTC timestamp, a minimal request
+// context block (remote addr, UA, host, URI, method), and the full
+// FingerprintData to <tmpdir>/crowdsec_fp_dump_<sanitized-label>.jsonl.
+//
+// Re-calling with the same label appends to the same file; different
+// labels produce different files. Designed for offline dataset collection
+// from on_challenge_submit and post_eval hooks.
+//
+// Returns the written path, or "" on error (always logged via logrus).
+// A nil fingerprint is treated as a soft no-op (warning logged) so a
+// rule firing in a hook before the fingerprint is populated doesn't
+// crash request processing.
+func DumpFingerprint(label string, fp *challenge.FingerprintData, req *ParsedRequest) string {
+	if fp == nil {
+		log.Warnf("DumpFingerprint(%q) called with nil fingerprint, skipping", label)
+		return ""
+	}
+
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("crowdsec_fp_dump_%s.jsonl", sanitizeFpLabel(label)))
+
+	entry := fpDumpEntry{
+		Label:       label,
+		Timestamp:   time.Now().UTC(),
+		Fingerprint: fp,
+	}
+	if req != nil {
+		entry.RemoteAddr = req.RemoteAddr
+		entry.UserAgent = req.Headers.Get("User-Agent")
+		entry.Host = req.Host
+		entry.URI = req.URI
+		entry.Method = req.Method
+	}
+
+	line, err := json.Marshal(entry)
+	if err != nil {
+		log.Errorf("DumpFingerprint(%q): marshal: %s", label, err)
+		return ""
+	}
+
+	mu := fpDumpLockFor(path)
+	mu.Lock()
+	defer mu.Unlock()
+
+	fd, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		log.Errorf("DumpFingerprint(%q): open %s: %s", label, path, err)
+		return ""
+	}
+	defer fd.Close()
+	if _, err := fd.Write(append(line, '\n')); err != nil {
+		log.Errorf("DumpFingerprint(%q): write %s: %s", label, path, err)
+		return ""
+	}
+	log.Infof("fingerprint dumped (label=%q) to %s", label, path)
+	return path
+}

--- a/pkg/appsec/fingerprint_dump_test.go
+++ b/pkg/appsec/fingerprint_dump_test.go
@@ -1,0 +1,260 @@
+package appsec
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/crowdsecurity/crowdsec/pkg/appsec/challenge"
+)
+
+// fakeFingerprint returns a minimal but distinguishable *challenge.FingerprintData
+// suitable for asserting that DumpFingerprint preserved the value end-to-end.
+func fakeFingerprint(fsid string) *challenge.FingerprintData {
+	return &challenge.FingerprintData{
+		FSID:  fsid,
+		Nonce: "test-nonce",
+		Time:  1717000000,
+		URL:   "https://example.test/path",
+	}
+}
+
+func fakeRequest() *ParsedRequest {
+	return &ParsedRequest{
+		RemoteAddr: "203.0.113.7:51234",
+		Host:       "example.test",
+		URI:        "/login",
+		Method:     "POST",
+		Headers:    http.Header{"User-Agent": []string{"Mozilla/5.0 (test)"}},
+	}
+}
+
+// readJSONL reads every line of the given path as a JSON object and returns them.
+func readJSONL(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	fd, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %s", path, err)
+	}
+	defer fd.Close()
+	var out []map[string]any
+	sc := bufio.NewScanner(fd)
+	// Fingerprints with full signals can be large; bump the buffer to avoid
+	// false negatives on real-shape payloads, even though our test data is tiny.
+	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for sc.Scan() {
+		var m map[string]any
+		if err := json.Unmarshal(sc.Bytes(), &m); err != nil {
+			t.Fatalf("invalid JSON line %q: %s", sc.Text(), err)
+		}
+		out = append(out, m)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan: %s", err)
+	}
+	return out
+}
+
+func TestSanitizeFpLabel(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"bot", "bot"},
+		{"human – Chrome on macOS!", "human_chrome_on_macos"},
+		{"   ", "unlabeled"},
+		{"", "unlabeled"},
+		{"!!! @@@ ", "unlabeled"},
+		{"Bot-1", "bot_1"},
+		{"Bot_1", "bot_1"},
+		// 50-char alpha label gets truncated to 40, trim of trailing underscore is a no-op.
+		{strings.Repeat("a", 50), strings.Repeat("a", 40)},
+	}
+	for _, tc := range cases {
+		got := sanitizeFpLabel(tc.in)
+		if got != tc.want {
+			t.Errorf("sanitizeFpLabel(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDumpFingerprint_AppendsAndPreservesFields(t *testing.T) {
+	// Redirect os.TempDir() to a per-test dir so the test is hermetic and
+	// doesn't collide with other runs (or pollute /tmp).
+	t.Setenv("TMPDIR", t.TempDir())
+
+	fp := fakeFingerprint("fsid-abc")
+	req := fakeRequest()
+
+	path1 := DumpFingerprint("test-human", fp, req)
+	if path1 == "" {
+		t.Fatal("first DumpFingerprint returned empty path")
+	}
+	wantPath := filepath.Join(os.TempDir(), "crowdsec_fp_dump_test_human.jsonl")
+	if path1 != wantPath {
+		t.Errorf("path = %q, want %q", path1, wantPath)
+	}
+
+	// Second call with the same label must append, not truncate.
+	path2 := DumpFingerprint("test-human", fakeFingerprint("fsid-def"), req)
+	if path2 != path1 {
+		t.Errorf("second call wrote to %q, want same file %q", path2, path1)
+	}
+
+	lines := readJSONL(t, path1)
+	if len(lines) != 2 {
+		t.Fatalf("got %d JSONL lines, want 2 (append failed?)", len(lines))
+	}
+
+	// Both lines must carry the operator-supplied label verbatim.
+	for i, line := range lines {
+		if line["label"] != "test-human" {
+			t.Errorf("line %d label = %v, want %q", i, line["label"], "test-human")
+		}
+		// Timestamp must parse as RFC3339.
+		ts, ok := line["timestamp"].(string)
+		if !ok {
+			t.Errorf("line %d timestamp not a string: %T", i, line["timestamp"])
+		} else if _, err := time.Parse(time.RFC3339Nano, ts); err != nil {
+			t.Errorf("line %d timestamp %q not RFC3339: %s", i, ts, err)
+		}
+		// Minimal request context preserved.
+		if line["remote_addr"] != "203.0.113.7:51234" {
+			t.Errorf("line %d remote_addr = %v", i, line["remote_addr"])
+		}
+		if line["user_agent"] != "Mozilla/5.0 (test)" {
+			t.Errorf("line %d user_agent = %v", i, line["user_agent"])
+		}
+		if line["host"] != "example.test" {
+			t.Errorf("line %d host = %v", i, line["host"])
+		}
+		if line["uri"] != "/login" {
+			t.Errorf("line %d uri = %v", i, line["uri"])
+		}
+		if line["method"] != "POST" {
+			t.Errorf("line %d method = %v", i, line["method"])
+		}
+	}
+
+	// Fingerprint payload must be preserved per-line (fsid differs across the two calls).
+	wantFSIDs := []string{"fsid-abc", "fsid-def"}
+	for i, line := range lines {
+		fp, ok := line["fingerprint"].(map[string]any)
+		if !ok {
+			t.Fatalf("line %d: fingerprint not an object: %T", i, line["fingerprint"])
+		}
+		if fp["fsid"] != wantFSIDs[i] {
+			t.Errorf("line %d fingerprint.fsid = %v, want %q", i, fp["fsid"], wantFSIDs[i])
+		}
+	}
+}
+
+func TestDumpFingerprint_DifferentLabelsGoToDifferentFiles(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	pHuman := DumpFingerprint("human", fakeFingerprint("a"), fakeRequest())
+	pBot := DumpFingerprint("bot", fakeFingerprint("b"), fakeRequest())
+	if pHuman == "" || pBot == "" {
+		t.Fatalf("paths empty: %q %q", pHuman, pBot)
+	}
+	if pHuman == pBot {
+		t.Fatalf("expected distinct files for distinct labels, got %q", pHuman)
+	}
+
+	if got := len(readJSONL(t, pHuman)); got != 1 {
+		t.Errorf("human file has %d lines, want 1", got)
+	}
+	if got := len(readJSONL(t, pBot)); got != 1 {
+		t.Errorf("bot file has %d lines, want 1", got)
+	}
+}
+
+func TestDumpFingerprint_NilFingerprintIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TMPDIR", dir)
+
+	got := DumpFingerprint("anything", nil, fakeRequest())
+	if got != "" {
+		t.Errorf("nil fingerprint returned path %q, want empty", got)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "crowdsec_fp_dump_") {
+			t.Errorf("nil fingerprint wrote a file: %s", e.Name())
+		}
+	}
+}
+
+func TestDumpFingerprint_NilRequestStillDumps(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	path := DumpFingerprint("nofreq", fakeFingerprint("xx"), nil)
+	if path == "" {
+		t.Fatal("expected dump to succeed with nil request")
+	}
+	lines := readJSONL(t, path)
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1", len(lines))
+	}
+	// Request fields are omitempty, so they should be absent from the JSON.
+	for _, k := range []string{"remote_addr", "user_agent", "host", "uri", "method"} {
+		if _, ok := lines[0][k]; ok {
+			t.Errorf("nil request still wrote %s=%v", k, lines[0][k])
+		}
+	}
+}
+
+func TestDumpFingerprint_EmptyAndJunkLabelsCollapse(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	p1 := DumpFingerprint("", fakeFingerprint("a"), nil)
+	p2 := DumpFingerprint("!!! @@@ ", fakeFingerprint("b"), nil)
+	if p1 == "" || p2 == "" {
+		t.Fatalf("paths empty: %q %q", p1, p2)
+	}
+	wantPath := filepath.Join(os.TempDir(), "crowdsec_fp_dump_unlabeled.jsonl")
+	if p1 != wantPath || p2 != wantPath {
+		t.Errorf("expected both junk labels to land in %q, got %q and %q", wantPath, p1, p2)
+	}
+	if got := len(readJSONL(t, p1)); got != 2 {
+		t.Errorf("unlabeled file has %d lines, want 2", got)
+	}
+}
+
+func TestDumpFingerprint_ConcurrentAppendIsLineSafe(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	const goroutines = 32
+	const perGoroutine = 20
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				if path := DumpFingerprint("race", fakeFingerprint("fsid"), fakeRequest()); path == "" {
+					t.Errorf("DumpFingerprint returned empty path under contention")
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	path := filepath.Join(os.TempDir(), "crowdsec_fp_dump_race.jsonl")
+	lines := readJSONL(t, path) // this would fatal on any torn line
+	if len(lines) != goroutines*perGoroutine {
+		t.Errorf("got %d lines, want %d", len(lines), goroutines*perGoroutine)
+	}
+}

--- a/pkg/appsec/fingerprint_dump_test.go
+++ b/pkg/appsec/fingerprint_dump_test.go
@@ -27,11 +27,16 @@ func fakeFingerprint(fsid string) *challenge.FingerprintData {
 
 func fakeRequest() *ParsedRequest {
 	return &ParsedRequest{
-		RemoteAddr: "203.0.113.7:51234",
-		Host:       "example.test",
-		URI:        "/login",
-		Method:     "POST",
-		Headers:    http.Header{"User-Agent": []string{"Mozilla/5.0 (test)"}},
+		// Distinct visitor vs. bouncer addresses so the test can prove
+		// DumpFingerprint records the *real* source IP (ClientIP) and
+		// not just the bouncer's TCP peer (RemoteAddr).
+		ClientIP:             "203.0.113.7",
+		RemoteAddr:           "127.0.0.1:54321",
+		RemoteAddrNormalized: "127.0.0.1",
+		Host:                 "example.test",
+		URI:                  "/login",
+		Method:               "POST",
+		Headers:              http.Header{"User-Agent": []string{"Mozilla/5.0 (test)"}},
 	}
 }
 
@@ -125,8 +130,17 @@ func TestDumpFingerprint_AppendsAndPreservesFields(t *testing.T) {
 			t.Errorf("line %d timestamp %q not RFC3339: %s", i, ts, err)
 		}
 		// Minimal request context preserved.
-		if line["remote_addr"] != "203.0.113.7:51234" {
+		// client_ip is the real visitor address — the field a SOC
+		// operator actually wants when triaging a sample. Verify it
+		// is distinct from remote_addr (which is the bouncer).
+		if line["client_ip"] != "203.0.113.7" {
+			t.Errorf("line %d client_ip = %v, want %q", i, line["client_ip"], "203.0.113.7")
+		}
+		if line["remote_addr"] != "127.0.0.1:54321" {
 			t.Errorf("line %d remote_addr = %v", i, line["remote_addr"])
+		}
+		if line["normalized_remote_addr"] != "127.0.0.1" {
+			t.Errorf("line %d normalized_remote_addr = %v", i, line["normalized_remote_addr"])
 		}
 		if line["user_agent"] != "Mozilla/5.0 (test)" {
 			t.Errorf("line %d user_agent = %v", i, line["user_agent"])
@@ -207,7 +221,7 @@ func TestDumpFingerprint_NilRequestStillDumps(t *testing.T) {
 		t.Fatalf("got %d lines, want 1", len(lines))
 	}
 	// Request fields are omitempty, so they should be absent from the JSON.
-	for _, k := range []string{"remote_addr", "user_agent", "host", "uri", "method"} {
+	for _, k := range []string{"client_ip", "remote_addr", "normalized_remote_addr", "user_agent", "host", "uri", "method"} {
 		if _, ok := lines[0][k]; ok {
 			t.Errorf("nil request still wrote %s=%v", k, lines[0][k])
 		}

--- a/pkg/appsec/waf_helpers.go
+++ b/pkg/appsec/waf_helpers.go
@@ -145,6 +145,9 @@ func GetPostEvalEnv(w *AppsecRuntimeConfig, state *AppsecRequestState, request *
 			}
 			return w.GrantChallengeCookie(state, request, reason, ttlOverride)
 		},
+		"DumpFingerprint": func(label string) string {
+			return DumpFingerprint(label, state.Fingerprint, request)
+		},
 		"fingerprint": state.Fingerprint,
 	}
 }
@@ -258,6 +261,9 @@ func GetOnChallengeSubmitEnv(w *AppsecRuntimeConfig, state *AppsecRequestState, 
 		},
 		"EvaluateMismatches": func() *challenge.MismatchReport {
 			return w.EvaluateMismatches(state, request)
+		},
+		"DumpFingerprint": func(label string) string {
+			return DumpFingerprint(label, state.Fingerprint, request)
 		},
 	}
 }


### PR DESCRIPTION
wazero's own config.go:651-652 docs are explicit:

> WithRandSource configures a source of random bytes. Defaults to return a deterministic source. You might override this with crypto/rand.Reader.


This adds back a proper random source, else it would defeat the runtime obfuscation randomness