### PR TITLE
challenge: require SSE4.1 + WX memory

### DIFF
--- a/pkg/appsec/challenge/challenge.go
+++ b/pkg/appsec/challenge/challenge.go
@@ -324,6 +324,29 @@ func compileObfuscatorModule(ctx context.Context, r wazero.Runtime) (wazero.Comp
 	return compiledMod, nil
 }
 
+func newWazeroRuntime(ctx context.Context) (wazero.Runtime, error) {
+	var r wazero.Runtime
+	var err error
+
+	func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				err = fmt.Errorf("failed to create wasm runtime in compiler mode: %v", rec)
+			}
+		}()
+
+		// We require wazero to run in compiler mode otherwise the JS compilation takes forever
+		// Compiler mode requires SSE4.1 + executable memory
+		r = wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigCompiler())
+	}()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
 func NewChallengeRuntime(ctx context.Context, opts ...Option) (*ChallengeRuntime, error) {
 	resolvedOpts := runtimeOptions{}
 	for _, opt := range opts {
@@ -380,7 +403,10 @@ func NewChallengeRuntime(ctx context.Context, opts ...Option) (*ChallengeRuntime
 		spentSetMaxEntries = spentSetDefaultMaxEntries
 	}
 
-	r := wazero.NewRuntime(ctx)
+	r, err := newWazeroRuntime(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	// No need to keep the closer around, we can just close the runtime itself when stopping
 	if _, err := wasi_snapshot_preview1.Instantiate(ctx, r); err != nil {

--- a/pkg/appsec/challenge/challenge.go
+++ b/pkg/appsec/challenge/challenge.go
@@ -329,7 +329,7 @@ func compileObfuscatorModule(ctx context.Context, r wazero.Runtime) (wazero.Comp
 // compilerSupported mimics the check performed by wazero for SSE4.1
 // We cannot rely in wazero on the wazero check, as it is used to choose whether to use the compiler or interpreter mode
 // If we force the compiler mode, and it's not supported, we will crash with SIGILL on the 1st instruction.
-// Compiler mode is required as interpreter mode is way too slow for the obfuscation (measured at at least 60 times slower)
+// Compiler mode is required as interpreter mode is way too slow for the obfuscation (measured as being at least 60 times slower)
 func compilerSupported() error {
 	switch runtime.GOARCH {
 	case "arm64":

--- a/pkg/appsec/challenge/challenge.go
+++ b/pkg/appsec/challenge/challenge.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -40,6 +41,7 @@ import (
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	"golang.org/x/sync/singleflight"
+	"golang.org/x/sys/cpu"
 )
 
 // Internal URL paths the challenge runtime intercepts. Bouncers MUST forward
@@ -324,19 +326,43 @@ func compileObfuscatorModule(ctx context.Context, r wazero.Runtime) (wazero.Comp
 	return compiledMod, nil
 }
 
+// compilerSupported mimics the check performed by wazero for SSE4.1
+// We cannot rely in wazero on the wazero check, as it is used to choose whether to use the compiler or interpreter mode
+// If we force the compiler mode, and it's not supported, we will crash with SIGILL on the 1st instruction.
+// Compiler mode is required as interpreter mode is way too slow for the obfuscation (measured at at least 60 times slower)
+func compilerSupported() error {
+	switch runtime.GOARCH {
+	case "arm64":
+		return nil
+	case "amd64":
+		if !cpu.X86.HasSSE41 {
+			return errors.New("CPU lacks SSE4.1")
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("GOARCH %s has no wasm compiler backend", runtime.GOARCH)
+	}
+}
+
 func newWazeroRuntime(ctx context.Context) (wazero.Runtime, error) {
+	if err := compilerSupported(); err != nil {
+		return nil, fmt.Errorf("wasm compiler mode unavailable: %w", err)
+	}
+
 	var r wazero.Runtime
 	var err error
 
 	func() {
+		// wazero checks for executable memory, and panics if it cannot allocat it.
+		// Catch the panic and return an error instead, so we can provide a more helpful message to the user.
 		defer func() {
 			if rec := recover(); rec != nil {
-				err = fmt.Errorf("failed to create wasm runtime in compiler mode: %v", rec)
+				err = fmt.Errorf("failed to create wasm runtime in compiler mode: %v "+
+					"(the kernel likely denied an executable memory mapping: check W^X hardening, seccomp or SELinux policy)", rec)
 			}
 		}()
 
-		// We require wazero to run in compiler mode otherwise the JS compilation takes forever
-		// Compiler mode requires SSE4.1 + executable memory
 		r = wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigCompiler())
 	}()
 


### PR DESCRIPTION
When using the challenge mode, crowdsec runs a JS obfuscator withing a WASM VM.

Wazero (the WASM runtime) requires both SSE4.1 + WX memory, otherwise it falls back to an interpreted mode, which is way too slow to be used for obfuscation.