### PR TITLE
Fix `Distinct()` panic on `[]string` and other non-`[]any` slices

### DIFF
--- a/pkg/exprhelpers/exprlib_test.go
+++ b/pkg/exprhelpers/exprlib_test.go
@@ -222,6 +222,64 @@ func TestParseQueryInExpr(t *testing.T) {
 	}
 }
 
+func TestDistinct(t *testing.T) {
+	err := Init(nil)
+	require.NoError(t, err)
+
+	// Direct calls: any slice/array element type must dedupe while preserving order.
+	out, err := Distinct([]string{"a", "a", "b"})
+	require.NoError(t, err)
+	require.Equal(t, []any{"a", "b"}, out)
+
+	out, err = Distinct([]any{"a", "a", "b", 1, 1})
+	require.NoError(t, err)
+	require.Equal(t, []any{"a", "b", 1}, out)
+
+	// Empty and nil slices return an empty []any (not nil).
+	out, err = Distinct([]string{})
+	require.NoError(t, err)
+	require.Equal(t, []any{}, out)
+
+	out, err = Distinct([]any(nil))
+	require.NoError(t, err)
+	require.Equal(t, []any{}, out)
+
+	// Non-slice input returns nil (unchanged contract).
+	out, err = Distinct("notaslice")
+	require.NoError(t, err)
+	require.Nil(t, out)
+
+	// Expr-level: Distinct(Split(...)) — Split returns []string, the regressed case.
+	tests := []struct {
+		name   string
+		env    map[string]any
+		code   string
+		result any
+		err    string
+	}{
+		{
+			name:   "Distinct(Split()) dedupes a []string",
+			env:    map[string]any{"raw": "a,a,b,b,c"},
+			code:   `Distinct(Split(raw, ","))`,
+			result: []any{"a", "b", "c"},
+		},
+		{
+			name:   "Distinct over an expr list literal",
+			env:    map[string]any{},
+			code:   `Distinct(["a", "a", "b"])`,
+			result: []any{"a", "b"},
+		},
+	}
+	for _, test := range tests {
+		program, err := expr.Compile(test.code, GetExprOptions(test.env)...)
+		require.NoError(t, err)
+		output, err := expr.Run(program, test.env)
+		require.NoError(t, err)
+		require.Equal(t, test.result, output)
+		log.Printf("test '%s' : OK", test.name)
+	}
+}
+
 func TestDistanceHelper(t *testing.T) {
 	err := Init(nil)
 	require.NoError(t, err)

--- a/pkg/exprhelpers/helpers.go
+++ b/pkg/exprhelpers/helpers.go
@@ -268,19 +268,16 @@ func FileInit(directory string, filename string, fileType string) error {
 // Expr helpers
 
 func Distinct(params ...any) (any, error) {
-	if rt := reflect.TypeOf(params[0]).Kind(); rt != reflect.Slice && rt != reflect.Array {
+	v := reflect.ValueOf(params[0])
+	if k := v.Kind(); k != reflect.Slice && k != reflect.Array {
 		return nil, nil
 	}
 
-	array := params[0].([]any)
-	if array == nil {
-		return []any{}, nil
-	}
-
 	exists := make(map[any]bool)
-	ret := make([]any, 0)
+	ret := make([]any, 0, v.Len())
 
-	for _, val := range array {
+	for i := range v.Len() {
+		val := v.Index(i).Interface()
 		if _, ok := exists[val]; !ok {
 			exists[val] = true
 			ret = append(ret, val)


### PR DESCRIPTION
## Description

`Distinct()` panics / errors on any non-`[]any` slice. It checks `reflect.Kind() == Slice/Array` but then does an unchecked `params[0].([]any)` assertion, which fails for `[]string` — the type returned by `Split`, `Fields`, `ParseUri`, `ExtractQueryParam`, etc. So the natural idiom

```
Distinct(Split(evt.raw, ","))
```

errors with `interface conversion: interface {} is []string, not []interface {}` instead of deduplicating (a direct Go call is a hard panic).

## Fix

Iterate the slice reflectively (mirroring the neighbouring `flatten()` helper) so any element type is handled. Behaviour for `[]any`, empty/nil slices, and non-slice inputs is unchanged, and order is preserved.

## Test

Added `TestDistinct` in `pkg/exprhelpers/exprlib_test.go` covering `[]string`, `[]any`, empty/nil, a non-slice input, and an expr-level `Distinct(Split(...))`. Passes under the package's `expr_debug` build tag.
