### PR TITLE
fix(docker): honor DISABLE_* hub knobs when the agent is disabled

### DIFF
--- a/build/docker/docker_start.sh
+++ b/build/docker/docker_start.sh
@@ -205,11 +205,17 @@ difference() {
 # prepare_hub updates/installs/removes Hub items based on env vars, but only when the agent is expected to run.
 # It exits early when the agent is disabled with DISABLE_AGENT or in the configuration.
 prepare_hub() {
+    # The default hub items are copied from /staging regardless of the agent
+    # (see the rsync in the staging step), so the DISABLE_* knobs have to be
+    # honored even when no agent runs - otherwise a LAPI-only container keeps
+    # collections it was explicitly told to drop.
     if istrue "$DISABLE_AGENT"; then
+        remove_hub_items
         return
     fi
 
     if conf_get '.crowdsec_service ?= null or (.crowdsec_service.enable? == false)' >/dev/null 2>&1; then
+        remove_hub_items
         return
     fi
 
@@ -256,6 +262,10 @@ prepare_hub() {
         cscli_if_clean appsec-rules install "$(difference "$APPSEC_RULES" "$DISABLE_APPSEC_RULES")"
     fi
 
+    remove_hub_items
+}
+
+remove_hub_items() {
     ## Remove collections, parsers, scenarios & postoverflows
     if [ "$DISABLE_COLLECTIONS" != "" ]; then
         # shellcheck disable=SC2086


### PR DESCRIPTION
Fixes #4563.

## The problem

The reporter root-caused this precisely, so briefly: the default hub items are copied into `/etc/crowdsec` by the staging `rsync`, which is **not** gated on `DISABLE_AGENT`. The knobs that remove them live in `prepare_hub()`, which returns early when the agent is disabled.

The copy is unconditional but the removal is agent-gated, so a LAPI-only container (`DISABLE_AGENT=true`, used purely as a decision store fed by CAPI) keeps the collections it was explicitly told to drop. `DISABLE_COLLECTIONS=crowdsecurity/linux` has no effect and the collection stays in `cscli collections list`.

## The change

The removal block moves into `remove_hub_items()`, which is called on the two paths that return early as well as at the end of the normal path. Removal now follows the same rule as the copy it is meant to undo.

Installing hub items still requires the agent, so that path is unchanged — this only makes the `DISABLE_*` knobs apply wherever the items can actually be present.

It covers all seven knobs, not just `DISABLE_COLLECTIONS`, since they are gated by the same early return: parsers, scenarios, postoverflows, contexts, appsec-configs and appsec-rules had the same problem.

## Verification

Since this path needs a built image and a LAPI-only container to exercise end to end, I verified it by extracting `prepare_hub`/`remove_hub_items` and running them against stubbed `cscli_if_clean`/`istrue`/`conf_get`, capturing the `cscli` calls:

- `DISABLE_AGENT=true`, `DISABLE_COLLECTIONS=crowdsecurity/linux`
  - before: **no `cscli` calls at all** — the knob is silently ignored, which is the reported bug
  - after: `collections remove crowdsecurity/linux --force`
- agent enabled, with both `COLLECTIONS` and `DISABLE_COLLECTIONS` set
  - before and after: identical — `parsers install …`, `collections install crowdsecurity/nginx`, `collections remove crowdsecurity/linux --force`

`shellcheck` is clean on the result (run on the LF-normalised file; my checkout is CRLF).

Happy to add a case to `build/docker/test` instead if you would rather have it covered there — I did not want to guess at the fixture conventions.