### PR TITLE
Minor fixes

### DIFF
--- a/cmd/crowdsec-cli/climetrics/store.go
+++ b/cmd/crowdsec-cli/climetrics/store.go
@@ -59,6 +59,59 @@ func (ms metricStore) Fetch(ctx context.Context, url string, db *database.Client
 	return nil
 }
 
+// metricLabels holds the label values extracted from a single Prometheus point.
+type metricLabels struct {
+	name         string
+	source       string
+	machine      string
+	bouncer      string
+	route        string
+	method       string
+	reason       string
+	origin       string
+	action       string
+	appsecEngine string
+	appsecRule   string
+	// kind is carried by the appsec-challenge accepted/rejected counters
+	// to distinguish sub-outcomes; empty for every other metric.
+	kind string
+	// bundle is carried by the challenge re-obfuscation counter
+	// (dynamic vs library); empty for every other metric.
+	bundle string
+	mtype  string
+}
+
+func extractLabels(p MetricPoint) metricLabels {
+	name, ok := p.Labels["name"]
+	if !ok {
+		log.Debugf("no name in Metric %v", p.Labels)
+	}
+
+	source, ok := p.Labels["source"]
+	if !ok {
+		log.Debugf("no source in Metric %v for %s", p.Labels, p.Name)
+	} else if srctype, ok := p.Labels["type"]; ok {
+		source = srctype + ":" + source
+	}
+
+	return metricLabels{
+		name:         name,
+		source:       source,
+		machine:      p.Labels["machine"],
+		bouncer:      p.Labels["bouncer"],
+		route:        p.Labels["route"],
+		method:       p.Labels["method"],
+		reason:       p.Labels["reason"],
+		origin:       p.Labels["origin"],
+		action:       p.Labels["action"],
+		appsecEngine: p.Labels["appsec_engine"],
+		appsecRule:   p.Labels["rule_name"],
+		kind:         p.Labels["kind"],
+		bundle:       p.Labels["bundle"],
+		mtype:        p.Labels["type"],
+	}
+}
+
 func (ms metricStore) processPrometheusMetrics(result []MetricPoint) {
 	mAcquis := ms["acquisition"].(statAcquis)
 	mAlert := ms["alerts"].(statAlert)
@@ -81,42 +134,7 @@ func (ms metricStore) processPrometheusMetrics(result []MetricPoint) {
 			continue
 		}
 
-		name, ok := p.Labels["name"]
-		if !ok {
-			log.Debugf("no name in Metric %v", p.Labels)
-		}
-
-		source, ok := p.Labels["source"]
-		if !ok {
-			log.Debugf("no source in Metric %v for %s", p.Labels, p.Name)
-		} else {
-			if srctype, ok := p.Labels["type"]; ok {
-				source = srctype + ":" + source
-			}
-		}
-
-		machine := p.Labels["machine"]
-		bouncer := p.Labels["bouncer"]
-
-		route := p.Labels["route"]
-		method := p.Labels["method"]
-
-		reason := p.Labels["reason"]
-		origin := p.Labels["origin"]
-		action := p.Labels["action"]
-
-		appsecEngine := p.Labels["appsec_engine"]
-		appsecRule := p.Labels["rule_name"]
-
-		// kind is carried by the appsec-challenge accepted/rejected counters
-		// to distinguish sub-outcomes; empty for every other metric.
-		kind := p.Labels["kind"]
-
-		// bundle is carried by the challenge re-obfuscation counter
-		// (dynamic vs library); empty for every other metric.
-		bundle := p.Labels["bundle"]
-
-		mtype := p.Labels["type"]
+		l := extractLabels(p)
 
 		ival := int(p.Value)
 
@@ -125,101 +143,101 @@ func (ms metricStore) processPrometheusMetrics(result []MetricPoint) {
 		// buckets
 		//
 		case metrics.BucketsInstantiationMetricName:
-			mBucket.Process(name, "instantiation", ival)
+			mBucket.Process(l.name, "instantiation", ival)
 		case metrics.BucketsCurrentCountMetricName:
-			mBucket.Process(name, "curr_count", ival)
+			mBucket.Process(l.name, "curr_count", ival)
 		case metrics.BucketsOverflowMetricName:
-			mBucket.Process(name, "overflow", ival)
+			mBucket.Process(l.name, "overflow", ival)
 		case metrics.BucketPouredMetricName:
-			mBucket.Process(name, "pour", ival)
-			mAcquis.Process(source, "pour", ival)
+			mBucket.Process(l.name, "pour", ival)
+			mAcquis.Process(l.source, "pour", ival)
 		case metrics.BucketsUnderflowMetricName:
-			mBucket.Process(name, "underflow", ival)
+			mBucket.Process(l.name, "underflow", ival)
 		//
 		// parsers
 		//
 		case metrics.GlobalParserHitsMetricName:
-			mAcquis.Process(source, "reads", ival)
+			mAcquis.Process(l.source, "reads", ival)
 		case metrics.GlobalParserHitsOkMetricName:
-			mAcquis.Process(source, "parsed", ival)
+			mAcquis.Process(l.source, "parsed", ival)
 		case metrics.GlobalParserHitsKoMetricName:
-			mAcquis.Process(source, "unparsed", ival)
+			mAcquis.Process(l.source, "unparsed", ival)
 		case metrics.NodesHitsMetricName:
-			mParser.Process(name, "hits", ival)
+			mParser.Process(l.name, "hits", ival)
 		case metrics.NodesHitsOkMetricName:
-			mParser.Process(name, "parsed", ival)
+			mParser.Process(l.name, "parsed", ival)
 		case metrics.NodesHitsKoMetricName:
-			mParser.Process(name, "unparsed", ival)
+			mParser.Process(l.name, "unparsed", ival)
 		//
 		// whitelists
 		//
 		case metrics.NodesWlHitsMetricName:
-			mWhitelist.Process(name, reason, "hits", ival)
+			mWhitelist.Process(l.name, l.reason, "hits", ival)
 		case metrics.NodesWlHitsOkMetricName:
-			mWhitelist.Process(name, reason, "whitelisted", ival)
+			mWhitelist.Process(l.name, l.reason, "whitelisted", ival)
 			// track as well whitelisted lines at acquis level
-			mAcquis.Process(source, "whitelisted", ival)
+			mAcquis.Process(l.source, "whitelisted", ival)
 		//
 		// lapi
 		//
 		case metrics.LapiRouteHitsMetricName:
-			mLapi.Process(route, method, ival)
+			mLapi.Process(l.route, l.method, ival)
 		case metrics.LapiMachineHitsMetricName:
-			mLapiMachine.Process(machine, route, method, ival)
+			mLapiMachine.Process(l.machine, l.route, l.method, ival)
 		case metrics.LapiBouncerHitsMetricName:
-			mLapiBouncer.Process(bouncer, route, method, ival)
+			mLapiBouncer.Process(l.bouncer, l.route, l.method, ival)
 		case metrics.LapiNilDecisionsMetricName, metrics.LapiNonNilDecisionsMetricName:
-			mLapiDecision.Process(bouncer, p.Name, ival)
+			mLapiDecision.Process(l.bouncer, p.Name, ival)
 		//
 		// decisions
 		//
 		case metrics.GlobalActiveDecisionsMetricName:
-			mDecision.Process(reason, origin, action, ival)
+			mDecision.Process(l.reason, l.origin, l.action, ival)
 		case metrics.GlobalAlertsMetricName:
-			mAlert.Process(reason, ival)
+			mAlert.Process(l.reason, ival)
 		//
 		// stash
 		//
 		case metrics.CacheMetricName:
-			mStash.Process(name, mtype, ival)
+			mStash.Process(l.name, l.mtype, ival)
 		//
 		// appsec
 		//
 		case "cs_appsec_reqs_total":
-			mAppsecEngine.Process(appsecEngine, "processed", ival)
+			mAppsecEngine.Process(l.appsecEngine, "processed", ival)
 		case "cs_appsec_block_total":
-			mAppsecEngine.Process(appsecEngine, "blocked", ival)
+			mAppsecEngine.Process(l.appsecEngine, "blocked", ival)
 		case "cs_appsec_rule_hits":
-			mAppsecRule.Process(appsecEngine, appsecRule, "triggered", ival)
+			mAppsecRule.Process(l.appsecEngine, l.appsecRule, "triggered", ival)
 		//
 		// bot detection / challenge lifecycle
 		//
 		case metrics.AppsecChallengeRequestedMetricName:
-			mAppsecEngine.Process(appsecEngine, "challenge_requested", ival)
-			mAppsecChallenge.Process(appsecEngine, "requested", ival)
+			mAppsecEngine.Process(l.appsecEngine, "challenge_requested", ival)
+			mAppsecChallenge.Process(l.appsecEngine, "requested", ival)
 		case metrics.AppsecChallengeSubmittedMetricName:
-			mAppsecChallenge.Process(appsecEngine, "submitted", ival)
+			mAppsecChallenge.Process(l.appsecEngine, "submitted", ival)
 		case metrics.AppsecChallengeAcceptedMetricName:
-			mAppsecEngine.Process(appsecEngine, "challenge_accepted", ival)
-			switch kind {
+			mAppsecEngine.Process(l.appsecEngine, "challenge_accepted", ival)
+			switch l.kind {
 			case "solved":
-				mAppsecChallenge.Process(appsecEngine, "solved", ival)
+				mAppsecChallenge.Process(l.appsecEngine, "solved", ival)
 			case "granted":
-				mAppsecChallenge.Process(appsecEngine, "granted", ival)
-				mAppsecChallenge.ProcessReason(appsecEngine, "granted", reason, ival)
+				mAppsecChallenge.Process(l.appsecEngine, "granted", ival)
+				mAppsecChallenge.ProcessReason(l.appsecEngine, "granted", l.reason, ival)
 			}
 		case metrics.AppsecChallengeRejectedMetricName:
-			mAppsecEngine.Process(appsecEngine, "challenge_rejected", ival)
-			switch kind {
+			mAppsecEngine.Process(l.appsecEngine, "challenge_rejected", ival)
+			switch l.kind {
 			case "protocol":
-				mAppsecChallenge.Process(appsecEngine, "rejected_protocol", ival)
-				mAppsecChallenge.ProcessReason(appsecEngine, "protocol", reason, ival)
+				mAppsecChallenge.Process(l.appsecEngine, "rejected_protocol", ival)
+				mAppsecChallenge.ProcessReason(l.appsecEngine, "protocol", l.reason, ival)
 			case "submission":
-				mAppsecChallenge.Process(appsecEngine, "rejected_submission", ival)
-				mAppsecChallenge.ProcessReason(appsecEngine, "submission", reason, ival)
+				mAppsecChallenge.Process(l.appsecEngine, "rejected_submission", ival)
+				mAppsecChallenge.ProcessReason(l.appsecEngine, "submission", l.reason, ival)
 			case "cookie":
-				mAppsecChallenge.Process(appsecEngine, "rejected_cookie", ival)
-				mAppsecChallenge.ProcessReason(appsecEngine, "cookie", reason, ival)
+				mAppsecChallenge.Process(l.appsecEngine, "rejected_cookie", ival)
+				mAppsecChallenge.ProcessReason(l.appsecEngine, "cookie", l.reason, ival)
 			}
 		//
 		// bot detection / challenge infrastructure (process-global, no engine label)
@@ -229,7 +247,7 @@ func (ms metricStore) processPrometheusMetrics(result []MetricPoint) {
 		case metrics.AppsecChallengeKepochEvictedMetricName:
 			mAppsecChallengeInfra.Process("kepoch_evicted", ival)
 		case metrics.AppsecChallengeReobfuscationMetricName:
-			switch bundle {
+			switch l.bundle {
 			case "dynamic":
 				mAppsecChallengeInfra.Process("reobfuscation_dynamic", ival)
 			case "library":

--- a/pkg/acquisition/modules/appsec/run.go
+++ b/pkg/acquisition/modules/appsec/run.go
@@ -105,6 +105,12 @@ func (w *Source) listenAndServe(ctx context.Context, t *tomb.Tomb) error {
 			w.logger.Errorf("Error shutting down Appsec server: %s", err.Error())
 		}
 
+		if w.AppsecRuntime != nil && w.AppsecRuntime.ChallengeRuntime != nil {
+			if err := w.AppsecRuntime.ChallengeRuntime.Close(ctx); err != nil {
+				w.logger.Errorf("Error closing challenge runtime: %s", err)
+			}
+		}
+
 		if w.config.ListenSocket != "" {
 			if err := os.Remove(w.config.ListenSocket); err != nil {
 				if !errors.Is(err, fs.ErrNotExist) {

--- a/pkg/appsec/appsec.go
+++ b/pkg/appsec/appsec.go
@@ -1671,6 +1671,11 @@ func (w *AppsecRuntimeConfig) GenerateResponse(response AppsecTempResponse, logg
 			resp.UserCookies = append(resp.UserCookies, cookie.String())
 		}
 		resp.UserHeaders = response.UserHeaders
+		if resp.UserHeaders == nil {
+			// default_remediation: challenge reaches here without any headers set
+			// (the internal challenge-serving paths always set Content-Type).
+			resp.UserHeaders = make(map[string][]string)
+		}
 		// If there's no Content-Security-Policy header, add a default one to make sure that the JS code can be evaluated
 		if _, ok := resp.UserHeaders["Content-Security-Policy"]; !ok {
 			resp.UserHeaders["Content-Security-Policy"] = []string{challenge.DefaultChallengeCSP}

--- a/pkg/appsec/appsec_challenge_test.go
+++ b/pkg/appsec/appsec_challenge_test.go
@@ -416,3 +416,25 @@ func TestAllowlistCookieRoundtripBypassesSendChallenge(t *testing.T) {
 	assert.Equal(t, statusBefore, state.Response.UserHTTPResponseCode, "challenge status must not overwrite")
 	assert.False(t, state.RequireChallenge, "RequireChallenge must stay false on bypassed replay")
 }
+
+// TestGenerateResponseChallengeNilHeaders guards against a regression where a
+// `default_remediation: challenge` match reaches GenerateResponse with no
+// UserHeaders map set (only the internal challenge-serving paths set headers).
+// Writing the default CSP into that nil map used to panic.
+func TestGenerateResponseChallengeNilHeaders(t *testing.T) {
+	rt := &AppsecRuntimeConfig{
+		Logger: log.NewEntry(log.StandardLogger()),
+		Config: &AppsecConfig{
+			UserBlockedHTTPCode:    http.StatusForbidden,
+			BouncerBlockedHTTPCode: http.StatusForbidden,
+		},
+	}
+
+	resp := AppsecTempResponse{Action: ChallengeRemediation, UserHeaders: nil}
+
+	require.NotPanics(t, func() {
+		_, body := rt.GenerateResponse(resp, rt.Logger)
+		require.NotNil(t, body.UserHeaders)
+		assert.Equal(t, []string{challenge.DefaultChallengeCSP}, body.UserHeaders["Content-Security-Policy"])
+	})
+}

--- a/pkg/appsec/challenge/DESIGN.md
+++ b/pkg/appsec/challenge/DESIGN.md
@@ -648,6 +648,7 @@ challenge:
   key_rotation_interval: 5m
   max_live_epochs: 3
   cookie_ttl: 12h
+  # max_cookie_size: 4096   # encoded cookie size ceiling (seal + open); bounds envelope allocation
   crypto_obfuscation_pool_size: 1
   # The library bundle is ALWAYS obfuscated (build-time). This flag only
   # adds further runtime-generated variants — leave off unless you want
@@ -759,6 +760,7 @@ mismatch` line, with their own `reasons` field. Correlate on `fsid` /
 | `key_rotation_interval` | duration | 5m | Min 30 s; must be the same across all instances |
 | `max_live_epochs` | int | 3 | Past epochs accepted; sized to cover the freshness window |
 | `cookie_ttl` | duration | 12h | Decoupled from rotation interval; can be long (24h+) |
+| `max_cookie_size` | int | 4096 | Encoded cookie size ceiling, enforced on seal and open. Bounds the memory allocated from the (attacker-supplied) fingerprint envelope — an over-allocation DoS guard. Matches the per-cookie size browsers guarantee; raise only for non-browser clients that tolerate larger cookies |
 | `crypto_obfuscation_pool_size` | int | 1 | Variants of dynamic key module per epoch; each costs ~5 s of CPU per rotation |
 | `library_runtime_obfuscation_enabled` | bool | false | Enable *runtime* library re-obfuscation. The library bundle is always obfuscated at build time regardless of this flag; this only adds further variants over time |
 | `library_obfuscation_pool_size` | int | 1 | Pool ceiling for library variants. Values > 1 are only meaningful when runtime obfuscation is enabled; otherwise the runtime warns and clamps to 1 |

--- a/pkg/appsec/challenge/challenge.go
+++ b/pkg/appsec/challenge/challenge.go
@@ -516,9 +516,6 @@ func NewChallengeRuntime(ctx context.Context, opts ...Option) (*ChallengeRuntime
 	return challengeRuntime, nil
 }
 
-// Close releases the wazero runtime and its compiled modules. Safe to call once
-// on shutdown (and on a nil receiver); the background goroutines stop on their
-// own via the construction context.
 func (c *ChallengeRuntime) Close(ctx context.Context) error {
 	if c == nil || c.r == nil {
 		return nil

--- a/pkg/appsec/challenge/challenge.go
+++ b/pkg/appsec/challenge/challenge.go
@@ -157,6 +157,11 @@ type ChallengeRuntime struct {
 	// so it can exceed the per-epoch signing window.
 	cookieTTL time.Duration
 
+	// maxCookieLen is the size ceiling enforced when sealing and opening cookies
+	// (crypto.go). Bounds the allocation derived from the attacker-influenced
+	// fingerprint envelope. Defaults to MaxCookieLen (the browser limit).
+	maxCookieLen int
+
 	// htmlTpl is the challenge HTML template, parsed once and reused so
 	// GetChallengePage doesn't re-parse per request.
 	htmlTpl *template.Template
@@ -180,6 +185,7 @@ type runtimeOptions struct {
 	rotationInterval                  time.Duration
 	maxLiveEpochs                     int
 	cookieTTL                         time.Duration
+	maxCookieLen                      int
 	cryptoObfuscationPoolSize         int
 	libraryRuntimeObfuscationEnabled  bool
 	libraryObfuscationPoolSize        int
@@ -229,6 +235,16 @@ func WithCookieTTL(ttl time.Duration) Option {
 	return func(o *runtimeOptions) {
 		if ttl > 0 {
 			o.cookieTTL = ttl
+		}
+	}
+}
+
+// WithMaxCookieLen sets the cookie size ceiling (see Config.MaxCookieSize);
+// zero/negative is ignored, leaving the MaxCookieLen default in effect.
+func WithMaxCookieLen(n int) Option {
+	return func(o *runtimeOptions) {
+		if n > 0 {
+			o.maxCookieLen = n
 		}
 	}
 }
@@ -362,6 +378,11 @@ func NewChallengeRuntime(ctx context.Context, opts ...Option) (*ChallengeRuntime
 		cookieTTL = defaultCookieTTL
 	}
 
+	maxCookieLen := resolvedOpts.maxCookieLen
+	if maxCookieLen <= 0 {
+		maxCookieLen = MaxCookieLen
+	}
+
 	cryptoPoolSize := resolvedOpts.cryptoObfuscationPoolSize
 	if cryptoPoolSize <= 0 {
 		cryptoPoolSize = cryptoObfuscationPoolDefaultSize
@@ -450,6 +471,7 @@ func NewChallengeRuntime(ctx context.Context, opts ...Option) (*ChallengeRuntime
 		cryptoPoolSize:                   cryptoPoolSize,
 		dynamicModuleCache:               make(map[int64][]string),
 		cookieTTL:                        cookieTTL,
+		maxCookieLen:                     maxCookieLen,
 		htmlTpl:                          htmlTpl,
 		spent:                            newSpentSet(spentSetMaxEntries),
 		logger:                           logger,
@@ -484,6 +506,7 @@ func NewChallengeRuntime(ctx context.Context, opts ...Option) (*ChallengeRuntime
 	logger.WithFields(log.Fields{
 		"rotation_interval":   rotationInterval,
 		"cookie_ttl":          cookieTTL,
+		"max_cookie_len":      maxCookieLen,
 		"pow_difficulty":      defaultPowDifficulty,
 		"crypto_pool_size":    cryptoPoolSize,
 		"library_pool_size":   libraryPoolSize,
@@ -661,7 +684,7 @@ func (c *ChallengeRuntime) ValidateChallengeResponse(request *http.Request, body
 	// the server validity window exactly c.cookieTTL (independent of key
 	// rotation); the browser Max-Age below matches so both expire together.
 	notAfter := time.Now().Add(c.cookieTTL).Unix()
-	cookieValue, err := sealCookieV0(envelope, c.keys.MasterCookieKey(), notAfter, 0, "", []byte(request.UserAgent()))
+	cookieValue, err := sealCookieV0(envelope, c.keys.MasterCookieKey(), notAfter, 0, "", []byte(request.UserAgent()), c.maxCookieLen)
 	if err != nil {
 		return nil, FingerprintData{}, fmt.Errorf("failed to seal challenge cookie: %w", err)
 	}
@@ -690,7 +713,7 @@ func (c *ChallengeRuntime) SealAllowlistCookie(request *http.Request, reason str
 	}
 
 	notAfter := time.Now().Add(ttl).Unix()
-	cookieValue, err := sealCookieV0(&pb.ChallengeCookie{}, c.keys.MasterCookieKey(), notAfter, cookieFlagAllowlisted, reason, []byte(request.UserAgent()))
+	cookieValue, err := sealCookieV0(&pb.ChallengeCookie{}, c.keys.MasterCookieKey(), notAfter, cookieFlagAllowlisted, reason, []byte(request.UserAgent()), c.maxCookieLen)
 	if err != nil {
 		return nil, fmt.Errorf("failed to seal allowlist cookie: %w", err)
 	}
@@ -723,7 +746,7 @@ func (c *ChallengeRuntime) ValidCookie(ck *http.Cookie, userAgent string) (*Cook
 		return nil, errors.New("nil cookie")
 	}
 
-	envelope, err := openCookie(ck.Value, c.keys.MasterCookieKey(), []byte(userAgent))
+	envelope, err := openCookie(ck.Value, c.keys.MasterCookieKey(), []byte(userAgent), c.maxCookieLen)
 	if err != nil {
 		return nil, fmt.Errorf("invalid challenge cookie: %w", err)
 	}

--- a/pkg/appsec/challenge/challenge.go
+++ b/pkg/appsec/challenge/challenge.go
@@ -516,6 +516,16 @@ func NewChallengeRuntime(ctx context.Context, opts ...Option) (*ChallengeRuntime
 	return challengeRuntime, nil
 }
 
+// Close releases the wazero runtime and its compiled modules. Safe to call once
+// on shutdown (and on a nil receiver); the background goroutines stop on their
+// own via the construction context.
+func (c *ChallengeRuntime) Close(ctx context.Context) error {
+	if c == nil || c.r == nil {
+		return nil
+	}
+	return c.r.Close(ctx)
+}
+
 // GetChallengePage renders the challenge HTML page with the given PoW difficulty.
 // If difficulty is 0, the default difficulty is used.
 func (c *ChallengeRuntime) GetChallengePage(ctx context.Context, userAgent string, difficulty int) (string, error) {

--- a/pkg/appsec/challenge/config.go
+++ b/pkg/appsec/challenge/config.go
@@ -42,6 +42,13 @@ type Config struct {
 	// per-epoch keys rotate tightly. Defaults to 12h.
 	CookieTTL *time.Duration `yaml:"cookie_ttl"`
 
+	// MaxCookieSize caps the challenge cookie's encoded size, enforced on both
+	// seal and open. It bounds the memory allocated from the (attacker-supplied)
+	// fingerprint envelope, closing an over-allocation DoS. Defaults to
+	// MaxCookieLen (4096, the per-cookie size browsers guarantee); raise it only
+	// if a non-browser client tolerates larger cookies.
+	MaxCookieSize *int `yaml:"max_cookie_size"`
+
 	// CryptoObfuscationPoolSize is how many obfuscations of the per-epoch
 	// sign-key module to keep per live epoch. Each variant embeds the same key
 	// with different byte layout, giving per-visitor variance. Defaults to 1.
@@ -93,6 +100,9 @@ func (c *Config) MergeFrom(other *Config) {
 	}
 	if other.CookieTTL != nil {
 		c.CookieTTL = other.CookieTTL
+	}
+	if other.MaxCookieSize != nil {
+		c.MaxCookieSize = other.MaxCookieSize
 	}
 	if other.CryptoObfuscationPoolSize != nil {
 		c.CryptoObfuscationPoolSize = other.CryptoObfuscationPoolSize
@@ -152,6 +162,9 @@ func BuildOptions(c *Config, parent *log.Entry) ([]Option, error) {
 	}
 	if c.CookieTTL != nil {
 		opts = append(opts, WithCookieTTL(*c.CookieTTL))
+	}
+	if c.MaxCookieSize != nil && *c.MaxCookieSize > 0 {
+		opts = append(opts, WithMaxCookieLen(*c.MaxCookieSize))
 	}
 	if c.CryptoObfuscationPoolSize != nil && *c.CryptoObfuscationPoolSize > 0 {
 		opts = append(opts, WithCryptoObfuscationPoolSize(*c.CryptoObfuscationPoolSize))

--- a/pkg/appsec/challenge/config_test.go
+++ b/pkg/appsec/challenge/config_test.go
@@ -46,6 +46,7 @@ func TestConfigMergeFromOverlaysOnlyNonNilFields(t *testing.T) {
 		LibraryObfuscationPoolSize:        new(2),
 		LibraryObfuscationRefreshInterval: new(30 * time.Minute),
 		SpentSetMaxEntries:                new(500_000),
+		MaxCookieSize:                     new(8192),
 	}
 
 	dst.MergeFrom(src)
@@ -66,6 +67,7 @@ func TestConfigMergeFromOverlaysOnlyNonNilFields(t *testing.T) {
 	assert.Equal(t, 2, *dst.LibraryObfuscationPoolSize)
 	assert.Equal(t, 30*time.Minute, *dst.LibraryObfuscationRefreshInterval)
 	assert.Equal(t, 500_000, *dst.SpentSetMaxEntries)
+	assert.Equal(t, 8192, *dst.MaxCookieSize)
 }
 
 // TestBuildOptionsNilOrEmptyConfig confirms a nil or fully-empty Config emits
@@ -96,11 +98,12 @@ func TestBuildOptionsTranslatesFieldsToRuntimeBehavior(t *testing.T) {
 		LibraryObfuscationPoolSize:        new(2),
 		LibraryObfuscationRefreshInterval: new(45 * time.Minute),
 		SpentSetMaxEntries:                new(250_000),
+		MaxCookieSize:                     new(8192),
 	}
 
 	opts, err := BuildOptions(cfg, nil)
 	require.NoError(t, err)
-	require.Len(t, opts, 10, "every populated field + the component logger must emit an option")
+	require.Len(t, opts, 11, "every populated field + the component logger must emit an option")
 
 	rt, err := NewChallengeRuntime(t.Context(), opts...)
 	require.NoError(t, err)
@@ -111,6 +114,7 @@ func TestBuildOptionsTranslatesFieldsToRuntimeBehavior(t *testing.T) {
 	assert.Equal(t, 2, rt.libraryPoolSize, "LibraryObfuscationPoolSize must reach the runtime")
 	assert.Equal(t, 45*time.Minute, rt.libraryRefreshInterval, "LibraryObfuscationRefreshInterval must reach the runtime")
 	assert.Equal(t, 250_000, rt.spent.maxEntries, "SpentSetMaxEntries must reach the runtime")
+	assert.Equal(t, 8192, rt.maxCookieLen, "MaxCookieSize must reach the runtime")
 }
 
 // TestLibraryPoolSizeClampedWhenRuntimeObfuscationDisabled confirms the

--- a/pkg/appsec/challenge/crypto.go
+++ b/pkg/appsec/challenge/crypto.go
@@ -120,11 +120,6 @@ func sealCookieV0(envelope *pb.ChallengeCookie, masterCookieKey []byte, notAfter
 		return "", fmt.Errorf("%w: %d > %d", ErrAllowlistReasonSize, len(reason), MaxAllowlistReasonLen)
 	}
 
-	envelopeBytes, err := proto.Marshal(envelope)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal challenge cookie proto: %w", err)
-	}
-
 	key, err := deriveKey(masterCookieKey)
 	if err != nil {
 		return "", err
@@ -140,21 +135,26 @@ func sealCookieV0(envelope *pb.ChallengeCookie, masterCookieKey []byte, notAfter
 		return "", fmt.Errorf("failed to create GCM: %w", err)
 	}
 
+	// Reject an over-limit envelope BEFORE marshaling it. The envelope derives
+	// from the client-submitted fingerprint, so a crafted submission could
+	// otherwise force a large proto.Marshal allocation for a cookie the browser
+	// would refuse to store anyway. proto.Size walks the message and returns its
+	// length WITHOUT allocating the marshal buffer, so the guard itself is cheap.
+	// RawURLEncoding expands raw bytes by 4/3, so invert maxCookieLen, then
+	// subtract the version byte, GCM nonce, and GCM tag to get the plaintext budget.
+	maxPlaintext := maxCookieLen/4*3 - 1 - gcm.NonceSize() - gcm.Overhead()
+	if plaintextLen := cookiePlaintextFixedHeaderLen + len(reason) + proto.Size(envelope); plaintextLen > maxPlaintext {
+		return "", fmt.Errorf("%w: plaintext=%d > %d", ErrCookieTooLarge, plaintextLen, maxPlaintext)
+	}
+
+	envelopeBytes, err := proto.Marshal(envelope)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal challenge cookie proto: %w", err)
+	}
+
 	nonce := make([]byte, gcm.NonceSize())
 	if _, err := rand.Read(nonce); err != nil {
 		return "", fmt.Errorf("failed to generate nonce: %w", err)
-	}
-
-	// Reject an envelope that would seal into an over-limit cookie before we
-	// allocate for it. envelopeBytes comes from the client-submitted
-	// fingerprint, so without this bound a crafted submission forces a large
-	// allocation here for a cookie the browser would refuse to store anyway.
-	// RawURLEncoding expands raw bytes by 4/3, so invert maxCookieLen, then
-	// subtract the version byte, GCM nonce, and GCM tag to get the plaintext
-	// budget.
-	maxPlaintext := maxCookieLen/4*3 - 1 - gcm.NonceSize() - gcm.Overhead()
-	if plaintextLen := cookiePlaintextFixedHeaderLen + len(reason) + len(envelopeBytes); plaintextLen > maxPlaintext {
-		return "", fmt.Errorf("%w: plaintext=%d > %d", ErrCookieTooLarge, plaintextLen, maxPlaintext)
 	}
 
 	// Build the plaintext: not_after_be8 || flags || reason_len_be || reason || envelope

--- a/pkg/appsec/challenge/crypto.go
+++ b/pkg/appsec/challenge/crypto.go
@@ -135,13 +135,7 @@ func sealCookieV0(envelope *pb.ChallengeCookie, masterCookieKey []byte, notAfter
 		return "", fmt.Errorf("failed to create GCM: %w", err)
 	}
 
-	// Reject an over-limit envelope BEFORE marshaling it. The envelope derives
-	// from the client-submitted fingerprint, so a crafted submission could
-	// otherwise force a large proto.Marshal allocation for a cookie the browser
-	// would refuse to store anyway. proto.Size walks the message and returns its
-	// length WITHOUT allocating the marshal buffer, so the guard itself is cheap.
-	// RawURLEncoding expands raw bytes by 4/3, so invert maxCookieLen, then
-	// subtract the version byte, GCM nonce, and GCM tag to get the plaintext budget.
+	// Reject an over-limit envelope before marshaling it.
 	maxPlaintext := maxCookieLen/4*3 - 1 - gcm.NonceSize() - gcm.Overhead()
 	if plaintextLen := cookiePlaintextFixedHeaderLen + len(reason) + proto.Size(envelope); plaintextLen > maxPlaintext {
 		return "", fmt.Errorf("%w: plaintext=%d > %d", ErrCookieTooLarge, plaintextLen, maxPlaintext)

--- a/pkg/appsec/challenge/crypto.go
+++ b/pkg/appsec/challenge/crypto.go
@@ -31,6 +31,7 @@ var (
 	ErrCookieExpired       = errors.New("cookie expired")
 	ErrCookieVersion       = errors.New("unknown cookie version")
 	ErrAllowlistReasonSize = errors.New("allowlist reason exceeds maximum length")
+	ErrCookieTooLarge      = errors.New("cookie exceeds maximum size")
 )
 
 const hkdfInfo = "crowdsec-challenge-cookie"
@@ -41,6 +42,16 @@ const hkdfInfo = "crowdsec-challenge-cookie"
 // well under the 4 KB browser limit even with the AES-GCM tag + base64
 // expansion.
 const MaxAllowlistReasonLen = 256
+
+// MaxCookieLen is the DEFAULT per-cookie size ceiling, matching what browsers
+// guarantee (RFC 6265 §6.1: 4096 bytes for name + value + attributes). The
+// challenge cookie round-trips through the browser, so a legitimate one always
+// fits. We reject anything larger on both the seal and open paths — capping the
+// allocations derived from the (attacker-influenced) envelope and closing a
+// memory-exhaustion DoS. Operators can override it via Config.MaxCookieSize
+// (e.g. when a custom client tolerates larger cookies); sealCookieV0/openCookie
+// fall back to this default when given a non-positive limit.
+const MaxCookieLen = 4096
 
 // Cookie wire format. A single version byte at offset 0 lets us evolve the
 // format without flag-day-style cookie invalidation. New formats add a new
@@ -100,7 +111,11 @@ func deriveKey(secret []byte) ([]byte, error) {
 // and authenticated (any tamper attempt invalidates the GCM tag).
 //
 // Returns ErrAllowlistReasonSize if reason exceeds MaxAllowlistReasonLen.
-func sealCookieV0(envelope *pb.ChallengeCookie, masterCookieKey []byte, notAfter int64, flags byte, reason string, aad []byte) (string, error) {
+func sealCookieV0(envelope *pb.ChallengeCookie, masterCookieKey []byte, notAfter int64, flags byte, reason string, aad []byte, maxCookieLen int) (string, error) {
+	if maxCookieLen <= 0 {
+		maxCookieLen = MaxCookieLen
+	}
+
 	if len(reason) > MaxAllowlistReasonLen {
 		return "", fmt.Errorf("%w: %d > %d", ErrAllowlistReasonSize, len(reason), MaxAllowlistReasonLen)
 	}
@@ -128,6 +143,18 @@ func sealCookieV0(envelope *pb.ChallengeCookie, masterCookieKey []byte, notAfter
 	nonce := make([]byte, gcm.NonceSize())
 	if _, err := rand.Read(nonce); err != nil {
 		return "", fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	// Reject an envelope that would seal into an over-limit cookie before we
+	// allocate for it. envelopeBytes comes from the client-submitted
+	// fingerprint, so without this bound a crafted submission forces a large
+	// allocation here for a cookie the browser would refuse to store anyway.
+	// RawURLEncoding expands raw bytes by 4/3, so invert maxCookieLen, then
+	// subtract the version byte, GCM nonce, and GCM tag to get the plaintext
+	// budget.
+	maxPlaintext := maxCookieLen/4*3 - 1 - gcm.NonceSize() - gcm.Overhead()
+	if plaintextLen := cookiePlaintextFixedHeaderLen + len(reason) + len(envelopeBytes); plaintextLen > maxPlaintext {
+		return "", fmt.Errorf("%w: plaintext=%d > %d", ErrCookieTooLarge, plaintextLen, maxPlaintext)
 	}
 
 	// Build the plaintext: not_after_be8 || flags || reason_len_be || reason || envelope
@@ -171,7 +198,18 @@ type CookieEnvelope struct {
 // openCookie decodes a sealed cookie, dispatching on the version byte.
 // Unknown versions are rejected with ErrCookieVersion. Expired cookies
 // (notAfter <= now) are rejected with ErrCookieExpired.
-func openCookie(encoded string, masterCookieKey []byte, aad []byte) (*CookieEnvelope, error) {
+func openCookie(encoded string, masterCookieKey []byte, aad []byte, maxCookieLen int) (*CookieEnvelope, error) {
+	if maxCookieLen <= 0 {
+		maxCookieLen = MaxCookieLen
+	}
+
+	// Reject over-limit values before base64-decoding or AEAD-opening them.
+	// The value is fully attacker-controlled and a legitimate cookie always
+	// fits maxCookieLen; this bounds both the decode and gcm.Open allocations.
+	if len(encoded) > maxCookieLen {
+		return nil, fmt.Errorf("%w: %d > %d", ErrCookieTooLarge, len(encoded), maxCookieLen)
+	}
+
 	raw, err := base64.RawURLEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to decode: %w", ErrCookieMalformed, err)

--- a/pkg/appsec/challenge/crypto.go
+++ b/pkg/appsec/challenge/crypto.go
@@ -197,9 +197,6 @@ func openCookie(encoded string, masterCookieKey []byte, aad []byte, maxCookieLen
 		maxCookieLen = MaxCookieLen
 	}
 
-	// Reject over-limit values before base64-decoding or AEAD-opening them.
-	// The value is fully attacker-controlled and a legitimate cookie always
-	// fits maxCookieLen; this bounds both the decode and gcm.Open allocations.
 	if len(encoded) > maxCookieLen {
 		return nil, fmt.Errorf("%w: %d > %d", ErrCookieTooLarge, len(encoded), maxCookieLen)
 	}

--- a/pkg/appsec/challenge/crypto.go
+++ b/pkg/appsec/challenge/crypto.go
@@ -43,14 +43,8 @@ const hkdfInfo = "crowdsec-challenge-cookie"
 // expansion.
 const MaxAllowlistReasonLen = 256
 
-// MaxCookieLen is the DEFAULT per-cookie size ceiling, matching what browsers
-// guarantee (RFC 6265 §6.1: 4096 bytes for name + value + attributes). The
-// challenge cookie round-trips through the browser, so a legitimate one always
-// fits. We reject anything larger on both the seal and open paths — capping the
-// allocations derived from the (attacker-influenced) envelope and closing a
-// memory-exhaustion DoS. Operators can override it via Config.MaxCookieSize
-// (e.g. when a custom client tolerates larger cookies); sealCookieV0/openCookie
-// fall back to this default when given a non-positive limit.
+// MaxCookieLen is the DEFAULT per-cookie size (RFC 6265 §6.1: 4096 bytes).
+// Can be configured via Config.MaxCookieSize and we reject anything bigger.
 const MaxCookieLen = 4096
 
 // Cookie wire format. A single version byte at offset 0 lets us evolve the

--- a/pkg/appsec/challenge/keyring_integration_test.go
+++ b/pkg/appsec/challenge/keyring_integration_test.go
@@ -22,10 +22,10 @@ func TestCookieV0_RoundTrip(t *testing.T) {
 	envelope := &pb.ChallengeCookie{PowDifficulty: 12}
 	notAfter := time.Now().Add(time.Hour).Unix()
 
-	encoded, err := sealCookieV0(envelope, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua"))
+	encoded, err := sealCookieV0(envelope, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua"), MaxCookieLen)
 	require.NoError(t, err)
 
-	got, err := openCookie(encoded, keys.MasterCookieKey(), []byte("ua"))
+	got, err := openCookie(encoded, keys.MasterCookieKey(), []byte("ua"), MaxCookieLen)
 	require.NoError(t, err)
 	assert.Equal(t, int32(12), got.Envelope.GetPowDifficulty())
 }
@@ -39,10 +39,10 @@ func TestCookieV0_ExpiredRejected(t *testing.T) {
 	// when issued (this is what a stale cookie sent by a slow client would
 	// look like on the server).
 	pastNotAfter := time.Now().Add(-time.Hour).Unix()
-	encoded, err := sealCookieV0(&pb.ChallengeCookie{}, keys.MasterCookieKey(), pastNotAfter, 0, "", []byte("ua"))
+	encoded, err := sealCookieV0(&pb.ChallengeCookie{}, keys.MasterCookieKey(), pastNotAfter, 0, "", []byte("ua"), MaxCookieLen)
 	require.NoError(t, err)
 
-	_, err = openCookie(encoded, keys.MasterCookieKey(), []byte("ua"))
+	_, err = openCookie(encoded, keys.MasterCookieKey(), []byte("ua"), MaxCookieLen)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrCookieExpired,
 		"expired cookie must produce ErrCookieExpired, got %v", err)
@@ -57,7 +57,7 @@ func TestCookieV0_TamperedExpirationRejected(t *testing.T) {
 	keys := testKeyRing()
 	notAfter := time.Now().Add(time.Hour).Unix()
 
-	encoded, err := sealCookieV0(&pb.ChallengeCookie{}, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua"))
+	encoded, err := sealCookieV0(&pb.ChallengeCookie{}, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua"), MaxCookieLen)
 	require.NoError(t, err)
 
 	raw, err := base64.RawURLEncoding.DecodeString(encoded)
@@ -71,7 +71,7 @@ func TestCookieV0_TamperedExpirationRejected(t *testing.T) {
 	tampered[1+12] ^= 0x80 // flip MSB of not_after's high byte
 	tamperedEncoded := base64.RawURLEncoding.EncodeToString(tampered)
 
-	_, err = openCookie(tamperedEncoded, keys.MasterCookieKey(), []byte("ua"))
+	_, err = openCookie(tamperedEncoded, keys.MasterCookieKey(), []byte("ua"), MaxCookieLen)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrCookieSignature,
 		"tampering with the not_after region must produce ErrCookieSignature (AEAD tag failure)")
@@ -82,10 +82,10 @@ func TestCookieV0_UAMismatchRejected(t *testing.T) {
 	keys := testKeyRing()
 	notAfter := time.Now().Add(time.Hour).Unix()
 
-	encoded, err := sealCookieV0(&pb.ChallengeCookie{}, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua-A"))
+	encoded, err := sealCookieV0(&pb.ChallengeCookie{}, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua-A"), MaxCookieLen)
 	require.NoError(t, err)
 
-	_, err = openCookie(encoded, keys.MasterCookieKey(), []byte("ua-B"))
+	_, err = openCookie(encoded, keys.MasterCookieKey(), []byte("ua-B"), MaxCookieLen)
 	assert.ErrorIs(t, err, ErrCookieSignature)
 }
 
@@ -106,7 +106,7 @@ func TestCookieV0_SurvivesArbitraryRotation(t *testing.T) {
 	// in-envelope expiration check (which uses real time.Now()) won't
 	// reject the cookie.
 	notAfter := t0.Add(24 * time.Hour).Unix()
-	encoded, err := sealCookieV0(&pb.ChallengeCookie{PowDifficulty: 9}, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua"))
+	encoded, err := sealCookieV0(&pb.ChallengeCookie{PowDifficulty: 9}, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua"), MaxCookieLen)
 	require.NoError(t, err)
 
 	// Roll the keyring's clock forward — this triggers per-epoch sign-key
@@ -125,7 +125,7 @@ func TestCookieV0_SurvivesArbitraryRotation(t *testing.T) {
 		// keyring time, simulating real rotation activity.
 		_, _ = keys.Current()
 
-		got, err := openCookie(encoded, keys.MasterCookieKey(), []byte("ua"))
+		got, err := openCookie(encoded, keys.MasterCookieKey(), []byte("ua"), MaxCookieLen)
 		require.NoError(t, err,
 			"cookie should still validate after %s of keyring rotation; got %v", advance, err)
 		assert.Equal(t, int32(9), got.Envelope.GetPowDifficulty())
@@ -140,10 +140,10 @@ func TestCookieV0_ExpiryEnforcedAgainstWallClock(t *testing.T) {
 	keys := testKeyRing()
 
 	pastNotAfter := time.Now().Add(-time.Minute).Unix()
-	encoded, err := sealCookieV0(&pb.ChallengeCookie{}, keys.MasterCookieKey(), pastNotAfter, 0, "", []byte("ua"))
+	encoded, err := sealCookieV0(&pb.ChallengeCookie{}, keys.MasterCookieKey(), pastNotAfter, 0, "", []byte("ua"), MaxCookieLen)
 	require.NoError(t, err)
 
-	_, err = openCookie(encoded, keys.MasterCookieKey(), []byte("ua"))
+	_, err = openCookie(encoded, keys.MasterCookieKey(), []byte("ua"), MaxCookieLen)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrCookieExpired)
 }
@@ -159,10 +159,10 @@ func TestCookieV0_MasterSecretChangeInvalidates(t *testing.T) {
 	keysB, err := NewKeyRing(bytes.Repeat([]byte{0xbb}, 32), time.Minute, 3)
 	require.NoError(t, err)
 
-	encoded, err := sealCookieV0(&pb.ChallengeCookie{}, keysA.MasterCookieKey(), notAfter, 0, "", []byte("ua"))
+	encoded, err := sealCookieV0(&pb.ChallengeCookie{}, keysA.MasterCookieKey(), notAfter, 0, "", []byte("ua"), MaxCookieLen)
 	require.NoError(t, err)
 
-	_, err = openCookie(encoded, keysB.MasterCookieKey(), []byte("ua"))
+	_, err = openCookie(encoded, keysB.MasterCookieKey(), []byte("ua"), MaxCookieLen)
 	assert.ErrorIs(t, err, ErrCookieSignature,
 		"cookie sealed under secret A must not decrypt under secret B")
 }
@@ -181,10 +181,10 @@ func TestCookieV0_DistributedSetup_TwoInstances(t *testing.T) {
 		"two instances with the same master_secret must derive the same master cookie key")
 
 	notAfter := time.Now().Add(time.Hour).Unix()
-	encoded, err := sealCookieV0(&pb.ChallengeCookie{PowDifficulty: 14}, a.MasterCookieKey(), notAfter, 0, "", []byte("ua"))
+	encoded, err := sealCookieV0(&pb.ChallengeCookie{PowDifficulty: 14}, a.MasterCookieKey(), notAfter, 0, "", []byte("ua"), MaxCookieLen)
 	require.NoError(t, err)
 
-	got, err := openCookie(encoded, b.MasterCookieKey(), []byte("ua"))
+	got, err := openCookie(encoded, b.MasterCookieKey(), []byte("ua"), MaxCookieLen)
 	require.NoError(t, err, "cookie issued by A must validate against B (same master_secret)")
 	assert.Equal(t, int32(14), got.Envelope.GetPowDifficulty())
 }
@@ -200,7 +200,7 @@ func TestCookie_UnknownVersionRejected(t *testing.T) {
 	raw := append([]byte{0xFE}, []byte("0123456789abcdefghijklmnop")...)
 	encoded := base64.RawURLEncoding.EncodeToString(raw)
 
-	_, err := openCookie(encoded, keys.MasterCookieKey(), []byte("ua"))
+	_, err := openCookie(encoded, keys.MasterCookieKey(), []byte("ua"), MaxCookieLen)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrCookieVersion, "unknown version byte must produce ErrCookieVersion")
 }
@@ -331,10 +331,10 @@ func TestCookieV0_AllowlistRoundTrip(t *testing.T) {
 	notAfter := time.Now().Add(time.Hour).Unix()
 	reason := "Googlebot/2.1 (compatible)"
 
-	encoded, err := sealCookieV0(&pb.ChallengeCookie{}, keys.MasterCookieKey(), notAfter, cookieFlagAllowlisted, reason, []byte("ua"))
+	encoded, err := sealCookieV0(&pb.ChallengeCookie{}, keys.MasterCookieKey(), notAfter, cookieFlagAllowlisted, reason, []byte("ua"), MaxCookieLen)
 	require.NoError(t, err)
 
-	got, err := openCookie(encoded, keys.MasterCookieKey(), []byte("ua"))
+	got, err := openCookie(encoded, keys.MasterCookieKey(), []byte("ua"), MaxCookieLen)
 	require.NoError(t, err)
 	assert.True(t, got.Allowlisted, "allowlist flag should round-trip true")
 	assert.Equal(t, reason, got.AllowlistReason, "reason should round-trip verbatim")
@@ -346,10 +346,10 @@ func TestCookieV0_AllowlistFlagDefaultsFalse(t *testing.T) {
 	keys := testKeyRing()
 	notAfter := time.Now().Add(time.Hour).Unix()
 
-	encoded, err := sealCookieV0(&pb.ChallengeCookie{PowDifficulty: 12}, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua"))
+	encoded, err := sealCookieV0(&pb.ChallengeCookie{PowDifficulty: 12}, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua"), MaxCookieLen)
 	require.NoError(t, err)
 
-	got, err := openCookie(encoded, keys.MasterCookieKey(), []byte("ua"))
+	got, err := openCookie(encoded, keys.MasterCookieKey(), []byte("ua"), MaxCookieLen)
 	require.NoError(t, err)
 	assert.False(t, got.Allowlisted, "default flag must be false")
 	assert.Empty(t, got.AllowlistReason)
@@ -362,9 +362,91 @@ func TestCookieV0_AllowlistReasonTooLong(t *testing.T) {
 	notAfter := time.Now().Add(time.Hour).Unix()
 	oversize := bytes.Repeat([]byte("x"), MaxAllowlistReasonLen+1)
 
-	_, err := sealCookieV0(&pb.ChallengeCookie{}, keys.MasterCookieKey(), notAfter, cookieFlagAllowlisted, string(oversize), []byte("ua"))
+	_, err := sealCookieV0(&pb.ChallengeCookie{}, keys.MasterCookieKey(), notAfter, cookieFlagAllowlisted, string(oversize), []byte("ua"), MaxCookieLen)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrAllowlistReasonSize)
+}
+
+// TestCookieV0_SealEnvelopeTooLarge confirms the seal path rejects an envelope
+// (built from the client-submitted fingerprint) that would produce an
+// over-limit cookie, before allocating for it. Without this bound a crafted
+// submission forces a large allocation for a cookie the browser would refuse.
+func TestCookieV0_SealEnvelopeTooLarge(t *testing.T) {
+	keys := testKeyRing()
+	notAfter := time.Now().Add(time.Hour).Unix()
+
+	// A fingerprint whose marshaled size blows past the plaintext budget.
+	envelope := &pb.ChallengeCookie{
+		Fingerprint: &pb.FingerprintData{Fsid: strings.Repeat("x", MaxCookieLen)},
+	}
+
+	_, err := sealCookieV0(envelope, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua"), MaxCookieLen)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCookieTooLarge)
+}
+
+// TestCookieV0_OpenValueTooLarge confirms the open path rejects an over-limit
+// cookie value before base64-decoding or AEAD-opening it.
+func TestCookieV0_OpenValueTooLarge(t *testing.T) {
+	keys := testKeyRing()
+
+	oversized := strings.Repeat("A", MaxCookieLen+1)
+
+	_, err := openCookie(oversized, keys.MasterCookieKey(), []byte("ua"), MaxCookieLen)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCookieTooLarge)
+}
+
+// TestCookieV0_RealCookieUnderLimit guards against the cap being set too low:
+// a normal sealed cookie must stay under MaxCookieLen and still round-trip.
+func TestCookieV0_RealCookieUnderLimit(t *testing.T) {
+	keys := testKeyRing()
+	notAfter := time.Now().Add(time.Hour).Unix()
+	envelope := &pb.ChallengeCookie{
+		Fingerprint:   &pb.FingerprintData{Fsid: "abc123", Url: "https://example.com/"},
+		PowDifficulty: 12,
+	}
+
+	encoded, err := sealCookieV0(envelope, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua"), MaxCookieLen)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(encoded), MaxCookieLen)
+
+	_, err = openCookie(encoded, keys.MasterCookieKey(), []byte("ua"), MaxCookieLen)
+	require.NoError(t, err)
+}
+
+// TestCookieV0_ConfigurableLimit confirms the seal/open ceiling honors a
+// caller-supplied bound (Config.MaxCookieSize → runtime.maxCookieLen) and that
+// a non-positive bound falls back to the MaxCookieLen default.
+func TestCookieV0_ConfigurableLimit(t *testing.T) {
+	keys := testKeyRing()
+	notAfter := time.Now().Add(time.Hour).Unix()
+
+	// A ~4 KB fingerprint: seals to a cookie that exceeds the 4096 default but
+	// fits a raised 8192 ceiling.
+	envelope := &pb.ChallengeCookie{
+		Fingerprint: &pb.FingerprintData{Fsid: strings.Repeat("x", 4000)},
+	}
+
+	// A tight limit rejects it on seal, before allocating.
+	_, err := sealCookieV0(envelope, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua"), 1024)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCookieTooLarge)
+
+	// A raised limit accepts the same envelope.
+	encoded, err := sealCookieV0(envelope, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua"), 8192)
+	require.NoError(t, err)
+	require.Greater(t, len(encoded), MaxCookieLen, "sanity: this cookie exceeds the default ceiling")
+
+	// The default ceiling (0 → MaxCookieLen) then rejects it on open...
+	_, err = openCookie(encoded, keys.MasterCookieKey(), []byte("ua"), 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCookieTooLarge)
+
+	// ...while the matching raised ceiling opens it successfully.
+	got, err := openCookie(encoded, keys.MasterCookieKey(), []byte("ua"), 8192)
+	require.NoError(t, err)
+	assert.NotNil(t, got)
 }
 
 // TestCookieV0_TamperedFlagsRejected confirms the flags byte is INSIDE the
@@ -373,7 +455,7 @@ func TestCookieV0_TamperedFlagsRejected(t *testing.T) {
 	keys := testKeyRing()
 	notAfter := time.Now().Add(time.Hour).Unix()
 
-	encoded, err := sealCookieV0(&pb.ChallengeCookie{}, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua"))
+	encoded, err := sealCookieV0(&pb.ChallengeCookie{}, keys.MasterCookieKey(), notAfter, 0, "", []byte("ua"), MaxCookieLen)
 	require.NoError(t, err)
 
 	raw, err := base64.RawURLEncoding.DecodeString(encoded)
@@ -386,7 +468,7 @@ func TestCookieV0_TamperedFlagsRejected(t *testing.T) {
 	tampered[1+12+8] ^= 0x01
 	tamperedEncoded := base64.RawURLEncoding.EncodeToString(tampered)
 
-	_, err = openCookie(tamperedEncoded, keys.MasterCookieKey(), []byte("ua"))
+	_, err = openCookie(tamperedEncoded, keys.MasterCookieKey(), []byte("ua"), MaxCookieLen)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrCookieSignature)
 }

--- a/pkg/appsec/challenge/obfuscator.go
+++ b/pkg/appsec/challenge/obfuscator.go
@@ -50,7 +50,7 @@ func (c *ChallengeRuntime) ObfuscateJS(ctx context.Context, inputJS string) (str
 		}
 		return "", fmt.Errorf("wasm instantiation error: %v", err)
 	}
-	defer mod.Close(ctx)
+	mod.Close(ctx)
 
 	return stdout.String(), nil
 }

--- a/pkg/appsec/challenge/obfuscator.go
+++ b/pkg/appsec/challenge/obfuscator.go
@@ -50,8 +50,7 @@ func (c *ChallengeRuntime) ObfuscateJS(ctx context.Context, inputJS string) (str
 		}
 		return "", fmt.Errorf("wasm instantiation error: %v", err)
 	}
-
-	mod.Close(ctx)
+	defer mod.Close(ctx)
 
 	return stdout.String(), nil
 }


### PR DESCRIPTION
 - avoid potential overflow on cookie size related allocs (and make it configurable, defaults to 4k)
 - make linter happy
 - kill a potential null deref
 - ensure wazero doesn't leak on restart