### PR TITLE
Unify sqlite build flag

### DIFF
--- a/pkg/database/drv_sqlite_mattn.go
+++ b/pkg/database/drv_sqlite_mattn.go
@@ -1,4 +1,4 @@
-//go:build !db_no_sqlite && !sqlite_modernc
+//go:build !no_db_sqlite && !sqlite_modernc
 
 package database
 

--- a/pkg/database/drv_sqlite_modernc.go
+++ b/pkg/database/drv_sqlite_modernc.go
@@ -1,4 +1,4 @@
-//go:build !db_no_sqlite && sqlite_modernc
+//go:build !no_db_sqlite && sqlite_modernc
 
 package database
 


### PR DESCRIPTION
There is a component named `db_sqlite` ([1](https://github.com/crowdsecurity/crowdsec/blob/master/Makefile#L182), [2](https://github.com/crowdsecurity/crowdsec/blob/master/pkg/cwversion/component/component.go#L28), [3](https://github.com/crowdsecurity/crowdsec/blob/master/pkg/database/drv_sqlite_mattn.go#L15), [4](https://github.com/crowdsecurity/crowdsec/blob/master/pkg/database/drv_sqlite_modernc.go#L18)).

In order to disable a component, [Makefile](https://github.com/crowdsecurity/crowdsec/blob/b962bc0d479e093c7885087e1d087ac0228f4c8c/Makefile#L215) suggests to apply `no_` prefix to a component name. For example, [no_db_postgres](https://github.com/crowdsecurity/crowdsec/blob/b962bc0d479e093c7885087e1d087ac0228f4c8c/pkg/database/drv_postgres.go#L1). However, sqlite doesn't follow the convention: [1](https://github.com/crowdsecurity/crowdsec/blob/b962bc0d479e093c7885087e1d087ac0228f4c8c/pkg/database/drv_sqlite_mattn.go#L1), [2](https://github.com/crowdsecurity/crowdsec/blob/b962bc0d479e093c7885087e1d087ac0228f4c8c/pkg/database/drv_sqlite_modernc.go#L1).

So, this PR changes flag names in order to comply with the convention.