### PR TITLE
fix(docker): allow spaces in ENROLL_INSTANCE_NAME

### DIFF
--- a/build/docker/docker_start.sh
+++ b/build/docker/docker_start.sh
@@ -424,18 +424,17 @@ fi
 
 # Enroll instance if enroll key is provided
 if isfalse "$DISABLE_LOCAL_API" && isfalse "$DISABLE_ONLINE_API" && [ "$ENROLL_KEY" != "" ]; then
-    enroll_args=""
+    enroll_args=()
     if [ "$ENROLL_INSTANCE_NAME" != "" ]; then
-        enroll_args="--name $ENROLL_INSTANCE_NAME"
+        enroll_args+=(--name "$ENROLL_INSTANCE_NAME")
     fi
     if [ "$ENROLL_TAGS" != "" ]; then
         # shellcheck disable=SC2086
         for tag in ${ENROLL_TAGS}; do
-            enroll_args="$enroll_args --tags $tag"
+            enroll_args+=(--tags "$tag")
         done
     fi
-    # shellcheck disable=SC2086
-    cscli console enroll $enroll_args "$ENROLL_KEY"
+    cscli console enroll "${enroll_args[@]}" "$ENROLL_KEY"
 fi
 
 # crowdsec sqlite database permissions


### PR DESCRIPTION
Setting `ENROLL_INSTANCE_NAME` to a value with spaces crashes the container on startup. The entrypoint builds the enroll flags as a string and expands them unquoted, so `ENROLL_INSTANCE_NAME="foo bar"` word-splits into two args and cscli fails:

```
Error: cscli console enroll: accepts 1 arg(s), received 2
```

Since the script runs under `set -e`, this aborts before crowdsec starts. Fixed by building the flags as an array so the name stays a single argument.

Fixes #4330