### PR TITLE
fix(leakybucket): emit overflow before pouring the next event

### DIFF
--- a/pkg/leakybucket/bayesian.go
+++ b/pkg/leakybucket/bayesian.go
@@ -75,7 +75,7 @@ func (p *BayesianProcessor) AfterBucketPour(_ *BucketFactory, msg pipeline.Event
 	if p.posterior > p.threshold {
 		l.logger.Debugf("Bayesian bucket overflow")
 		l.Ovflw_ts = l.Last_ts
-		l.Out <- l.Queue
+		l.pendingOverflow = l.Queue
 		return nil
 	}
 

--- a/pkg/leakybucket/bucket.go
+++ b/pkg/leakybucket/bucket.go
@@ -29,8 +29,11 @@ type Leaky struct {
 	Queue *pipeline.Queue
 	// Leaky buckets are receiving message through a chan
 	In chan *pipeline.Event `json:"-"`
-	// Leaky buckets are pushing their overflows through a chan
-	Out chan *pipeline.Queue `json:"-"`
+	// pendingOverflow holds the queue an event source (Pour or an overflow
+	// processor) decided to overflow with. It is emitted at the end of the same
+	// LeakRoutine iteration that produced it, before any further event can be
+	// poured into the (shared, bounded-ring) queue.
+	pendingOverflow *pipeline.Queue
 	// shared for all buckets (the idea is to kill this afterward)
 	AllOut chan pipeline.Event `json:"-"`
 	// the unique identifier of the bucket (a hash)
@@ -88,7 +91,6 @@ func NewLeakyFromFactory(f *BucketFactory) *Leaky {
 		Limiter: limiter,
 		Uuid:    seed.Generate(),
 		Queue:   pipeline.NewQueue(Qsize),
-		Out:     make(chan *pipeline.Queue, 1),
 		Suicide: make(chan bool, 1),
 		AllOut:  f.ret,
 		Factory: f,
@@ -205,9 +207,6 @@ func (l *Leaky) LeakRoutine(ctx context.Context, gate pourGate) {
 			if l.Factory.orderEvent {
 				orderEvent[l.Mapkey].Done()
 			}
-		case ofw := <-l.Out:
-			l.overflow(ofw)
-			return
 		// suiciiiide
 		case <-l.Suicide:
 			// don't wait defer to close the channel, in case we are blocked before returning
@@ -257,14 +256,18 @@ func (l *Leaky) LeakRoutine(ctx context.Context, gate pourGate) {
 			return
 		case <-ctx.Done():
 			l.logger.Debugf("Bucket externally killed, return")
-			for len(l.Out) > 0 {
-				ofw := <-l.Out
-				l.overflow(ofw)
-			}
 			l.AllOut <- pipeline.Event{Type: pipeline.OVFLW, Overflow: pipeline.RuntimeAlert{Mapkey: l.Mapkey}}
 			return
 		}
 	End:
+		// An event source (Pour or an overflow processor) may have decided to
+		// overflow during this iteration. Emit it now, in the same iteration that
+		// produced it and after the ordering gate was released, so no further
+		// event can be poured into the shared queue the alert is built from.
+		if l.pendingOverflow != nil {
+			l.overflow(l.pendingOverflow)
+			return
+		}
 	}
 }
 
@@ -285,7 +288,7 @@ func Pour(l *Leaky, gate pourGate, msg pipeline.Event) {
 		l.Ovflw_ts = time.Now().UTC()
 		l.logger.Debugf("Last event to be poured, bucket overflow.")
 		l.Queue.Add(msg)
-		l.Out <- l.Queue
+		l.pendingOverflow = l.Queue
 	}
 }
 

--- a/pkg/leakybucket/bucket.go
+++ b/pkg/leakybucket/bucket.go
@@ -218,40 +218,18 @@ func (l *Leaky) LeakRoutine(ctx context.Context, gate pourGate) {
 			return
 		// we underflow or reach bucket deadline (timers)
 		case <-durationTickerChan:
-			var (
-				alert pipeline.RuntimeAlert
-				err   error
-			)
 			l.Ovflw_ts = time.Now().UTC()
-			l.markDone()
-			ofw := l.Queue
-			alert = pipeline.RuntimeAlert{Mapkey: l.Mapkey}
-
 			if l.timedOverflow {
-				metrics.BucketsOverflow.With(prometheus.Labels{"name": l.Factory.Spec.Name}).Inc()
-
-				alert, err = NewAlert(l, ofw)
-				if err != nil {
-					log.Error(err)
-				}
-				for _, f := range l.Factory.processors {
-					alert, ofw = f.OnBucketOverflow(l.Factory, l, alert, ofw)
-					if ofw == nil {
-						l.logger.Debugf("Overflow has been discarded (%T)", f)
-						break
-					}
-				}
+				// a counter bucket reached its deadline: this is a real overflow,
+				// emit it through the same path as a capacity overflow.
 				l.logger.Infof("Timed Overflow")
+				l.overflow(l.Queue)
 			} else {
 				l.logger.Debugf("bucket underflow, destroy")
+				l.markDone()
 				metrics.BucketsUnderflow.With(prometheus.Labels{"name": l.Factory.Spec.Name}).Inc()
+				l.AllOut <- pipeline.Event{Overflow: pipeline.RuntimeAlert{Mapkey: l.Mapkey}, Type: pipeline.OVFLW}
 			}
-			if l.logger.Level >= log.TraceLevel {
-				// don't sdump if it's not going to be printed, it's expensive
-				l.logger.Tracef("Overflow event: %s", spew.Sdump(pipeline.Event{Overflow: alert}))
-			}
-
-			l.AllOut <- pipeline.Event{Overflow: alert, Type: pipeline.OVFLW}
 			l.logger.Tracef("Returning from leaky routine.")
 			return
 		case <-ctx.Done():

--- a/pkg/leakybucket/conditional.go
+++ b/pkg/leakybucket/conditional.go
@@ -70,7 +70,7 @@ func (p *ConditionalProcessor) AfterBucketPour(f *BucketFactory, msg pipeline.Ev
 		if condition {
 			l.logger.Debugf("Conditional bucket overflow")
 			l.Ovflw_ts = l.Last_ts
-			l.Out <- l.Queue
+			l.pendingOverflow = l.Queue
 			return nil
 		}
 	}

--- a/pkg/leakybucket/timemachine.go
+++ b/pkg/leakybucket/timemachine.go
@@ -43,7 +43,7 @@ func TimeMachinePour(l *Leaky, _ pourGate, msg pipeline.Event) {
 		l.Ovflw_ts = d
 		l.logger.Debugf("Bucket overflow at %s", l.Ovflw_ts)
 		l.Queue.Add(msg)
-		l.Out <- l.Queue
+		l.pendingOverflow = l.Queue
 	}
 }
 

--- a/pkg/leakybucket/trigger.go
+++ b/pkg/leakybucket/trigger.go
@@ -38,7 +38,7 @@ func (*TriggerProcessor) OnBucketPour(_ *BucketFactory, msg pipeline.Event, l *L
 
 	l.logger.Debug("Bucket overflow")
 	l.Queue.Add(msg)
-	l.Out <- l.Queue
+	l.pendingOverflow = l.Queue
 
 	return nil
 }


### PR DESCRIPTION
## Problem

Some hub scenario tests fail intermittently on loaded CI runners with the overflow alert carrying the wrong events — e.g. `gitea-bf`:

```
results[8].Overflow.Alert.Events[0].GetMeta("user") == "test"
    Actual expression values:
        results[8]...GetMeta("user") = 'test1'
```

Source IP and timestamp are correct; only the events are wrong (`test` → `test1..test6`).

## Root cause

In `LeakRoutine` (`pkg/leakybucket/bucket.go`), a bucket signalled an overflow by sending its queue **pointer** over the buffered `l.Out` channel and draining it a loop iteration later, in a `select` that races `case <-l.In`. `l.Queue` is a bounded ring (`pipeline.Queue.Add` drops the oldest past capacity) shared by pointer with the alert. If a further same-timestamp event wins that race, it is poured into the same queue and evicts the events the overflow alert is about to be built from.

Rare locally, reliable on oversubscribed CI runners. `-order-event` enforces per-bucket pour ordering but does not prevent this, because the overflow was emitted a `select` iteration *after* the pour that produced it.

## Fix

Replace the `l.Out` self-channel with an explicit `pendingOverflow *pipeline.Queue` field. Every overflow source sets it — `Pour`, `TimeMachinePour`, and the trigger/conditional/bayesian processors (the processor sources can't return through `Pour`, so a shared signal is needed) — and `LeakRoutine` emits it once at the `End:` label:

- **Same iteration** that produced it, so no further event can be poured into the shared queue → fixes the corruption.
- **After** `orderEvent.Done()` releases the ordering gate, so a `Reprocess: true` overflow fed back into the pour routine cannot deadlock (`overflow()` blocks on the output channel).

Also removes a latent per-bucket hang where a trigger bucket could re-pour into an already-full buffered `l.Out`.

## Testing

- `go test ./pkg/leakybucket/...` passes.
- Hubtests per bucket type — leaky (`gitea-bf`), conditional (`ssh-time-based-bf`, `sshd-impossible-travel`), trigger (`thinkphp-cve-2018-20062`, `CVE-2017-9841`, `spring4shell_cve-2022-22965`) — pass; bayesian covered by unit-test data.
- Reprocess scenarios (`nextcloud-bf`, `dovecot-slow-bf`, `apereo-cas-bf`) pass without hanging.
- Full scenario hubtest suite passes; `gitea-bf` overflow content stable across many `-dump-data -order-event` runs.
- No performance regression (A/B timing of the two binaries is equal within noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)