### PR TITLE
cscli lapi register: no error if the credentials file does not exist

### DIFF
--- a/cmd/crowdsec-cli/clilapi/lapi.go
+++ b/cmd/crowdsec-cli/clilapi/lapi.go
@@ -28,8 +28,18 @@ func (cli *cliLapi) NewCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Usage()
 		},
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-			if err := cli.cfg().LoadAPIClient(); err != nil {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			cfg := cli.cfg()
+			if err := cfg.LoadAPIClient(); err != nil {
+				// "register" creates the credentials file, so a configured
+				// path whose file is missing or unreadable must not block it.
+				// The api.client section is still required: it provides the
+				// destination path and the URL fallback.
+				if cmd.Name() == "register" && cfg.API != nil && cfg.API.Client != nil &&
+					cfg.API.Client.CredentialsFilePath != "" {
+					return nil
+				}
+
 				return fmt.Errorf("loading api client: %w", err)
 			}
 

--- a/cmd/crowdsec-cli/clilapi/register.go
+++ b/cmd/crowdsec-cli/clilapi/register.go
@@ -14,6 +14,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/core/idgen"
 	"github.com/crowdsecurity/crowdsec/cmd/crowdsec-cli/core/reload"
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
+	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 )
 
 func (cli *cliLapi) register(ctx context.Context, apiURL string, outputFile string, machine string, token string) error {
@@ -65,6 +66,11 @@ func (cli *cliLapi) register(ctx context.Context, apiURL string, outputFile stri
 	}
 
 	apiCfg := cfg.API.Client.Credentials
+	if apiCfg == nil {
+		// no pre-existing credentials file was loaded
+		apiCfg = &csconfig.ApiCredentialsCfg{}
+	}
+
 	apiCfg.Login = lapiUser
 	apiCfg.Password = password.String()
 

--- a/cmd/crowdsec-cli/clilapi/register_test.go
+++ b/cmd/crowdsec-cli/clilapi/register_test.go
@@ -1,0 +1,54 @@
+package clilapi
+
+import (
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
+)
+
+func configWithMissingCredentialsFile(t *testing.T) *csconfig.Config {
+	t.Helper()
+
+	return &csconfig.Config{
+		API: &csconfig.APICfg{
+			Client: &csconfig.LocalApiClientCfg{
+				CredentialsFilePath: filepath.Join(t.TempDir(), "does-not-exist", "credentials.yaml"),
+			},
+		},
+	}
+}
+
+// A missing credentials file must not prevent "lapi register" from running,
+// because creating that file is the command's purpose.
+func TestRegisterWithoutCredentialsFile(t *testing.T) {
+	cfg := configWithMissingCredentialsFile(t)
+
+	cmd := New(func() *csconfig.Config { return cfg }).NewCommand()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"register", "--machine", "testmachine", "--url", "http://127.0.0.1:1", "--token", "testtoken"})
+
+	err := cmd.Execute()
+
+	// The command gets past credentials loading and fails only when it
+	// actually talks to the (unreachable) API.
+	require.ErrorContains(t, err, "api client register")
+	require.NotContains(t, err.Error(), "loading api client")
+}
+
+// Subcommands that read the LAPI still require an existing credentials file.
+func TestStatusStillRequiresCredentialsFile(t *testing.T) {
+	cfg := configWithMissingCredentialsFile(t)
+
+	cmd := New(func() *csconfig.Config { return cfg }).NewCommand()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"status"})
+
+	err := cmd.Execute()
+	require.ErrorContains(t, err, "loading api client")
+}

--- a/test/bats/01_cscli_lapi.bats
+++ b/test/bats/01_cscli_lapi.bats
@@ -204,6 +204,29 @@ teardown() {
     assert_output "true"
 }
 
+@test "cscli lapi register --token (no pre-existing credentials file)" {
+    config_set '.api.server.auto_registration.enabled=true'
+    config_set '.api.server.auto_registration.token="12345678901234567890123456789012"'
+    config_set '.api.server.auto_registration.allowed_ranges=["127.0.0.1/32"]'
+
+    rune -0 ./instance-crowdsec start
+
+    LOCAL_API_CREDENTIALS=$(config_get '.api.client.credentials_path')
+    rm -f "$LOCAL_API_CREDENTIALS"
+
+    rune -0 cscli lapi register --machine freshmachine --url http://127.0.0.1:8080 --token 12345678901234567890123456789012
+    assert_stderr --partial "Successfully registered to Local API"
+    assert_stderr --partial "Local API credentials written to '$LOCAL_API_CREDENTIALS'"
+
+    # the written credentials authenticate (the machine was auto-validated)
+    rune -0 cscli lapi status
+
+    # subcommands that read the LAPI still require the credentials file
+    rm -f "$LOCAL_API_CREDENTIALS"
+    rune -1 cscli lapi status
+    assert_stderr --partial "no such file or directory"
+}
+
 @test "cscli lapi register --token (bad source ip)" {
     config_set '.api.server.auto_registration.enabled=true'
     config_set '.api.server.auto_registration.token="12345678901234567890123456789012"'


### PR DESCRIPTION
`cscli lapi register --token <token> --url <url>` fails with `loading api client: while reading yaml file: open <credentials_path>: no such file or directory` when the credentials file does not exist yet, which defeats token-based bootstrap of a fresh log processor (the reporter was following the multiserver setup guide with only a token). The failure comes from the lapi command group's PersistentPreRunE, which loads the existing credentials before subcommands such as register and status run, and register is the one subcommand whose job is to create that file.

This skips the pre-load for register when a credentials path is configured, covering the missing, empty, and corrupt file states, since register overwrites the file on success and the reporter's empty-file workaround shows tolerating only the missing case is not enough. `lapi status` keeps requiring a loadable credentials file, and register initializes empty credentials when none were loaded. This is the lapi analogue of #3645, which made `capi register` tolerate a missing online_api_credentials.yaml; the group hook is kept here because it also serves status, and register still uses loaded credentials for the URL fallback when the file exists.

Adds two unit tests (register proceeds past loading with a missing file and fails only at the unreachable API; status still requires the file) and a bats case covering the full bootstrap roundtrip: register with no pre-existing credentials file, then a successful `lapi status` with the freshly written credentials.

Fixes #4237
