### PR TITLE
acquisition: fix transformation being ignored

### DIFF
--- a/pkg/acquisition/acquisition.go
+++ b/pkg/acquisition/acquisition.go
@@ -650,7 +650,7 @@ func StartAcquisition(
 				})
 			}
 
-			if err := acquireSource(ctx, subsrc, subsrc.GetName(), output, acquisTomb); err != nil {
+			if err := acquireSource(ctx, subsrc, subsrc.GetName(), outChan, acquisTomb); err != nil {
 				// if one of the acquisitions returns an error, we kill the others to properly shutdown
 				acquisTomb.Kill(err)
 			}

--- a/pkg/acquisition/acquisition.go
+++ b/pkg/acquisition/acquisition.go
@@ -469,7 +469,12 @@ func transform(
 		case <-acquisTomb.Dying():
 			logger.Debugf("transformer is dying")
 			return
-		case evt := <-transformChan:
+		case evt, ok := <-transformChan:
+			if !ok {
+				logger.Debugf("transform channel is closed, transformer is exiting")
+				return
+			}
+
 			logger.Tracef("Received event %s", evt.Line.Raw)
 
 			out, err := expr.Run(transformRuntime, map[string]any{"evt": &evt})
@@ -631,12 +636,14 @@ func StartAcquisition(
 
 			outChan := output
 
+			var transformChan chan pipeline.Event
+
 			log.Debugf("datasource %s UUID: %s", subsrc.GetName(), subsrc.GetUuid())
 
 			if transformRuntime, ok := transformRuntimes[subsrc.GetUuid()]; ok {
 				log.Infof("transform expression found for datasource %s", subsrc.GetName())
 
-				transformChan := make(chan pipeline.Event)
+				transformChan = make(chan pipeline.Event)
 				outChan = transformChan
 				transformLogger := log.WithFields(log.Fields{
 					"component":  "transform",
@@ -645,12 +652,23 @@ func StartAcquisition(
 
 				acquisTomb.Go(func() error {
 					defer trace.ReportPanic()
-					transform(outChan, output, acquisTomb, transformRuntime, transformLogger)
+					transform(transformChan, output, acquisTomb, transformRuntime, transformLogger)
 					return nil
 				})
 			}
 
-			if err := acquireSource(ctx, subsrc, subsrc.GetName(), outChan, acquisTomb); err != nil {
+			err := acquireSource(ctx, subsrc, subsrc.GetName(), outChan, acquisTomb)
+
+			// In cat mode the datasource is done writing when acquireSource returns, so we
+			// close the transform channel to let the transformer drain and exit: the tomb
+			// can then die on its own, which is what signals the end of a cat run.
+			// In tail mode datasources may keep writing from goroutines they spawned, so
+			// closing here would panic; the transformer exits on Dying() instead.
+			if transformChan != nil && subsrc.GetMode() == configuration.CAT_MODE {
+				close(transformChan)
+			}
+
+			if err != nil {
 				// if one of the acquisitions returns an error, we kill the others to properly shutdown
 				acquisTomb.Kill(err)
 			}

--- a/pkg/acquisition/acquisition_test.go
+++ b/pkg/acquisition/acquisition_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/expr-lang/expr"
 	"github.com/goccy/go-yaml"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -22,6 +23,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/acquisition/types"
 	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
 	"github.com/crowdsecurity/crowdsec/pkg/cwhub"
+	"github.com/crowdsecurity/crowdsec/pkg/exprhelpers"
 	"github.com/crowdsecurity/crowdsec/pkg/metrics"
 	"github.com/crowdsecurity/crowdsec/pkg/pipeline"
 )
@@ -621,4 +623,103 @@ func TestStartAcquisition_MissingFetcher(t *testing.T) {
 	go func() { errCh <- StartAcquisition(ctx, []types.DataSource{&CatModeNoFetcher{}}, out, &tb) }()
 
 	require.ErrorContains(t, <-errCh, "cat_no_fetcher: cat mode is set but OneShotAcquisition is not supported")
+}
+
+// MockCatTransform emits a single event in cat mode, and reports a configurable
+// uuid so a transform expression can be attached to it.
+type MockCatTransform struct {
+	configuration.DataSourceCommonCfg `yaml:",inline"`
+	uuid                              string
+}
+
+func (*MockCatTransform) UnmarshalConfig(_ []byte) error { return nil }
+func (f *MockCatTransform) Configure(_ context.Context, _ []byte, _ *log.Entry, _ metrics.AcquisitionMetricsLevel) error {
+	f.Mode = configuration.CAT_MODE
+	return nil
+}
+func (*MockCatTransform) GetMode() string   { return configuration.CAT_MODE }
+func (*MockCatTransform) GetName() string   { return "mock_cat_transform" }
+func (f *MockCatTransform) GetUuid() string { return f.uuid }
+func (f *MockCatTransform) Dump() any       { return f }
+func (*MockCatTransform) CanRun() error     { return nil }
+
+func (*MockCatTransform) OneShotAcquisition(_ context.Context, out chan pipeline.Event, _ *tomb.Tomb) error {
+	evt := pipeline.Event{}
+	evt.Line.Src = "test"
+	evt.Line.Raw = "original"
+	out <- evt
+
+	return nil
+}
+
+// registerTransform compiles expr and attaches it to the given datasource uuid
+// for the duration of the test.
+func registerTransform(t *testing.T, uuid string, exprStr string) {
+	t.Helper()
+
+	prog, err := expr.Compile(exprStr, exprhelpers.GetExprOptions(map[string]any{"evt": &pipeline.Event{}})...)
+	require.NoError(t, err)
+
+	transformRuntimes[uuid] = prog
+
+	t.Cleanup(func() { delete(transformRuntimes, uuid) })
+}
+
+// TestStartAcquisitionTransform checks that events emitted by a datasource with
+// a transform expression actually go through the transformer.
+func TestStartAcquisitionTransform(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		expected []string
+	}{
+		{
+			name:     "string",
+			expr:     `evt.Line.Raw + "-transformed"`,
+			expected: []string{"original-transformed"},
+		},
+		{
+			name:     "slice",
+			expr:     `[evt.Line.Raw + "-1", evt.Line.Raw + "-2"]`,
+			expected: []string{"original-1", "original-2"},
+		},
+		{
+			name:     "invalid type, event is sent as-is",
+			expr:     `42`,
+			expected: []string{"original"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			uuid := "transform-" + tc.name
+
+			registerTransform(t, uuid, tc.expr)
+
+			sources := []types.DataSource{&MockCatTransform{uuid: uuid}}
+			out := make(chan pipeline.Event)
+			acquisTomb := tomb.Tomb{}
+
+			go func() {
+				_ = StartAcquisition(ctx, sources, out, &acquisTomb)
+			}()
+
+			got := []string{}
+
+		READLOOP:
+			for {
+				select {
+				case evt := <-out:
+					got = append(got, evt.Line.Raw)
+				case <-time.After(1 * time.Second):
+					break READLOOP
+				}
+			}
+
+			acquisTomb.Kill(nil)
+
+			assert.Equal(t, tc.expected, got)
+		})
+	}
 }

--- a/pkg/acquisition/acquisition_test.go
+++ b/pkg/acquisition/acquisition_test.go
@@ -723,3 +723,33 @@ func TestStartAcquisitionTransform(t *testing.T) {
 		})
 	}
 }
+
+// TestStartAcquisitionCatTransformTerminates checks that in cat mode, acquisition
+// terminates on its own once the datasource is done reading, even when a transform
+// is configured. cmd/crowdsec relies on acquisTomb dying to trigger the shutdown.
+func TestStartAcquisitionCatTransformTerminates(t *testing.T) {
+	ctx := t.Context()
+	uuid := "transform-terminate"
+
+	registerTransform(t, uuid, `evt.Line.Raw + "-transformed"`)
+
+	sources := []types.DataSource{&MockCatTransform{uuid: uuid}}
+	// buffered, so the transformer is never blocked writing its result
+	out := make(chan pipeline.Event, 10)
+	acquisTomb := tomb.Tomb{}
+
+	done := make(chan error, 1)
+
+	go func() { done <- StartAcquisition(ctx, sources, out, &acquisTomb) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		acquisTomb.Kill(nil)
+		t.Fatal("StartAcquisition did not return: cat mode with a transform never terminates")
+	}
+
+	require.Len(t, out, 1)
+	assert.Equal(t, "original-transformed", (<-out).Line.Raw)
+}

--- a/pkg/acquisition/acquisition_test.go
+++ b/pkg/acquisition/acquisition_test.go
@@ -402,65 +402,113 @@ func (*MockTail) GetUuid() string { return "" }
 
 // func StartAcquisition(sources []DataSource, output chan types.Event, AcquisTomb *tomb.Tomb) error {
 
-func TestStartAcquisitionCat(t *testing.T) {
-	ctx := t.Context()
-	sources := []types.DataSource{
-		&MockCat{},
+// acquisitionTimeout is only ever reached when acquisition fails to terminate:
+// it's generous on purpose, a healthy run finishes in microseconds.
+const acquisitionTimeout = 10 * time.Second
+
+// quietPeriod is how long we wait to confirm that no extra event shows up. Kept
+// short on purpose: an unexpected event slower than this is missed, which is
+// better than failing at random on a loaded machine.
+const quietPeriod = 100 * time.Millisecond
+
+// startAcquisition starts an acquisition in the background. The returned channel
+// receives the result of StartAcquisition, i.e. it fires once the tomb is dead
+// and every datasource (and the transformer, if any) is done writing.
+func startAcquisition(t *testing.T, sources []types.DataSource, out chan pipeline.Event, acquisTomb *tomb.Tomb) chan error {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() { done <- StartAcquisition(t.Context(), sources, out, acquisTomb) }()
+
+	return done
+}
+
+// waitForAcquisition waits for acquisition to terminate and returns its error.
+func waitForAcquisition(t *testing.T, done chan error) error {
+	t.Helper()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(acquisitionTimeout):
+		t.Fatal("acquisition did not terminate")
+		return nil
 	}
-	out := make(chan pipeline.Event)
-	acquisTomb := tomb.Tomb{}
+}
 
-	go func() {
-		err := StartAcquisition(ctx, sources, out, &acquisTomb)
-		assert.NoError(t, err)
-	}()
+// readEvents reads exactly n events, failing if they don't all show up in time.
+func readEvents(t *testing.T, out chan pipeline.Event, n int) []pipeline.Event {
+	t.Helper()
 
-	count := 0
+	evts := make([]pipeline.Event, 0, n)
 
-READLOOP:
-	for {
+	for i := range n {
 		select {
-		case <-out:
-			count++
-		case <-time.After(1 * time.Second):
-			break READLOOP
+		case evt := <-out:
+			evts = append(evts, evt)
+		case <-time.After(acquisitionTimeout):
+			t.Fatalf("timed out waiting for event %d/%d", i+1, n)
 		}
 	}
 
-	assert.Equal(t, 10, count)
+	return evts
+}
+
+// requireNoMoreEvents checks that acquisition doesn't emit more than expected.
+func requireNoMoreEvents(t *testing.T, out chan pipeline.Event) {
+	t.Helper()
+
+	select {
+	case evt := <-out:
+		t.Fatalf("unexpected extra event: %q", evt.Line.Raw)
+	case <-time.After(quietPeriod):
+	}
+}
+
+// runCatAcquisition runs a cat-mode acquisition to completion and returns the raw
+// lines it produced. Cat acquisition ends when the tomb dies, i.e. once every
+// datasource and the transformer (if any) are done writing, so the result is
+// complete and we never have to guess with a sleep.
+func runCatAcquisition(t *testing.T, sources []types.DataSource) []string {
+	t.Helper()
+
+	// buffered, so nothing can block on writing while we wait for termination
+	out := make(chan pipeline.Event, 100)
+	acquisTomb := tomb.Tomb{}
+
+	done := startAcquisition(t, sources, out, &acquisTomb)
+
+	if err := waitForAcquisition(t, done); err != nil {
+		acquisTomb.Kill(nil)
+		require.NoError(t, err)
+	}
+
+	got := []string{}
+	for len(out) > 0 {
+		got = append(got, (<-out).Line.Raw)
+	}
+
+	return got
+}
+
+func TestStartAcquisitionCat(t *testing.T) {
+	got := runCatAcquisition(t, []types.DataSource{&MockCat{}})
+
+	assert.Len(t, got, 10)
 }
 
 func TestStartAcquisitionTail(t *testing.T) {
-	ctx := t.Context()
-	sources := []types.DataSource{
-		&MockTail{},
-	}
-	out := make(chan pipeline.Event)
+	out := make(chan pipeline.Event, 100)
 	acquisTomb := tomb.Tomb{}
 
-	go func() {
-		if err := StartAcquisition(ctx, sources, out, &acquisTomb); err != nil {
-			t.Error("unexpected error")
-		}
-	}()
+	done := startAcquisition(t, []types.DataSource{&MockTail{}}, out, &acquisTomb)
 
-	count := 0
+	readEvents(t, out, 10)
+	requireNoMoreEvents(t, out)
 
-READLOOP:
-	for {
-		select {
-		case <-out:
-			count++
-		case <-time.After(1 * time.Second):
-			break READLOOP
-		}
-	}
-
-	assert.Equal(t, 10, count)
-
+	// tail mode never ends on its own, so ask it to stop and check that it does
 	acquisTomb.Kill(nil)
-	time.Sleep(1 * time.Second)
-	require.NoError(t, acquisTomb.Err(), "tomb is not dead")
+	require.NoError(t, waitForAcquisition(t, done), "tomb is not dead")
 }
 
 type MockTailError struct {
@@ -480,35 +528,17 @@ func (*MockTailError) StreamingAcquisition(_ context.Context, out chan pipeline.
 }
 
 func TestStartAcquisitionTailError(t *testing.T) {
-	ctx := t.Context()
-	sources := []types.DataSource{
-		&MockTailError{},
-	}
-	out := make(chan pipeline.Event)
+	// buffered: the datasource kills the tomb right after writing, we read afterwards
+	out := make(chan pipeline.Event, 100)
 	acquisTomb := tomb.Tomb{}
 
-	go func() {
-		if err := StartAcquisition(ctx, sources, out, &acquisTomb); err != nil && err.Error() != "got error (tomb)" {
-			t.Errorf("expected error, got '%s'", err)
-		}
-	}()
+	done := startAcquisition(t, []types.DataSource{&MockTailError{}}, out, &acquisTomb)
 
-	count := 0
+	// the datasource kills the tomb itself, so acquisition ends without our help
+	cstest.RequireErrorContains(t, waitForAcquisition(t, done), "got error (tomb)")
 
-READLOOP:
-	for {
-		select {
-		case <-out:
-			count++
-		case <-time.After(1 * time.Second):
-			break READLOOP
-		}
-	}
-
-	assert.Equal(t, 10, count)
-	// acquisTomb.Kill(nil)
-	time.Sleep(1 * time.Second)
-	cstest.RequireErrorContains(t, acquisTomb.Err(), "got error (tomb)")
+	// every write happened before the tomb died, so the events are all buffered
+	assert.Len(t, out, 10)
 }
 
 type MockSourceByDSN struct {
@@ -692,32 +722,11 @@ func TestStartAcquisitionTransform(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := t.Context()
 			uuid := "transform-" + tc.name
 
 			registerTransform(t, uuid, tc.expr)
 
-			sources := []types.DataSource{&MockCatTransform{uuid: uuid}}
-			out := make(chan pipeline.Event)
-			acquisTomb := tomb.Tomb{}
-
-			go func() {
-				_ = StartAcquisition(ctx, sources, out, &acquisTomb)
-			}()
-
-			got := []string{}
-
-		READLOOP:
-			for {
-				select {
-				case evt := <-out:
-					got = append(got, evt.Line.Raw)
-				case <-time.After(1 * time.Second):
-					break READLOOP
-				}
-			}
-
-			acquisTomb.Kill(nil)
+			got := runCatAcquisition(t, []types.DataSource{&MockCatTransform{uuid: uuid}})
 
 			assert.Equal(t, tc.expected, got)
 		})
@@ -728,28 +737,11 @@ func TestStartAcquisitionTransform(t *testing.T) {
 // terminates on its own once the datasource is done reading, even when a transform
 // is configured. cmd/crowdsec relies on acquisTomb dying to trigger the shutdown.
 func TestStartAcquisitionCatTransformTerminates(t *testing.T) {
-	ctx := t.Context()
 	uuid := "transform-terminate"
 
 	registerTransform(t, uuid, `evt.Line.Raw + "-transformed"`)
 
-	sources := []types.DataSource{&MockCatTransform{uuid: uuid}}
-	// buffered, so the transformer is never blocked writing its result
-	out := make(chan pipeline.Event, 10)
-	acquisTomb := tomb.Tomb{}
+	got := runCatAcquisition(t, []types.DataSource{&MockCatTransform{uuid: uuid}})
 
-	done := make(chan error, 1)
-
-	go func() { done <- StartAcquisition(ctx, sources, out, &acquisTomb) }()
-
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(2 * time.Second):
-		acquisTomb.Kill(nil)
-		t.Fatal("StartAcquisition did not return: cat mode with a transform never terminates")
-	}
-
-	require.Len(t, out, 1)
-	assert.Equal(t, "original-transformed", (<-out).Line.Raw)
+	assert.Equal(t, []string{"original-transformed"}, got)
 }

--- a/pkg/acquisition/acquisition_test.go
+++ b/pkg/acquisition/acquisition_test.go
@@ -411,10 +411,10 @@ const acquisitionTimeout = 10 * time.Second
 // better than failing at random on a loaded machine.
 const quietPeriod = 100 * time.Millisecond
 
-// startAcquisition starts an acquisition in the background. The returned channel
+// launchAcquisition starts an acquisition in the background. The returned channel
 // receives the result of StartAcquisition, i.e. it fires once the tomb is dead
 // and every datasource (and the transformer, if any) is done writing.
-func startAcquisition(t *testing.T, sources []types.DataSource, out chan pipeline.Event, acquisTomb *tomb.Tomb) chan error {
+func launchAcquisition(t *testing.T, sources []types.DataSource, out chan pipeline.Event, acquisTomb *tomb.Tomb) chan error {
 	t.Helper()
 
 	done := make(chan error, 1)
@@ -476,7 +476,7 @@ func runCatAcquisition(t *testing.T, sources []types.DataSource) []string {
 	out := make(chan pipeline.Event, 100)
 	acquisTomb := tomb.Tomb{}
 
-	done := startAcquisition(t, sources, out, &acquisTomb)
+	done := launchAcquisition(t, sources, out, &acquisTomb)
 
 	if err := waitForAcquisition(t, done); err != nil {
 		acquisTomb.Kill(nil)
@@ -501,7 +501,7 @@ func TestStartAcquisitionTail(t *testing.T) {
 	out := make(chan pipeline.Event, 100)
 	acquisTomb := tomb.Tomb{}
 
-	done := startAcquisition(t, []types.DataSource{&MockTail{}}, out, &acquisTomb)
+	done := launchAcquisition(t, []types.DataSource{&MockTail{}}, out, &acquisTomb)
 
 	readEvents(t, out, 10)
 	requireNoMoreEvents(t, out)
@@ -532,7 +532,7 @@ func TestStartAcquisitionTailError(t *testing.T) {
 	out := make(chan pipeline.Event, 100)
 	acquisTomb := tomb.Tomb{}
 
-	done := startAcquisition(t, []types.DataSource{&MockTailError{}}, out, &acquisTomb)
+	done := launchAcquisition(t, []types.DataSource{&MockTailError{}}, out, &acquisTomb)
 
 	// the datasource kills the tomb itself, so acquisition ends without our help
 	cstest.RequireErrorContains(t, waitForAcquisition(t, done), "got error (tomb)")
@@ -543,7 +543,7 @@ func TestStartAcquisitionTailError(t *testing.T) {
 
 type MockSourceByDSN struct {
 	configuration.DataSourceCommonCfg `yaml:",inline"`
-	Toto                              string `yaml:"toto"`
+	Toto                              string     `yaml:"toto"`
 	logger                            *log.Entry //nolint:unused
 }
 
@@ -582,7 +582,7 @@ func TestConfigureByDSN(t *testing.T) {
 			ExpectedError: "no acquisition for protocol foobar://",
 		},
 		{
-			dsn:            "mockdsn://test_expect",
+			dsn: "mockdsn://test_expect",
 		},
 		{
 			dsn:           "mockdsn://bad",
@@ -609,16 +609,18 @@ func TestConfigureByDSN(t *testing.T) {
 	}
 }
 
-
 // TailModeNoTailer configures itself in "tail" mode but does not implement the Tailer methods.
-type TailModeNoTailer struct {}
+type TailModeNoTailer struct{}
+
 func (*TailModeNoTailer) UnmarshalConfig(_ []byte) error { return nil }
-func (*TailModeNoTailer) Configure(_ context.Context, _ []byte, _ *log.Entry, _ metrics.AcquisitionMetricsLevel) error { return nil }
-func (*TailModeNoTailer) GetMode() string   { return configuration.TAIL_MODE }
-func (*TailModeNoTailer) GetName() string   { return "tail_no_tailer" }
-func (*TailModeNoTailer) GetUuid() string   { return "" }
-func (s *TailModeNoTailer) Dump() any       { return s }
-func (*TailModeNoTailer) CanRun() error     { return nil }
+func (*TailModeNoTailer) Configure(_ context.Context, _ []byte, _ *log.Entry, _ metrics.AcquisitionMetricsLevel) error {
+	return nil
+}
+func (*TailModeNoTailer) GetMode() string { return configuration.TAIL_MODE }
+func (*TailModeNoTailer) GetName() string { return "tail_no_tailer" }
+func (*TailModeNoTailer) GetUuid() string { return "" }
+func (s *TailModeNoTailer) Dump() any     { return s }
+func (*TailModeNoTailer) CanRun() error   { return nil }
 
 func TestStartAcquisition_MissingTailer(t *testing.T) {
 	ctx := t.Context()
@@ -632,15 +634,17 @@ func TestStartAcquisition_MissingTailer(t *testing.T) {
 	require.ErrorContains(t, <-errCh, "tail_no_tailer: tail mode is set but the datasource does not support streaming acquisition")
 }
 
-
 // CatModeNoTailer configures itself in "cat" mode but does not implement the Fetcher methods.
-type CatModeNoFetcher struct {}
+type CatModeNoFetcher struct{}
+
 func (*CatModeNoFetcher) UnmarshalConfig(_ []byte) error { return nil }
-func (*CatModeNoFetcher) Configure(_ context.Context, _ []byte, _ *log.Entry, _ metrics.AcquisitionMetricsLevel) error { return nil }
+func (*CatModeNoFetcher) Configure(_ context.Context, _ []byte, _ *log.Entry, _ metrics.AcquisitionMetricsLevel) error {
+	return nil
+}
 func (*CatModeNoFetcher) GetMode() string { return configuration.CAT_MODE }
 func (*CatModeNoFetcher) GetName() string { return "cat_no_fetcher" }
 func (*CatModeNoFetcher) GetUuid() string { return "" }
-func (s *CatModeNoFetcher) Dump() any       { return s }
+func (s *CatModeNoFetcher) Dump() any     { return s }
 func (*CatModeNoFetcher) CanRun() error   { return nil }
 
 func TestStartAcquisition_MissingFetcher(t *testing.T) {


### PR DESCRIPTION
Since the datasource refactoring, we were passing the output chan to the datasources even if a transform expression was provided, instead of the transform chan.

This PR also fixes the transform goroutine being kept alive after the acquisition ended in replay mode.