### PR TITLE
waf challenge: add threshold support

### DIFF
--- a/pkg/acquisition/modules/appsec/appsec_hooks_test.go
+++ b/pkg/acquisition/modules/appsec/appsec_hooks_test.go
@@ -1563,6 +1563,41 @@ func TestAppsecOnChallengeHooks(t *testing.T) {
 			},
 		},
 		{
+			// The score accumulator is per-request state, which on_load
+			// predates entirely.
+			name:             "on_load AddRequestScore() fails to load",
+			expected_load_ok: false,
+			on_load: []appsec.Hook{
+				{Apply: []string{`AddRequestScore(15, "utc_timezone")`}},
+			},
+			input_request: appsec.ParsedRequest{
+				RemoteAddr:  "1.2.3.4",
+				Method:      "GET",
+				URI:         "/protected",
+				HTTPRequest: &http.Request{Host: "example.com"},
+			},
+		},
+		{
+			name:             "pre_eval score accumulates across hooks",
+			expected_load_ok: true,
+			pre_eval: []appsec.Hook{
+				{Filter: "true", Apply: []string{`AddRequestScore(30, "no_user_agent")`}},
+				{Filter: "true", Apply: []string{`AddRequestScore(20, "suspicious_path")`}},
+				{Filter: "RequestScore() >= 45", Apply: []string{`DropRequest("request score " + string(RequestScore()))`}},
+			},
+			input_request: appsec.ParsedRequest{
+				RemoteAddr:  "1.2.3.4",
+				Method:      "GET",
+				URI:         "/protected",
+				HTTPRequest: &http.Request{Host: "example.com"},
+			},
+			output_asserts: func(events []pipeline.Event, responses []appsec.AppsecTempResponse, appsecResponse appsec.BodyResponse, statusCode int) {
+				require.Len(t, responses, 1)
+				require.Equal(t, appsec.BanRemediation, responses[0].Action,
+					"50 points across two hooks must cross the 45 bar")
+			},
+		},
+		{
 			// SendChallenge in an out-of-band post_eval hook is rejected at runtime
 			name:             "outofband post_eval SendChallenge() is rejected",
 			expected_load_ok: true,

--- a/pkg/appsec/appsec.go
+++ b/pkg/appsec/appsec.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -265,6 +266,9 @@ type AppsecRequestState struct {
 	// rule expression don't redo the work (or re-emit observability).
 	// nil until the first call.
 	LastMismatchReport *challenge.MismatchReport
+
+	// Tracks the request score + reasons
+	RequestScore RequestScore
 
 	// HookVars is a per-request scratch space exposed to expr hooks as
 	// `hook_vars`. Helpers (e.g. ValidateRequestWithSchema) publish string
@@ -1030,9 +1034,8 @@ func (wc *AppsecConfig) Build(ctx context.Context, hub *cwhub.Hub) (*AppsecRunti
 // state, when non-nil, is consulted between rule iterations: if
 // state.HooksHalted is true (set by a terminal expr helper such as
 // RejectSubmission or the on_challenge_submit GrantChallengeCookie),
-// remaining rules in this phase are skipped. ProcessOnLoadRules and
-// the non-submit phases pass nil — they have no terminal actions
-// today.
+// remaining rules in this phase are skipped. ProcessOnLoadRules passes
+// nil — it has no request state at all.
 func (w *AppsecRuntimeConfig) processHooks(hooks []Hook, env map[string]interface{}, hookType string, state *AppsecRequestState) error {
 	has_match := false
 
@@ -1180,9 +1183,11 @@ func (w *AppsecRuntimeConfig) ProcessOnChallengeRules(ctx context.Context, state
 			// itself (with the operator-chosen verbosity), so we don't
 			// re-log here — just serve the rejection envelope.
 			w.emitChallengeEvent(request, ChallengeEventInfo{
-				Reason:      ChallengeReasonRejected,
-				FailReason:  state.SubmissionRejection.Reason,
-				Fingerprint: &fpData,
+				Reason:       ChallengeReasonRejected,
+				FailReason:   state.SubmissionRejection.Reason,
+				Fingerprint:  &fpData,
+				Score:        state.RequestScore.Total(),
+				ScoreReasons: state.RequestScore.Reasons(),
 			})
 			return w.setChallengeResponse(state, http.StatusOK, bodyChallengeRejected,
 				map[string]string{"Content-Type": "application/json", "Cache-Control": "no-cache, no-store"}, nil)
@@ -1239,7 +1244,7 @@ func (w *AppsecRuntimeConfig) ProcessOnChallengeRules(ctx context.Context, state
 		return nil
 	}
 
-	return w.processHooks(w.CompiledOnChallenge, GetOnChallengeEnv(ctx, w, state, request), "on_challenge", nil)
+	return w.processHooks(w.CompiledOnChallenge, GetOnChallengeEnv(ctx, w, state, request), "on_challenge", state)
 }
 
 func (w *AppsecRuntimeConfig) ProcessPreEvalRules(ctx context.Context, state *AppsecRequestState, request *ParsedRequest) error {
@@ -1523,6 +1528,32 @@ func (w *AppsecRuntimeConfig) EvaluateMismatches(state *AppsecRequestState, requ
 	return report
 }
 
+const (
+	hookVarRequestScore        = "request_score"
+	hookVarRequestScoreReasons = "request_score_reasons"
+	hookVarRequestScoreDetail  = "request_score_detail"
+)
+
+func (w *AppsecRuntimeConfig) AddRequestScore(state *AppsecRequestState, points int, reason string) error {
+	total := state.RequestScore.Add(points, reason)
+
+	if state.HookVars != nil {
+		state.HookVars[hookVarRequestScore] = strconv.Itoa(total)
+		state.HookVars[hookVarRequestScoreReasons] = strings.Join(state.RequestScore.Reasons(), ",")
+		state.HookVars[hookVarRequestScoreDetail] = state.RequestScore.String()
+	}
+
+	if w.Logger != nil {
+		w.Logger.WithFields(log.Fields{
+			"reason": reason,
+			"points": points,
+			"total":  total,
+		}).Debug("request score updated")
+	}
+
+	return nil
+}
+
 // emitMismatchObservability logs the report at Debug level and bumps the
 // per-reason/severity Prometheus counter. Called exactly once per request
 // from EvaluateMismatches (guarded by state.LastMismatchReport being nil
@@ -1606,9 +1637,11 @@ func (w *AppsecRuntimeConfig) SendChallenge(ctx context.Context, state *AppsecRe
 	}
 
 	w.emitChallengeEvent(request, ChallengeEventInfo{
-		Reason:      ChallengeReasonRequested,
-		Difficulty:  target,
-		Fingerprint: state.Fingerprint,
+		Reason:       ChallengeReasonRequested,
+		Difficulty:   target,
+		Fingerprint:  state.Fingerprint,
+		Score:        state.RequestScore.Total(),
+		ScoreReasons: state.RequestScore.Reasons(),
 	})
 
 	return nil

--- a/pkg/appsec/appsec_score_hooks_test.go
+++ b/pkg/appsec/appsec_score_hooks_test.go
@@ -1,0 +1,191 @@
+package appsec
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/crowdsecurity/crowdsec/pkg/appsec/challenge"
+)
+
+// End-to-end coverage of the threshold model the shipped
+// appsec-bot-challenge-scoring configs implement: several hooks each credit a
+// weight, a later hook acts only once the total crosses a bar.
+//
+// The decision lives in on_challenge_submit because that is the gate — a
+// visitor must pass it to be issued a cookie, and the fingerprint measured
+// there is the one sealed into that cookie.
+
+// scoringSignalHooks mirrors the weights config: one hook per signal, keyed on
+// the aggregate mismatch report, never on the running score.
+func scoringSignalHooks() []Hook {
+	return []Hook{
+		{
+			Filter: `EvaluateMismatches().Has("cdp")`,
+			Apply:  []string{`AddRequestScore(100, "cdp")`},
+		},
+		{
+			Filter: `EvaluateMismatches().Has("timezone_country")`,
+			Apply:  []string{`AddRequestScore(5, "timezone_country")`},
+		},
+	}
+}
+
+// scoringPolicyHook mirrors a threshold config: refuse the submission, and with
+// it the cookie, once the score crosses the bar.
+func scoringPolicyHook() Hook {
+	return Hook{
+		Filter: `RequestScore() >= 75`,
+		Apply:  []string{`RejectSubmission("request score " + string(RequestScore()) + ": " + join(RequestScoreReasons(), ","), "verbose")`},
+	}
+}
+
+// fpEuropeParisClean is fpEuropeParisCDP with no library signal fired, so a
+// US client IP leaves only the soft timezone_country mismatch.
+func fpEuropeParisClean(t *testing.T) *challenge.FingerprintData {
+	t.Helper()
+
+	raw := `{
+      "signals": {
+        "device": {"platform": "MacIntel"},
+        "browser": {
+          "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120",
+          "highEntropyValues": {"platform": "macOS"}
+        },
+        "locale": {
+          "internationalization": {"timezone": "Europe/Paris"},
+          "languages": {"language": "en"}
+        }
+      },
+      "fsid": "FS_CLEAN", "nonce": "n", "time": 1, "url": "http://x/",
+      "fastBotDetection": false,
+      "fastBotDetectionDetails": {}
+    }`
+
+	fp := &challenge.FingerprintData{}
+	require.NoError(t, json.Unmarshal([]byte(raw), fp))
+
+	return fp
+}
+
+// newScoringState builds the in-band request state the challenge dispatcher
+// hands to user hooks once it has a fingerprint to inspect.
+func newScoringState(t *testing.T, rt *AppsecRuntimeConfig, fp *challenge.FingerprintData) (*AppsecRequestState, *ParsedRequest) {
+	t.Helper()
+	setupGeoIP(t)
+
+	state := &AppsecRequestState{HookVars: map[string]string{}}
+	state.ResetResponse(rt.Config)
+	state.CurrentPhase = PhaseInBand // SendChallenge refuses to run out-of-band
+	state.Fingerprint = fp
+
+	req := newInBandRequest(http.MethodGet, "/", nil)
+	req.ClientIP = testIPUS // geoips to US, so a Europe/Paris tz mismatches
+	req.AppsecEngine = "test-engine"
+
+	return state, req
+}
+
+// runSubmitHooks drives a compiled on_challenge_submit list the way
+// ProcessOnChallengeRules does — state is passed so RejectSubmission can halt
+// the remaining rules.
+func runSubmitHooks(t *testing.T, rt *AppsecRuntimeConfig, hooks []Hook, fp *challenge.FingerprintData) *AppsecRequestState {
+	t.Helper()
+
+	compiled, err := buildHookList(t.Context(), hooks, hookOnChallengeSubmit, &appsecExprPatcher{})
+	require.NoError(t, err)
+
+	state, req := newScoringState(t, rt, fp)
+
+	require.NoError(t, rt.processHooks(
+		compiled,
+		GetOnChallengeSubmitEnv(rt, state, req),
+		"on_challenge_submit",
+		state,
+	))
+
+	return state
+}
+
+// Two signals sum past the bar → no cookie is issued. RejectSubmission is
+// terminal, so the trailing sentinel must not run; the accumulator doubles as
+// the probe for that.
+func TestOnChallengeSubmitScoreCrossesThreshold(t *testing.T) {
+	rt := newChallengeTestRuntime(t, nil)
+
+	hooks := append(scoringSignalHooks(),
+		scoringPolicyHook(),
+		Hook{Filter: `true`, Apply: []string{`AddRequestScore(1000, "sentinel")`}},
+	)
+
+	state := runSubmitHooks(t, rt, hooks, fpEuropeParisCDP(t))
+
+	assert.Equal(t, 105, state.RequestScore.Total())
+	assert.Equal(t, []string{"cdp", "timezone_country"}, state.RequestScore.Reasons())
+
+	require.NotNil(t, state.SubmissionRejection)
+	assert.Equal(t, "request score 105: cdp,timezone_country", state.SubmissionRejection.Reason)
+	assert.True(t, state.HooksHalted)
+	assert.NotContains(t, state.RequestScore.Reasons(), "sentinel", "sentinel hook must not have run")
+
+	assert.Equal(t, "105", state.HookVars[hookVarRequestScore])
+	assert.Equal(t, "cdp,timezone_country", state.HookVars[hookVarRequestScoreReasons])
+	assert.Equal(t, "cdp=100,timezone_country=5", state.HookVars[hookVarRequestScoreDetail])
+}
+
+// The motivating case: one weak signal on its own must not act. Same hooks,
+// same threshold — only the evidence differs.
+func TestOnChallengeSubmitSingleWeakSignalStaysBelowThreshold(t *testing.T) {
+	rt := newChallengeTestRuntime(t, nil)
+
+	hooks := append(scoringSignalHooks(), scoringPolicyHook())
+	state := runSubmitHooks(t, rt, hooks, fpEuropeParisClean(t))
+
+	assert.Equal(t, 5, state.RequestScore.Total())
+	assert.Equal(t, []string{"timezone_country"}, state.RequestScore.Reasons())
+
+	assert.Nil(t, state.SubmissionRejection, "a lone weak signal must still be issued a cookie")
+	assert.False(t, state.HooksHalted)
+	assert.Equal(t, "5", state.HookVars[hookVarRequestScore])
+}
+
+// Hooks are appended across configs and evaluated in order, so a policy config
+// listed ahead of the weights config reads an empty score and does nothing.
+func TestOnChallengeSubmitPolicyBeforeSignalsDoesNotFire(t *testing.T) {
+	rt := newChallengeTestRuntime(t, nil)
+
+	hooks := append([]Hook{scoringPolicyHook()}, scoringSignalHooks()...)
+	state := runSubmitHooks(t, rt, hooks, fpEuropeParisCDP(t))
+
+	assert.Equal(t, 105, state.RequestScore.Total(), "signals still score, just too late")
+	assert.Nil(t, state.SubmissionRejection, "policy hook saw an empty score")
+}
+
+// The accumulator is exposed in every request phase, not just the submit gate.
+// on_challenge is the one that also has SendChallenge, so a custom config can
+// escalate PoW difficulty from a score built there.
+func TestOnChallengeScoreCanEscalateDifficulty(t *testing.T) {
+	hooks := append(scoringSignalHooks(), Hook{
+		Filter: `RequestScore() >= 75`,
+		Apply:  []string{`SetChallengeDifficulty("high")`, `SendChallenge()`},
+	})
+
+	rt := newChallengeTestRuntime(t, hooks)
+	state, req := newScoringState(t, rt, fpEuropeParisCDP(t))
+
+	require.NoError(t, rt.processHooks(
+		rt.CompiledOnChallenge,
+		GetOnChallengeEnv(t.Context(), rt, state, req),
+		"on_challenge",
+		state,
+	))
+
+	assert.Equal(t, 105, state.RequestScore.Total())
+	assert.True(t, state.RequireChallenge)
+	assert.Equal(t, ChallengeRemediation, state.Response.Action)
+	require.NotNil(t, state.ChallengeDifficulty)
+	assert.Equal(t, challenge.PowDifficultyHigh, *state.ChallengeDifficulty)
+}

--- a/pkg/appsec/challenge/DESIGN.md
+++ b/pkg/appsec/challenge/DESIGN.md
@@ -365,16 +365,64 @@ Six hook stages, two of which are challenge-specific:
 | Hook | When | Env | Notable helpers |
 |---|---|---|---|
 | `on_load` | Engine startup, once | runtime config | `SetChallengeDifficulty` (sets runtime default) |
-| `pre_eval` | Before WAF | request + state | `SendChallenge`, `GrantChallengeCookie(reason, ttl?)`, `SetChallengeDifficulty` (per-req) |
+| `pre_eval` | Before WAF | request + state | `SendChallenge`, `GrantChallengeCookie(reason, ttl?)`, `SetChallengeDifficulty` (per-req), `AddRequestScore`/`RequestScore` |
 | `post_eval` | After WAF | request + state | same as `pre_eval` |
 | `on_match` | Per-rule match | event + state | `SetRemediation`, `SetReturnCode` |
-| `on_challenge` | Valid cookie/submission, fingerprint available | fingerprint + state | `SendChallenge`, `SetChallengeDifficulty`, `EvaluateMismatches`, `fingerprint.*` |
-| `on_challenge_submit` | POST `/submit` after crypto validation | fingerprint + state | `RejectSubmission`, `GrantChallengeCookie(reason, ttl?)` (inline), `EvaluateMismatches` |
+| `on_challenge` | Valid cookie/submission, fingerprint available | fingerprint + state | `SendChallenge`, `SetChallengeDifficulty`, `EvaluateMismatches`, `fingerprint.*`, `AddRequestScore`/`RequestScore` |
+| `on_challenge_submit` | POST `/submit` after crypto validation | fingerprint + state | `RejectSubmission`, `GrantChallengeCookie(reason, ttl?)` (inline), `EvaluateMismatches`, `AddRequestScore`/`RequestScore` |
 
 `on_challenge` is skipped if `state.Fingerprint` is nil (no valid cookie or
 submission). `on_challenge_submit` is deliberately narrow: only helpers that
 preserve the challenge-submit JSON envelope shape are exposed — a 307 redirect
 from this phase would break the client JS state machine.
+
+### 1.7b Request score accumulator
+
+`AppsecRequestState.RequestScore` ([`pkg/appsec/score.go`](../score.go)) lets rules
+express a **threshold** policy instead of a boolean one: each signal credits a
+weight and a later rule acts only once the total crosses a bar. This is what makes
+a soft signal usable — a literal `UTC` browser timezone is worth a few points, never
+a block on its own.
+
+Four helpers, registered by `addRequestScoreHelpers` in
+[`waf_helpers.go`](../waf_helpers.go) into **every request phase** (`pre_eval`,
+`post_eval`, `on_match`, `on_challenge`, `on_challenge_submit`). `on_load` is
+deliberately excluded — there is no request state yet, so scoring there is a
+config-load error rather than a silent no-op.
+
+| Helper | Semantics |
+|---|---|
+| `AddRequestScore(points, reason)` | Credits `points` to `reason`. Repeats on the same reason **sum**, so CRS-style per-matched-rule scoring works. `points` may be negative (trust credit) or zero (observe-only: registers the reason without moving the total). Blank reasons normalize to `"unspecified"` |
+| `RequestScore()` | Running total; 0 before anything scored |
+| `RequestScoreReasons()` | Distinct reasons, first-seen order (stable output) |
+| `RequestScoreFor(reason)` | Running total for one reason |
+
+The accumulator is domain-neutral on purpose: bot-detection weights and CRS anomaly
+scores are the same mechanism, and the name should not tie it to the first use.
+
+**Not cleared by `ResetResponse`**, joining `HookVars`, `LastMismatchReport` and
+`ChallengeExempt` in the deliberately-preserved set. `ResetResponse`'s contract is
+response fields, and `ClearResponse` is exported — a mid-request caller must not be
+able to wipe an accumulated verdict.
+
+**Observability.** Each call publishes `request_score`, `request_score_reasons` and
+`request_score_detail` into `hook_vars`, and logs one Debug line (a twenty-signal
+config would otherwise emit twenty Info lines per request). Because `copyHookVars`
+only fires on a WAF interrupt — and a challenge issued purely because a score crossed
+a threshold matches no rule — the score is *also* carried on `ChallengeEventInfo`
+(§1.6 of the hub docs): `SendChallenge` and the rejected-submission path stamp
+`evt.Parsed["request_score"]` / `["request_score_reasons"]`.
+
+**Ordering facts for rule authors** (documentation-level; nothing guards them):
+
+1. `on_challenge` runs **before** `pre_eval`, so a score built in `pre_eval` cannot
+   influence an `on_challenge` decision in the same request.
+2. Top-level (non band-scoped) `pre_eval:` / `post_eval:` / `on_match:` hooks run
+   once per band against the same state, so an unconditional adder there scores
+   twice. Scope the hook under `inband:` / `outofband:` to avoid it.
+
+See §3.3 for the config-composition rule that keeps a weights/thresholds split
+order-independent.
 
 ### 1.8 Fingerprint mismatch report
 
@@ -787,6 +835,10 @@ mismatch` line, with their own `reasons` field. Correlate on `fsid` /
 | `fingerprint.UAMobileMismatch()` | wherever `fingerprint` is non-nil | Atomic check, no aggregation |
 | `fingerprint.AcceptLanguageMismatch(req)` | same | Atomic check |
 | `fingerprint.TimezoneCountryMismatch(country)` | same | Atomic check |
+| `AddRequestScore(points, reason)` | every request phase | Credits weighted evidence; repeats on a reason sum. See §1.11 |
+| `RequestScore()` | same | Running total, 0 before anything scored |
+| `RequestScoreReasons()` | same | Distinct reasons, first-seen order |
+| `RequestScoreFor(reason)` | same | Running total for one reason |
 
 #### `MismatchReport` API
 
@@ -826,6 +878,30 @@ challenge:
 Other top-level YAML keys follow the existing appsec-config patterns: rules
 and hooks are *appended* across configs; scalars like `default_remediation`,
 HTTP codes, and challenge fields are *overridden*.
+
+#### Hook ordering across configs
+
+Hooks are *appended*, in the order the configs are listed, so a config whose rule
+depends on what an earlier config did is order-sensitive. The hub's
+`appsec-bot-challenge-scoring` split is the worked example: the weights
+(`AddRequestScore`) must run before the thresholds (`RequestScore() >= N`), or the
+threshold sees an empty score and silently never fires.
+
+Two things to know when designing such a split:
+
+- A glob (`appsec_configs: [crowdsecurity/appsec-bot-*]`) expands to a
+  **case-insensitively sorted** list of item names
+  (`config.go` → `cwhub.GetItemsByType`), so it is the *names* that decide the
+  order, not the operator. Item names carry no `.yaml` suffix — which is what makes
+  `…-scoring` sort ahead of `…-scoring-balanced` (prefix rule). Had the sort been on
+  filenames it would invert, since `-` (0x2D) precedes `.` (0x2E).
+- Within one config, `Build` concatenates the top-level hook list before the
+  `inband:` one (`onChallengeHooks := wc.OnChallenge` then
+  `append(…, wc.InBand.OnChallenge...)`), and `LoadByPath` accumulates the two
+  across configs separately. Splitting a producer into top-level and a consumer
+  into `inband:` therefore makes the pair order-*independent* — at the cost of a
+  config shaped unlike every other one in the collection, which is why the hub
+  configs don't do it and rely on naming instead.
 
 ### 3.4 Single-instance vs distributed deployment
 
@@ -870,6 +946,35 @@ the keyring tolerates one rotation interval of clock skew, no more.
   `SetChallengeDifficulty("high")` for suspect fingerprints. Reserve
   `"impossible"` for known-bad: solving it server-side is rejected, so it
   acts as a soft block via the challenge flow rather than a hard `ban`.
+- **Threshold mode** (§1.7b): when no single signal is decisive, weight them
+  and act on the total. Scale the weights so 100 means "conclusive on its own",
+  then pick a bar:
+
+  ```yaml
+  inband:
+    on_challenge_submit:
+      - filter: EvaluateMismatches().Has("utc_timezone")
+        apply: [ 'AddRequestScore(15, "utc_timezone")' ]
+      - filter: EvaluateMismatches().Has("cdp")
+        apply: [ 'AddRequestScore(100, "cdp")' ]
+      - filter: RequestScore() >= 75
+        apply: [ 'RejectSubmission("score " + string(RequestScore()), "verbose")' ]
+  ```
+
+  **Score at the submit gate, not on every request.** `on_challenge_submit` is
+  the only path to a cookie, and the fingerprint it measures is the one sealed
+  into that cookie — so a threshold tested there decides the visitor's fate
+  once. Re-scoring from `on_challenge` re-derives the same verdict from
+  immutable data on every subsequent request; reach for it only when the action
+  needs a helper the submit env deliberately withholds (`SetChallengeDifficulty`,
+  `SetRemediation`, `SendChallenge`), e.g. to escalate PoW difficulty for a
+  grey-zone visitor rather than refuse them. Note that the submit POST
+  short-circuits before pre_eval / WAF / post_eval
+  (`appsec_runner.go`: `if state.RequireChallenge { return }`), so those phases
+  never see it at all.
+
+  The hub ships this as `crowdsecurity/appsec-bot-challenge-scoring` plus a
+  `-permissive` / `-balanced` / `-strict` threshold config.
 
 ### 3.6 Operational notes
 

--- a/pkg/appsec/event.go
+++ b/pkg/appsec/event.go
@@ -2,6 +2,7 @@ package appsec
 
 import (
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/appsec/challenge"
@@ -73,6 +74,9 @@ type ChallengeEventInfo struct {
 	FailErr     error                      // set on failed; carries the sentinel-wrapped error so metrics can classify via errors.Is.
 	Difficulty  int                        // target PoW difficulty for this moment
 	Fingerprint *challenge.FingerprintData // nil when none available (e.g. requested w/o cookie)
+
+	Score        int
+	ScoreReasons []string
 }
 
 // ChallengeEventFromRequest builds a LOG event for a challenge lifecycle moment.
@@ -89,6 +93,13 @@ func ChallengeEventFromRequest(r *ParsedRequest, labels map[string]string, txUui
 	evt.Parsed["challenge_difficulty"] = strconv.Itoa(info.Difficulty)
 	if info.FailReason != "" {
 		evt.Parsed["challenge_fail_reason"] = info.FailReason
+	}
+
+	// Because scores can be either positive or negative, it's possible to end up with a zero total even with multiple rule matches
+	// Check the length of the reasons slice to determine if any contributions were made
+	if len(info.ScoreReasons) > 0 {
+		evt.Parsed["request_score"] = strconv.Itoa(info.Score)
+		evt.Parsed["request_score_reasons"] = strings.Join(info.ScoreReasons, ",")
 	}
 
 	if fp := info.Fingerprint; fp != nil {

--- a/pkg/appsec/event_test.go
+++ b/pkg/appsec/event_test.go
@@ -48,6 +48,34 @@ func TestChallengeEventFromRequest(t *testing.T) {
 				require.Equal(t, ModuleName, evt.Line.Module)
 				// no fingerprint → no fingerprint fields
 				require.NotContains(t, evt.Parsed, "fsid")
+				// nothing scored → no score fields
+				require.NotContains(t, evt.Parsed, "request_score")
+				require.NotContains(t, evt.Parsed, "request_score_reasons")
+			},
+		},
+		{
+			name: "score rides along when contributions fired",
+			info: ChallengeEventInfo{
+				Reason:       ChallengeReasonRequested,
+				Difficulty:   15,
+				Score:        105,
+				ScoreReasons: []string{"cdp", "timezone_country"},
+			},
+			assert: func(t *testing.T, evt pipeline.Event) {
+				require.Equal(t, "105", evt.Parsed["request_score"])
+				require.Equal(t, "cdp,timezone_country", evt.Parsed["request_score_reasons"])
+			},
+		},
+		{
+			name: "a zero total with contributions is still reported",
+			info: ChallengeEventInfo{
+				Reason:       ChallengeReasonRequested,
+				Score:        0,
+				ScoreReasons: []string{"utc_timezone", "trusted_gpu"},
+			},
+			assert: func(t *testing.T, evt pipeline.Event) {
+				require.Equal(t, "0", evt.Parsed["request_score"])
+				require.Equal(t, "utc_timezone,trusted_gpu", evt.Parsed["request_score_reasons"])
 			},
 		},
 		{

--- a/pkg/appsec/score.go
+++ b/pkg/appsec/score.go
@@ -1,0 +1,85 @@
+package appsec
+
+import (
+	"strconv"
+	"strings"
+)
+
+const unspecifiedScoreReason = "unspecified"
+
+type RequestScore struct {
+	total    int
+	order    []string
+	byReason map[string]int
+}
+
+func (s *RequestScore) Add(points int, reason string) int {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = unspecifiedScoreReason
+	}
+
+	if s.byReason == nil {
+		s.byReason = make(map[string]int)
+	}
+
+	if _, seen := s.byReason[reason]; !seen {
+		s.order = append(s.order, reason)
+	}
+
+	s.byReason[reason] += points
+	s.total += points
+
+	return s.total
+}
+
+func (s *RequestScore) Total() int {
+	if s == nil {
+		return 0
+	}
+
+	return s.total
+}
+
+func (s *RequestScore) For(reason string) int {
+	if s == nil {
+		return 0
+	}
+
+	return s.byReason[strings.TrimSpace(reason)]
+}
+
+func (s *RequestScore) Reasons() []string {
+	if s == nil || len(s.order) == 0 {
+		return nil
+	}
+
+	out := make([]string, len(s.order))
+	copy(out, s.order)
+
+	return out
+}
+
+func (s *RequestScore) Empty() bool {
+	return s == nil || len(s.order) == 0
+}
+
+func (s *RequestScore) String() string {
+	if s.Empty() {
+		return ""
+	}
+
+	var b strings.Builder
+
+	for i, reason := range s.order {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+
+		b.WriteString(reason)
+		b.WriteByte('=')
+		b.WriteString(strconv.Itoa(s.byReason[reason]))
+	}
+
+	return b.String()
+}

--- a/pkg/appsec/score_test.go
+++ b/pkg/appsec/score_test.go
@@ -1,0 +1,127 @@
+package appsec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestScoreZeroValue(t *testing.T) {
+	var s RequestScore
+
+	assert.Equal(t, 0, s.Total())
+	assert.Empty(t, s.Reasons())
+	assert.Empty(t, s.String())
+	assert.True(t, s.Empty())
+	assert.Equal(t, 0, s.For("never_fired"))
+}
+
+func TestRequestScoreAccumulates(t *testing.T) {
+	var s RequestScore
+
+	assert.Equal(t, 15, s.Add(15, "utc_timezone"))
+	assert.Equal(t, 115, s.Add(100, "cdp"))
+	assert.Equal(t, 120, s.Add(5, "timezone_country"))
+
+	assert.Equal(t, 120, s.Total())
+	// first-seen order, not insertion-sorted or map order
+	assert.Equal(t, []string{"utc_timezone", "cdp", "timezone_country"}, s.Reasons())
+	assert.Equal(t, "utc_timezone=15,cdp=100,timezone_country=5", s.String())
+}
+
+// A repeated reason sums rather than replacing: that is what CRS-style
+// "every matched rule adds its severity" needs. The reason keeps the
+// position it was first seen at, so output stays stable.
+func TestRequestScoreRepeatedReasonSums(t *testing.T) {
+	var s RequestScore
+
+	s.Add(5, "crs_sqli")
+	s.Add(15, "ua_mobile")
+	s.Add(10, "crs_sqli")
+
+	assert.Equal(t, 30, s.Total())
+	assert.Equal(t, 15, s.For("crs_sqli"))
+	assert.Equal(t, []string{"crs_sqli", "ua_mobile"}, s.Reasons())
+	assert.Equal(t, "crs_sqli=15,ua_mobile=15", s.String())
+}
+
+func TestRequestScoreNegativeAndZeroPoints(t *testing.T) {
+	var s RequestScore
+
+	s.Add(15, "utc_timezone")
+	s.Add(-20, "trusted_gpu")
+	assert.Equal(t, -5, s.Total(), "credits are not clamped at zero")
+
+	// A zero-point contribution is observe-only: it must not move the total
+	// but must still show up in the breakdown.
+	s.Add(0, "observed_only")
+	assert.Equal(t, -5, s.Total())
+	assert.Contains(t, s.Reasons(), "observed_only")
+	assert.Equal(t, 0, s.For("observed_only"))
+
+	// Signals fired but canceled out — still not Empty().
+	assert.False(t, s.Empty())
+}
+
+func TestRequestScoreBlankReasonNormalized(t *testing.T) {
+	var s RequestScore
+
+	s.Add(3, "")
+	s.Add(4, "   ")
+
+	assert.Equal(t, 7, s.Total())
+	assert.Equal(t, []string{unspecifiedScoreReason}, s.Reasons())
+	assert.Equal(t, 7, s.For(unspecifiedScoreReason))
+}
+
+func TestRequestScoreReasonsIsACopy(t *testing.T) {
+	var s RequestScore
+
+	s.Add(1, "a")
+
+	reasons := s.Reasons()
+	reasons[0] = "mutated"
+
+	assert.Equal(t, []string{"a"}, s.Reasons(), "callers must not be able to mutate internal state")
+}
+
+func TestAddRequestScoreMirrorsHookVars(t *testing.T) {
+	w := makeRuntime()
+	state := &AppsecRequestState{HookVars: map[string]string{}}
+
+	require.NoError(t, w.AddRequestScore(state, 100, "cdp"))
+	require.NoError(t, w.AddRequestScore(state, 15, "utc_timezone"))
+
+	assert.Equal(t, "115", state.HookVars[hookVarRequestScore])
+	assert.Equal(t, "cdp,utc_timezone", state.HookVars[hookVarRequestScoreReasons])
+	assert.Equal(t, "cdp=100,utc_timezone=15", state.HookVars[hookVarRequestScoreDetail])
+}
+
+// ResetResponse clears response fields only. The score is per-request
+// evaluation state (like HookVars, LastMismatchReport and ChallengeExempt)
+// and must survive it — ClearResponse is exported and callable mid-request.
+func TestResetResponseDoesNotClearRequestScore(t *testing.T) {
+	w := makeRuntime()
+	state := &AppsecRequestState{HookVars: map[string]string{}}
+
+	require.NoError(t, w.AddRequestScore(state, 45, "headless_screen_resolution"))
+
+	state.ResetResponse(&AppsecConfig{})
+
+	assert.Equal(t, 45, state.RequestScore.Total())
+	assert.Equal(t, []string{"headless_screen_resolution"}, state.RequestScore.Reasons())
+	assert.Equal(t, "45", state.HookVars[hookVarRequestScore])
+}
+
+func TestRequestScoreIsPerRequest(t *testing.T) {
+	w := makeRuntime()
+
+	first := &AppsecRequestState{HookVars: map[string]string{}}
+	require.NoError(t, w.AddRequestScore(first, 100, "cdp"))
+	assert.Equal(t, 100, first.RequestScore.Total())
+
+	fresh := &AppsecRequestState{}
+	assert.Equal(t, 0, fresh.RequestScore.Total())
+	assert.Empty(t, fresh.RequestScore.Reasons())
+}

--- a/pkg/appsec/waf_helpers.go
+++ b/pkg/appsec/waf_helpers.go
@@ -133,6 +133,12 @@ func GetPreEvalEnv(ctx context.Context, w *AppsecRuntimeConfig, state *AppsecReq
 		},
 		"DisableBodyInspection": func() error { return w.DisableBodyInspection(state) },
 		"ExemptFromChallenge":   func(reason string) error { return w.ExemptFromChallenge(state, request, reason) },
+		"AddRequestScore": func(points int, reason string) error {
+			return w.AddRequestScore(state, points, reason)
+		},
+		"RequestScore":        func() int { return state.RequestScore.Total() },
+		"RequestScoreReasons": func() []string { return state.RequestScore.Reasons() },
+		"RequestScoreFor":     func(reason string) int { return state.RequestScore.For(reason) },
 	}
 }
 
@@ -161,6 +167,12 @@ func GetPostEvalEnv(ctx context.Context, w *AppsecRuntimeConfig, state *AppsecRe
 		"fingerprint":         state.Fingerprint,
 		"hook_vars":           state.HookVars,
 		"ExemptFromChallenge": func(reason string) error { return w.ExemptFromChallenge(state, request, reason) },
+		"AddRequestScore": func(points int, reason string) error {
+			return w.AddRequestScore(state, points, reason)
+		},
+		"RequestScore":        func() int { return state.RequestScore.Total() },
+		"RequestScoreReasons": func() []string { return state.RequestScore.Reasons() },
+		"RequestScoreFor":     func(reason string) int { return state.RequestScore.For(reason) },
 	}
 }
 
@@ -198,6 +210,12 @@ func GetOnChallengeEnv(ctx context.Context, w *AppsecRuntimeConfig, state *Appse
 		"EvaluateMismatches": func() *challenge.MismatchReport {
 			return w.EvaluateMismatches(state, request)
 		},
+		"AddRequestScore": func(points int, reason string) error {
+			return w.AddRequestScore(state, points, reason)
+		},
+		"RequestScore":        func() int { return state.RequestScore.Total() },
+		"RequestScoreReasons": func() []string { return state.RequestScore.Reasons() },
+		"RequestScoreFor":     func(reason string) int { return state.RequestScore.For(reason) },
 	}
 }
 
@@ -274,6 +292,12 @@ func GetOnChallengeSubmitEnv(w *AppsecRuntimeConfig, state *AppsecRequestState, 
 		"DumpFingerprint": func(label string) string {
 			return DumpFingerprint(w.FingerprintDumpDir, label, state.Fingerprint, request)
 		},
+		"AddRequestScore": func(points int, reason string) error {
+			return w.AddRequestScore(state, points, reason)
+		},
+		"RequestScore":        func() int { return state.RequestScore.Total() },
+		"RequestScoreReasons": func() []string { return state.RequestScore.Reasons() },
+		"RequestScoreFor":     func(reason string) int { return state.RequestScore.For(reason) },
 	}
 }
 
@@ -295,5 +319,11 @@ func GetOnMatchEnv(w *AppsecRuntimeConfig, state *AppsecRequestState, request *P
 		"SetChallengeCookie":  func(cookie cookie.AppsecCookie) error { return w.SetChallengeCookie(state, cookie) },
 		"AppsecCookie":        cookie.NewAppsecCookie,
 		"ExemptFromChallenge": func(reason string) error { return w.ExemptFromChallenge(state, request, reason) },
+		"AddRequestScore": func(points int, reason string) error {
+			return w.AddRequestScore(state, points, reason)
+		},
+		"RequestScore":        func() int { return state.RequestScore.Total() },
+		"RequestScoreReasons": func() []string { return state.RequestScore.Reasons() },
+		"RequestScoreFor":     func(reason string) int { return state.RequestScore.For(reason) },
 	}
 }

--- a/pkg/appsec/waf_helpers_test.go
+++ b/pkg/appsec/waf_helpers_test.go
@@ -21,6 +21,60 @@ func TestBotChallengeHooksCompile(t *testing.T) {
 	}
 }
 
+// TestRequestScoreHooksCompile guards the score accumulator env entries: the
+// four helpers must compile in every request phase. The filter also exercises
+// the expr builtins the shipped threshold configs rely on to build a reject
+// reason (string() over an int, join() over a []string).
+func TestRequestScoreHooksCompile(t *testing.T) {
+	stages := []hookStage{hookPreEval, hookPostEval, hookOnMatch, hookOnChallenge, hookOnChallengeSubmit}
+	for _, stage := range stages {
+		h := &Hook{
+			Filter: `RequestScore() >= 45 && RequestScoreFor("cdp") > 0 && string(RequestScore()) != "" && join(RequestScoreReasons(), ",") != ""`,
+			Apply:  []string{`AddRequestScore(15, "utc_timezone")`},
+		}
+		require.NoError(t, h.Build(t.Context(), stage, &appsecExprPatcher{}), "stage %v", stage)
+	}
+}
+
+// on_load has no request state, so scoring there must fail at config load
+// rather than silently no-op.
+func TestRequestScoreHooksRejectedInOnLoad(t *testing.T) {
+	h := &Hook{Apply: []string{`AddRequestScore(15, "utc_timezone")`}}
+	require.Error(t, h.Build(t.Context(), hookOnLoad, &appsecExprPatcher{}))
+}
+
+// The accumulator is plain Go state: referencing it must not drag the
+// challenge runtime (WASM VM, obfuscator, keyring) into existence.
+func TestRequestScoreDoesNotNeedChallengeRuntime(t *testing.T) {
+	patcher := &appsecExprPatcher{}
+	h := &Hook{
+		Filter: `RequestScore() >= 45`,
+		Apply:  []string{`AddRequestScore(15, "utc_timezone")`},
+	}
+	require.NoError(t, h.Build(t.Context(), hookPreEval, patcher))
+	assert.False(t, patcher.NeedWASMVM)
+}
+
+func TestRequestScoreEnvClosuresBindState(t *testing.T) {
+	state := &AppsecRequestState{HookVars: map[string]string{}}
+	env := GetOnChallengeEnv(t.Context(), makeRuntime(), state, &ParsedRequest{})
+
+	add := env["AddRequestScore"].(func(int, string) error)
+	total := env["RequestScore"].(func() int)
+	reasons := env["RequestScoreReasons"].(func() []string)
+	forReason := env["RequestScoreFor"].(func(string) int)
+
+	assert.Equal(t, 0, total())
+
+	require.NoError(t, add(100, "cdp"))
+	require.NoError(t, add(15, "utc_timezone"))
+
+	assert.Equal(t, 115, total())
+	assert.Equal(t, []string{"cdp", "utc_timezone"}, reasons())
+	assert.Equal(t, 100, forReason("cdp"))
+	assert.Equal(t, 115, state.RequestScore.Total())
+}
+
 // TestExemptFromChallengeSetsFlag verifies ExemptFromChallenge(reason) flips the
 // per-request ChallengeExempt flag (which SendChallenge later honors), and that
 // the flag is per-request state.


### PR DESCRIPTION
Add new helpers to allow scoring of a request:
 - `AddRequestScore(points, reason)`: add points for the given reason. Can be negative (eg, because something in the request is trustworthy)
 - `RequestScore()`
 - `RequestScoreReasons()`
 - `RequestScoreFor(reason)`
 
This allows to write more granular appsec configs and to use weaker signals to make a decision whether an IP is coming from a bot or not (eg, `utc_timezone` is set. It's very unusual, but blocking based only on this would be too harsh):

```
inband:
  on_challenge_submit:
    - filter: EvaluateMismatches().Has("cdp")
      apply:
        - AddRequestScore(100, "cdp")
    - filter: EvaluateMismatches().Has("webdriver")
      apply:
        - AddRequestScore(100, "webdriver")
    - filter: EvaluateMismatches().Has("webdriver_writable")
      apply:
        - AddRequestScore(100, "webdriver_writable")
     - filter: EvaluateMismatches().Has("headless_screen_resolution")
      apply:
        - AddRequestScore(50, "headless_screen_resolution")
     - filter: EvaluateMismatches().Has("gpu_mismatch")
      apply:
        - AddRequestScore(30, "gpu_mismatch")
    - filter: EvaluateMismatches().Has("high_cpu_count")
      apply:
        - AddRequestScore(30, "high_cpu_count")
    - filter: RequestScore() >= 75
      apply:
        - 'RejectSubmission("request score " + string(RequestScore()) + ": " + join(RequestScoreReasons(), ","), "verbose")'
```
 
 While currently targeted towards the challenge mode, it can also be used to score any request:
 ```
  - filter: req.Header.Get("Accept-Language") == ""
      apply:
        - AddRequestScore(15, "no_accept_language")
```