### PR TITLE
[bot-detection] Fix leak of background pre-warmer goroutine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/umahmood/haversine v0.0.0-20151105152445-808ab04add26
 	github.com/wasilibs/go-re2 v1.12.0
 	github.com/xhit/go-simple-mail/v2 v2.16.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/mod v0.38.0
 	golang.org/x/net v0.57.0

--- a/pkg/appsec/challenge/challenge.go
+++ b/pkg/appsec/challenge/challenge.go
@@ -107,6 +107,15 @@ type ChallengeRuntime struct {
 	r             wazero.Runtime
 	obfuscatorMod wazero.CompiledModule
 
+	// preWarmCancel stops the background dynamicModulePreWarmer. The pre-warmer
+	// runs under a context Close() can cancel rather than the constructor ctx,
+	// because on reload the process ctx outlives the runtime — without this the
+	// old goroutine would tick forever against a closed runtime. Nil for runtimes
+	// built without the pre-warmer (e.g. in tests). Close() cancels before
+	// closing the runtime, so a teardown-time obfuscation error is always paired
+	// with a cancelled ctx and the pre-warmer suppresses its warning.
+	preWarmCancel context.CancelFunc
+
 	// challengeCode is the build-time-obfuscated challenge crypto/glue code,
 	// decompressed once at startup from initial_bundle.js.gz and injected inline
 	// on every challenge page. Static for the life of the process (no runtime
@@ -433,10 +442,12 @@ func NewChallengeRuntime(ctx context.Context, opts ...Option) (*ChallengeRuntime
 	}
 
 	// The dynamic-module pre-warmer is always on — the per-epoch key must be
-	// re-obfuscated on every rotation (bounded cost, one pass per variant). The
-	// challenge code itself is static (build-time obfuscated), so there is no
-	// library refresher anymore.
-	go challengeRuntime.dynamicModulePreWarmer(ctx)
+	// re-obfuscated on every rotation (bounded cost, one pass per variant). It
+	// runs under a context owned by Close() rather than the constructor ctx, so
+	// a reload (which reuses the process ctx) can stop it — see Close().
+	runCtx, cancel := context.WithCancel(ctx)
+	challengeRuntime.preWarmCancel = cancel
+	go challengeRuntime.dynamicModulePreWarmer(runCtx)
 
 	logger.WithFields(log.Fields{
 		"rotation_interval": rotationInterval,
@@ -453,6 +464,15 @@ func (c *ChallengeRuntime) Close(ctx context.Context) error {
 	if c == nil || c.r == nil {
 		return nil
 	}
+
+	// Stop the pre-warmer before closing the runtime. Cancel is synchronous, so
+	// once it returns the pre-warmer's ctx is cancelled; if closing the runtime
+	// then trips an in-flight obfuscation, the pre-warmer sees the cancelled ctx
+	// and suppresses the otherwise-spurious "runtime closed" warning.
+	if c.preWarmCancel != nil {
+		c.preWarmCancel()
+	}
+
 	return c.r.Close(ctx)
 }
 

--- a/pkg/appsec/challenge/challenge.go
+++ b/pkg/appsec/challenge/challenge.go
@@ -113,7 +113,7 @@ type ChallengeRuntime struct {
 	// old goroutine would tick forever against a closed runtime. Nil for runtimes
 	// built without the pre-warmer (e.g. in tests). Close() cancels before
 	// closing the runtime, so a teardown-time obfuscation error is always paired
-	// with a cancelled ctx and the pre-warmer suppresses its warning.
+	// with a canceled ctx and the pre-warmer suppresses its warning.
 	preWarmCancel context.CancelFunc
 
 	// challengeCode is the build-time-obfuscated challenge crypto/glue code,
@@ -466,8 +466,8 @@ func (c *ChallengeRuntime) Close(ctx context.Context) error {
 	}
 
 	// Stop the pre-warmer before closing the runtime. Cancel is synchronous, so
-	// once it returns the pre-warmer's ctx is cancelled; if closing the runtime
-	// then trips an in-flight obfuscation, the pre-warmer sees the cancelled ctx
+	// once it returns the pre-warmer's ctx is canceled; if closing the runtime
+	// then trips an in-flight obfuscation, the pre-warmer sees the canceled ctx
 	// and suppresses the otherwise-spurious "runtime closed" warning.
 	if c.preWarmCancel != nil {
 		c.preWarmCancel()

--- a/pkg/appsec/challenge/close_test.go
+++ b/pkg/appsec/challenge/close_test.go
@@ -1,0 +1,37 @@
+package challenge
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// TestClose_StopsPreWarmer is the regression guard for the pre-warmer goroutine
+// leak: before the fix, Close() closed the wazero runtime but left
+// dynamicModulePreWarmer ticking against it forever (logging
+// "runtime closed with exit_code(0)" once per epoch, per leaked goroutine, and
+// growing on every reload). goleak asserts the goroutine is gone after Close().
+func TestClose_StopsPreWarmer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("constructor pays the initial dynamic-module obfuscation cost (~seconds); skipped in -short")
+	}
+
+	rt, err := NewChallengeRuntime(t.Context(),
+		WithMasterSecret([]byte("0123456789abcdef0123456789abcdef")),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, rt.preWarmCancel, "constructor must wire the pre-warmer cancel func")
+
+	// Let the pre-warmer goroutine reach its select before we stop it.
+	time.Sleep(100 * time.Millisecond)
+
+	start := time.Now()
+	require.NoError(t, rt.Close(t.Context()))
+	require.Less(t, time.Since(start), time.Second,
+		"Close() cancels the pre-warmer and returns without waiting on it")
+
+	// No lingering pre-warmer (or wazero runtime) goroutines after Close().
+	goleak.VerifyNone(t)
+}

--- a/pkg/appsec/challenge/dynamic_module.go
+++ b/pkg/appsec/challenge/dynamic_module.go
@@ -89,6 +89,12 @@ func (c *ChallengeRuntime) dynamicModulePreWarmer(ctx context.Context) {
 			}).Debug("pre-warming dynamic key module for upcoming epoch")
 
 			if _, err := c.dynamicModuleForEpoch(ctx, nextEpoch); err != nil {
+				// On shutdown Close() cancels us then closes the runtime; the
+				// resulting instantiation error isn't a real pre-warm failure,
+				// so don't log it — just exit.
+				if ctx.Err() != nil {
+					return
+				}
 				c.log().WithError(err).WithField("epoch", nextEpoch).
 					Warn("pre-warm of next epoch failed; first request after rotation will pay obfuscation cost")
 			}


### PR DESCRIPTION
reloads lead to a leak of `dynamicModulePreWarmer` (wasm runtime was shutdown, but not the associated go routine). Leads to increasing spam of this error in logs:

```
pre-warm of next epoch failed; first request after rotation will pay obfuscation cost
```