### PR TITLE
docs: fix broken Vagrant include link in test README

### DIFF
--- a/test/ansible/README.md
+++ b/test/ansible/README.md
@@ -116,7 +116,7 @@ After this, you will find up to 30GB of base images in `/var/lib/libvirt/images`
 which you need to remove by hand when you have finished testing or leave them
 around for the next time.
 
-You can give more memory or CPU juice to the VMs by editing [Vagrantfile.common](vagrant/Vagrantfile.common).
+You can give more memory or CPU juice to the VMs by editing [Vagrantfile.common](vagrant/common).
 
 ## Test Matrix
 


### PR DESCRIPTION
`test/ansible/README.md` links the shared Vagrant include:

> ...by editing [Vagrantfile.common](vagrant/Vagrantfile.common).

`vagrant/Vagrantfile.common` does not exist (from `test/ansible/` that resolves to `test/ansible/vagrant/Vagrantfile.common`). The shared include is `test/ansible/vagrant/common`, so this repoints the link.
