### PR TITLE
apiserver: don't query expired decisions for a bouncer that never pulled

### DIFF
--- a/pkg/apiserver/controllers/v1/decisions.go
+++ b/pkg/apiserver/controllers/v1/decisions.go
@@ -336,20 +336,20 @@ func (c *Controller) streamDecisions(gctx *gin.Context, bouncerInfo *ent.Bouncer
 
 		gctx.Writer.WriteString(`], "deleted": [`)
 
-		// Use a 2-second overlap to avoid missing decisions that expired around the last pull time
-		var expiredSince *time.Time
+		// A bouncer that never completed a pull holds no decision, so it has nothing to remove:
+		// skip the query instead of scanning every decision that ever expired.
 		if bouncerInfo.LastPull != nil {
-			since := bouncerInfo.LastPull.Add(-2 * time.Second)
-			expiredSince = &since
-		}
+			// Use a 2-second overlap to avoid missing decisions that expired around the last pull time
+			expiredSince := bouncerInfo.LastPull.Add(-2 * time.Second)
 
-		err = writeDeltaDecisions(gctx, now, filters, expiredSince, c.DBClient.QueryExpiredDecisionsSinceWithFilters)
-		if err != nil {
-			log.Errorf("failed sending expired decisions for delta: %v", err)
-			gctx.Writer.WriteString("]}")
-			gctx.Writer.Flush()
+			err = writeDeltaDecisions(gctx, now, filters, &expiredSince, c.DBClient.QueryExpiredDecisionsSinceWithFilters)
+			if err != nil {
+				log.Errorf("failed sending expired decisions for delta: %v", err)
+				gctx.Writer.WriteString("]}")
+				gctx.Writer.Flush()
 
-			return err
+				return err
+			}
 		}
 
 		gctx.Writer.WriteString("]}")

--- a/pkg/apiserver/controllers/v1/decisions_test.go
+++ b/pkg/apiserver/controllers/v1/decisions_test.go
@@ -1,0 +1,75 @@
+package v1
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
+	"github.com/crowdsecurity/crowdsec/pkg/database"
+	"github.com/crowdsecurity/crowdsec/pkg/database/ent"
+)
+
+// cancelOnDeleted cancels the request context as soon as the "deleted" part of
+// the stream begins, like a bouncer that disconnects in the middle of a pull.
+type cancelOnDeleted struct {
+	*httptest.ResponseRecorder
+	cancel context.CancelFunc
+}
+
+func (w *cancelOnDeleted) Write(b []byte) (int, error) {
+	if strings.Contains(string(b), `"deleted"`) {
+		w.cancel()
+	}
+
+	return w.ResponseRecorder.Write(b)
+}
+
+func (w *cancelOnDeleted) WriteString(s string) (int, error) {
+	if strings.Contains(s, `"deleted"`) {
+		w.cancel()
+	}
+
+	return w.ResponseRecorder.WriteString(s)
+}
+
+func TestStreamDeltaClientDisconnect(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	ctx := t.Context()
+
+	dbClient, err := database.NewClient(ctx, &csconfig.DatabaseCfg{
+		Type:   "sqlite",
+		DbName: "crowdsec",
+		DbPath: filepath.Join(t.TempDir(), "test.sqlite"),
+	}, nil)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = dbClient.Ent.Close()
+	})
+
+	c := &Controller{DBClient: dbClient}
+
+	reqCtx, cancel := context.WithCancel(ctx)
+	rec := &cancelOnDeleted{ResponseRecorder: httptest.NewRecorder(), cancel: cancel}
+
+	gctx, _ := gin.CreateTestContext(rec)
+	gctx.Request = httptest.NewRequest(http.MethodGet, "/v1/decisions/stream", nil).WithContext(reqCtx)
+
+	lastPull := time.Now().UTC().Add(-time.Minute)
+
+	err = c.streamDecisions(gctx, &ent.Bouncer{LastPull: &lastPull}, time.Now().UTC(), map[string][]string{})
+	require.ErrorIs(t, err, database.QueryFail)
+
+	// even when the expired query fails mid-stream, the response must end as valid JSON
+	assert.Equal(t, `{"new": [], "deleted": []}`, rec.Body.String())
+}

--- a/pkg/apiserver/decisions_test.go
+++ b/pkg/apiserver/decisions_test.go
@@ -257,6 +257,47 @@ func TestDeleteDecision(t *testing.T) {
 	assert.Equal(t, "3", resp.NbDeleted)
 }
 
+func TestStreamDeltaFirstPull(t *testing.T) {
+	ctx := t.Context()
+
+	// A bouncer that never completed a pull has no decision to remove, so the
+	// deleted list must be empty instead of holding every expired decision.
+	lapi := SetupLAPITest(t, ctx)
+
+	// Create Valid Alert: one decision for 91.121.79.179 (id=1), one for 91.121.79.178 (id=2)
+	lapi.InsertAlertFromFile(t, ctx, "./tests/alert_minibulk.json")
+
+	// Expire the first one, so the database holds one active and one expired decision
+	w := lapi.RecordResponse(t, ctx, "DELETE", "/v1/decisions/1", emptyBody, PASSWORD)
+	assert.Equal(t, 200, w.Code)
+
+	// First pull ever for this bouncer (last_pull is NULL), without startup=true
+	w = lapi.RecordResponse(t, ctx, "GET", "/v1/decisions/stream", emptyBody, APIKEY)
+	decisions, code := readDecisionsStreamResp(t, w)
+	assert.Equal(t, 200, code)
+	assert.Len(t, decisions["new"], 1)
+	assert.Equal(t, int64(2), decisions["new"][0].ID)
+	assert.Empty(t, decisions["deleted"])
+
+	// The pull above set last_pull, so the following delta behaves as usual
+	w = lapi.RecordResponse(t, ctx, "DELETE", "/v1/decisions/2", emptyBody, PASSWORD)
+	assert.Equal(t, 200, w.Code)
+
+	w = lapi.RecordResponse(t, ctx, "GET", "/v1/decisions/stream", emptyBody, APIKEY)
+	decisions, code = readDecisionsStreamResp(t, w)
+	assert.Equal(t, 200, code)
+	assert.Empty(t, decisions["new"])
+
+	// Decision 1 expired just before the previous pull, so the 2-second overlap
+	// may legitimately send it again: only require the one expired since then.
+	deleted := make([]int64, 0, len(decisions["deleted"]))
+	for _, d := range decisions["deleted"] {
+		deleted = append(deleted, d.ID)
+	}
+
+	assert.Contains(t, deleted, int64(2))
+}
+
 func TestStreamStartDecisionDedup(t *testing.T) {
 	ctx := t.Context()
 


### PR DESCRIPTION
Fixes #4613

## What

A bouncer that has never completed a pull has `bouncers.last_pull = NULL`. In the delta branch of the decision stream, `expiredSince` is then left nil, and `QueryExpiredDecisionsSinceWithFilters` skips its `until` lower bound entirely:

```go
if since != nil {
    query = query.Where(decision.UntilGT(*since))
}
```

so the query degrades from "what expired since your last pull" to "everything that ever expired", with every row passing through the `longestDecisionForScopeTypeValue` self-anti-join.

Such a bouncer holds no decision from this LAPI, so its deleted set is empty by construction — the whole result is discarded work. This skips the query instead of running it.

## Impact

On a production LAPI with ~2.2M rows in `decisions` (~50k active, ~25.5k distinct `(value, type, scope)`), a single delta pull from a bouncer with `last_pull IS NULL` took 26-37 minutes at ~700% CPU, against 1.5-4.5s for the same request from a bouncer with `last_pull` populated. Run directly against the DB file, one 30,000-row page of the unbounded statement takes ~45s on an i9-12900K and over 120s on a Xeon E3-1245v2, while the bounded form returns in ~1s. `EXPLAIN QUERY PLAN` is identical in both cases and `sqlite_stat1` is absent, so this is the missing predicate rather than a planner divergence.

It is also somewhat self-sustaining: `last_pull` is only written on a fully successful response, so a bouncer whose client times out during the multi-minute response can retry into the same query.

## Regression

Introduced by #3020 (`44a2014f`), released in v1.6.3, which turned `since` into a pointer and made the predicate conditional in the same commit. That PR did guard the other path — `StreamDecisionNonChunked` passed `&time.Time{}` rather than nil — but #4413 later removed that path, leaving only the one that passes nil.

## Test

Adds `TestStreamDeltaFirstPull`. Every existing stream test uses `startup=true`, so the delta path had no coverage at all; this covers both the first-pull case and the ordinary delta that follows it.

The test is red on master and green with the fix:

```
--- FAIL: TestStreamDeltaFirstPull (0.37s)
        Error: Should be empty, but was [0x31cdd7d91b00]
```

Locally: `go test ./pkg/apiserver/... ./pkg/database/...` passes, `go vet` and `gofmt` are clean. I was not able to run `golangci-lint` (not installed on this machine), so CI is the first full lint pass.

## Not in scope

Two related things I deliberately left out, both noted in the issue:

- `startup=true` runs the same unbounded statement by construction (`QueryExpiredDecisionsWithFilters` has no `since` parameter). Whether a client doing a full resync needs a deleted set at all is a contract question I did not want to assume.
- The anti-join joins on `(value, type, scope)` + a range on `until` while the only supporting index is `(value)`. Adding `index.Fields("value", "type", "scope", "until")` speeds up every stream query including the bounded ones — applied as a manual index on the affected host it took the unbounded statement from >120s to 12.74s per page, and the end-to-end first sync from 26-37 min to 71s. It is an independent change and belongs in its own PR — happy to open it if you want it.