### PR TITLE
lapi: use decision id as cursor for delta pull

### DIFF
--- a/pkg/apiserver/controllers/v1/decisions.go
+++ b/pkg/apiserver/controllers/v1/decisions.go
@@ -155,10 +155,13 @@ func (c *Controller) DeleteDecisions(gctx *gin.Context) {
 	gctx.JSON(http.StatusOK, deleteDecisionResp)
 }
 
-func writeStartupDecisions(gctx *gin.Context, now time.Time, filters map[string][]string, dbFunc func(context.Context, time.Time, map[string][]string) ([]*ent.Decision, error)) error {
+// writeDecisions streams the decisions returned by query into the array the caller has already
+// opened, paginating by id from startID. A startup resync passes 0, a stream delta passes the
+// bouncer cursor: both are the same query, they only differ in where they start.
+func writeDecisions(gctx *gin.Context, now time.Time, filters map[string][]string, startID int, query func(context.Context, time.Time, map[string][]string) ([]*ent.Decision, error)) error {
 	limit := 30000 // FIXME : make it configurable
 	needComma := false
-	lastId := 0
+	lastId := startID
 
 	ctx := gctx.Request.Context()
 
@@ -177,7 +180,7 @@ func writeStartupDecisions(gctx *gin.Context, now time.Time, filters map[string]
 			filters["id_gt"] = []string{lastIdStr}
 		}
 
-		data, err := dbFunc(ctx, now, filters)
+		data, err := query(ctx, now, filters)
 		if err != nil {
 			return err
 		}
@@ -211,7 +214,7 @@ func writeStartupDecisions(gctx *gin.Context, now time.Time, filters map[string]
 			lastId = data[len(data)-1].ID
 		}
 
-		log.Debugf("startup: %d decisions returned (limit: %d, lastid: %d)", len(data), limit, lastId)
+		log.Debugf("stream: %d decisions returned (limit: %d, lastid: %d)", len(data), limit, lastId)
 
 		if len(data) < limit {
 			gctx.Writer.Flush()
@@ -223,119 +226,28 @@ func writeStartupDecisions(gctx *gin.Context, now time.Time, filters map[string]
 	return nil
 }
 
-func writeDeltaDecisions(gctx *gin.Context, now time.Time, filters map[string][]string, lastPull *time.Time, dbFunc func(context.Context, time.Time, *time.Time, map[string][]string) ([]*ent.Decision, error)) error {
-	limit := 30000 // FIXME : make it configurable
-	needComma := false
-	lastId := 0
-
-	ctx := gctx.Request.Context()
-
-	// We write to a buffer instead of directly to the writer to avoid the \n added by enc.Encode()
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-
-	limitStr := strconv.Itoa(limit)
-	filters["limit"] = []string{limitStr}
-	// callers reuse the same filters map across calls; clear any pagination cursor left by a previous call.
-	delete(filters, "id_gt")
-
-	for {
-		if lastId > 0 {
-			lastIdStr := strconv.Itoa(lastId)
-			filters["id_gt"] = []string{lastIdStr}
-		}
-
-		data, err := dbFunc(ctx, now, lastPull, filters)
-		if err != nil {
-			return err
-		}
-
-		for _, d := range data {
-			if needComma {
-				gctx.Writer.WriteString(",")
-			} else {
-				needComma = true
-			}
-
-			buf.Reset()
-			if err := enc.Encode(formatOneDecision(d)); err != nil {
-				gctx.Writer.Flush()
-
-				return err
-			}
-			// Encode() appends a trailing newline; strip it to keep the wire format compact.
-			b := buf.Bytes()
-			if n := len(b); n > 0 && b[n-1] == '\n' {
-				b = b[:n-1]
-			}
-			if _, err := gctx.Writer.Write(b); err != nil {
-				gctx.Writer.Flush()
-
-				return err
-			}
-		}
-
-		if len(data) > 0 {
-			lastId = data[len(data)-1].ID
-		}
-
-		log.Debugf("delta: %d decisions returned (limit: %d, lastid: %d)", len(data), limit, lastId)
-
-		if len(data) < limit {
-			gctx.Writer.Flush()
-
-			break
-		}
-	}
-
-	return nil
-}
-
-func (c *Controller) streamDecisions(gctx *gin.Context, bouncerInfo *ent.Bouncer, now time.Time, filters map[string][]string) error {
-	var err error
-
+func (c *Controller) streamDecisions(gctx *gin.Context, bouncerInfo *ent.Bouncer, now time.Time, filters map[string][]string, cursor int, startup bool) error {
 	gctx.Writer.Header().Set("Content-Type", "application/json")
 	gctx.Writer.Header().Set("Transfer-Encoding", "chunked")
 	gctx.Writer.WriteHeader(http.StatusOK)
 	gctx.Writer.WriteString(`{"new": [`) // No need to check for errors, the doc says it always returns nil
 
-	// if the blocker just started, return all decisions
-	if val, ok := gctx.Request.URL.Query()["startup"]; ok && val[0] == "true" {
-		// Active decisions
-		err := writeStartupDecisions(gctx, now, filters, c.DBClient.QueryAllDecisionsWithFilters)
-		if err != nil {
-			log.Errorf("failed sending new decisions for startup: %v", err)
-			gctx.Writer.WriteString(`], "deleted": []}`)
-			gctx.Writer.Flush()
-
-			return err
-		}
-
-		gctx.Writer.WriteString(`], "deleted": [`)
-		// Expired decisions
-		err = writeStartupDecisions(gctx, now, filters, c.DBClient.QueryExpiredDecisionsWithFilters)
-		if err != nil {
-			log.Errorf("failed sending expired decisions for startup: %v", err)
-			gctx.Writer.WriteString(`]}`)
-			gctx.Writer.Flush()
-
-			return err
-		}
-
-		gctx.Writer.WriteString(`]}`)
+	// Active decisions. A startup resync is this same query with a zero cursor.
+	if err := writeDecisions(gctx, now, filters, cursor, c.DBClient.QueryAllDecisionsWithFilters); err != nil {
+		log.Errorf("failed sending new decisions: %v", err)
+		gctx.Writer.WriteString(`], "deleted": []}`)
 		gctx.Writer.Flush()
-	} else {
-		err = writeDeltaDecisions(gctx, now, filters, bouncerInfo.LastPull, c.DBClient.QueryNewDecisionsSinceWithFilters)
-		if err != nil {
-			log.Errorf("failed sending new decisions for delta: %v", err)
-			gctx.Writer.WriteString(`], "deleted": []}`)
-			gctx.Writer.Flush()
 
-			return err
-		}
+		return err
+	}
 
-		gctx.Writer.WriteString(`], "deleted": [`)
+	gctx.Writer.WriteString(`], "deleted": [`)
 
+	// Expired decisions. Unlike the active ones these are keyed on until, not on the cursor:
+	// a decision expires when the clock passes it, with no write to order against.
+	expired := c.DBClient.QueryExpiredDecisionsWithFilters
+
+	if !startup {
 		// Use a 2-second overlap to avoid missing decisions that expired around the last pull time
 		var expiredSince *time.Time
 		if bouncerInfo.LastPull != nil {
@@ -343,18 +255,21 @@ func (c *Controller) streamDecisions(gctx *gin.Context, bouncerInfo *ent.Bouncer
 			expiredSince = &since
 		}
 
-		err = writeDeltaDecisions(gctx, now, filters, expiredSince, c.DBClient.QueryExpiredDecisionsSinceWithFilters)
-		if err != nil {
-			log.Errorf("failed sending expired decisions for delta: %v", err)
-			gctx.Writer.WriteString("]}")
-			gctx.Writer.Flush()
-
-			return err
+		expired = func(ctx context.Context, now time.Time, filters map[string][]string) ([]*ent.Decision, error) {
+			return c.DBClient.QueryExpiredDecisionsSinceWithFilters(ctx, now, expiredSince, filters)
 		}
-
-		gctx.Writer.WriteString("]}")
-		gctx.Writer.Flush()
 	}
+
+	if err := writeDecisions(gctx, now, filters, 0, expired); err != nil {
+		log.Errorf("failed sending expired decisions: %v", err)
+		gctx.Writer.WriteString(`]}`)
+		gctx.Writer.Flush()
+
+		return err
+	}
+
+	gctx.Writer.WriteString(`]}`)
+	gctx.Writer.Flush()
 
 	return nil
 }
@@ -382,12 +297,32 @@ func (c *Controller) StreamDecision(gctx *gin.Context) {
 		filters["scopes"] = []string{"ip,range"}
 	}
 
-	err = c.streamDecisions(gctx, bouncerInfo, streamStartTime, filters)
+	val, ok := filters["startup"]
+	startup := ok && val[0] == "true"
+
+	// Read the cursor before streaming anything: a decision we cannot see yet belongs to an
+	// uncommitted transaction and will get a higher id, so this value cannot step over it.
+	// A wall clock timestamp cannot make that promise, which is why last_pull is not used here.
+	latestID, err := c.DBClient.LatestDecisionID(gctx.Request.Context())
+	if err != nil {
+		c.HandleDBErrors(gctx, err)
+
+		return
+	}
+
+	cursor := bouncerInfo.StreamCursor
+	// A cursor past the end of the table means the decisions were rewound under us: a partial
+	// restore, or MySQL < 8.0 recomputing AUTO_INCREMENT after the highest rows were deleted.
+	if startup || cursor > latestID {
+		cursor = 0
+	}
+
+	err = c.streamDecisions(gctx, bouncerInfo, streamStartTime, filters, cursor, startup)
 
 	if err == nil {
-		// Only update the last pull time if no error occurred when sending the decisions to avoid missing decisions
+		// Only update the pull state if no error occurred when sending the decisions to avoid missing decisions
 		// Do not reuse the context provided by gin because we already have sent the response to the client, so there's a chance for it to already be canceled
-		if err := c.DBClient.UpdateBouncerLastPull(context.Background(), streamStartTime, bouncerInfo.ID); err != nil {
+		if err := c.DBClient.UpdateBouncerStreamPull(context.Background(), streamStartTime, latestID, bouncerInfo.ID); err != nil {
 			log.Errorf("unable to update bouncer '%s' pull: %v", bouncerInfo.Name, err)
 		}
 	}

--- a/pkg/apiserver/decisions_test.go
+++ b/pkg/apiserver/decisions_test.go
@@ -2,8 +2,10 @@ package apiserver
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -339,4 +341,66 @@ type DecisionTest struct {
 	NewChecks     []DecisionCheck
 	DelChecks     []DecisionCheck
 	AuthType      string
+}
+
+// Regression for cs-firewall-bouncer#508.
+//
+// A blocklist import stamps created_at inside its transaction, so a decision can commit after a
+// pull that could not see it, carrying a created_at older than that pull. Keyed on a timestamp
+// such a decision is skipped by every later delta and only comes back on a full resync; keyed on
+// the id cursor it is delivered on the next pull.
+func TestStreamDecisionLateCommit(t *testing.T) {
+	ctx := t.Context()
+	lapi := SetupLAPITest(t, ctx)
+
+	// A first pull establishes the bouncer position.
+	w := lapi.RecordResponse(t, ctx, "GET", "/v1/decisions/stream?startup=true", emptyBody, APIKEY)
+	_, code := readDecisionsStreamResp(t, w)
+	require.Equal(t, 200, code)
+
+	// A decision whose transaction started before that pull and committed after it.
+	_, err := lapi.DBClient.Ent.Decision.Create().
+		SetCreatedAt(time.Now().UTC().Add(-time.Hour)).
+		SetUntil(time.Now().UTC().Add(time.Hour)).
+		SetScenario("test/late-commit").
+		SetType("ban").
+		SetScope("Ip").
+		SetValue("11.22.33.44").
+		SetOrigin("lists").
+		Save(ctx)
+	require.NoError(t, err)
+
+	w = lapi.RecordResponse(t, ctx, "GET", "/v1/decisions/stream", emptyBody, APIKEY)
+	decisions, code := readDecisionsStreamResp(t, w)
+	require.Equal(t, 200, code)
+	require.Len(t, decisions["new"], 1)
+	require.Equal(t, "11.22.33.44", *decisions["new"][0].Value)
+
+	// And it is not resent once the cursor has moved past it.
+	w = lapi.RecordResponse(t, ctx, "GET", "/v1/decisions/stream", emptyBody, APIKEY)
+	decisions, code = readDecisionsStreamResp(t, w)
+	require.Equal(t, 200, code)
+	require.Empty(t, decisions["new"])
+}
+
+// A cursor past the end of the decisions table (partial restore, or MySQL < 8.0 recomputing
+// AUTO_INCREMENT) must fall back to a full resync rather than silently starving the bouncer.
+func TestStreamDecisionCursorAheadOfTable(t *testing.T) {
+	ctx := t.Context()
+	lapi := SetupLAPITest(t, ctx)
+
+	lapi.InsertAlertFromFile(t, ctx, "./tests/alert_sample.json")
+
+	w := lapi.RecordResponse(t, ctx, "GET", "/v1/decisions/stream?startup=true", emptyBody, APIKEY)
+	decisions, code := readDecisionsStreamResp(t, w)
+	require.Equal(t, 200, code)
+	require.Len(t, decisions["new"], 1)
+
+	_, err := lapi.DBClient.Ent.Bouncer.Update().SetStreamCursor(999999).Save(ctx)
+	require.NoError(t, err)
+
+	w = lapi.RecordResponse(t, ctx, "GET", "/v1/decisions/stream", emptyBody, APIKEY)
+	decisions, code = readDecisionsStreamResp(t, w)
+	require.Equal(t, 200, code)
+	require.Len(t, decisions["new"], 1)
 }

--- a/pkg/apiserver/decisions_test.go
+++ b/pkg/apiserver/decisions_test.go
@@ -1,11 +1,16 @@
 package apiserver
 
 import (
+	"context"
+	"sort"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/crowdsecurity/crowdsec/pkg/csnet"
+	"github.com/crowdsecurity/crowdsec/pkg/types"
 )
 
 const (
@@ -403,4 +408,117 @@ func TestStreamDecisionCursorAheadOfTable(t *testing.T) {
 	decisions, code = readDecisionsStreamResp(t, w)
 	require.Equal(t, 200, code)
 	require.Len(t, decisions["new"], 1)
+}
+
+// The delta is now driven by the id cursor rather than a timestamp, so every filter has to keep
+// working on top of it, and the cursor has to advance even when a filter matches nothing.
+func TestStreamDecisionDeltaFilters(t *testing.T) {
+	seed := func(t *testing.T, ctx context.Context, lapi LAPI) {
+		t.Helper()
+
+		seedOne(t, ctx, lapi, "1.0.0.1", "lists", "crowdsecurity/ssh_bf", types.Ip, "ban")
+		seedOne(t, ctx, lapi, "1.0.0.2", "crowdsec", "crowdsecurity/http_probing", types.Ip, "ban")
+		seedOne(t, ctx, lapi, "1.0.0.3", "CAPI", "crowdsecurity/ssh_bf", types.Ip, "captcha")
+		seedOne(t, ctx, lapi, "someuser", "crowdsec", "crowdsecurity/test", "user", "ban")
+	}
+
+	tests := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{"no filter", "", []string{"1.0.0.1", "1.0.0.2", "1.0.0.3"}},
+		{"origins", "&origins=lists", []string{"1.0.0.1"}},
+		{"multiple origins", "&origins=lists,CAPI", []string{"1.0.0.1", "1.0.0.3"}},
+		{"unknown origin", "&origins=nope", nil},
+		{"scenarios_containing", "&scenarios_containing=ssh_bf", []string{"1.0.0.1", "1.0.0.3"}},
+		{"scenarios_not_containing", "&scenarios_not_containing=ssh_bf", []string{"1.0.0.2"}},
+		{"multiple scenarios_containing", "&scenarios_containing=ssh_bf,http_probing", []string{"1.0.0.1", "1.0.0.2", "1.0.0.3"}},
+		{"unknown scenarios_containing", "&scenarios_containing=nope", nil},
+		{"scopes", "&scopes=user", []string{"someuser"}},
+		{"scopes ip+user", "&scopes=ip,user", []string{"1.0.0.1", "1.0.0.2", "1.0.0.3", "someuser"}},
+		{"value", "&value=1.0.0.2", []string{"1.0.0.2"}},
+		{"type", "&type=captcha", []string{"1.0.0.3"}},
+		{"ip", "&ip=1.0.0.1", []string{"1.0.0.1"}},
+		{"range", "&range=1.0.0.0/30&contains=false", []string{"1.0.0.1", "1.0.0.2", "1.0.0.3"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			lapi := SetupLAPITest(t, ctx)
+
+			// decisions already delivered before the cursor was parked: they match several of
+			// the filters below, so they resurface if the cursor is ignored
+			lapi.InsertAlertFromFile(t, ctx, "./tests/alert_minibulk.json")
+			seedOne(t, ctx, lapi, "9.9.9.9", "lists", "crowdsecurity/ssh_bf", types.Ip, "ban")
+
+			w := lapi.RecordResponse(t, ctx, "GET", "/v1/decisions/stream?startup=true", emptyBody, APIKEY)
+			_, code := readDecisionsStreamResp(t, w)
+			require.Equal(t, 200, code)
+
+			before, err := lapi.DBClient.LatestDecisionID(ctx)
+			require.NoError(t, err)
+			require.NotZero(t, before, "cursor must be non-zero so the delta really is id > cursor")
+
+			seed(t, ctx, lapi)
+
+			w = lapi.RecordResponse(t, ctx, "GET", "/v1/decisions/stream?"+tc.query, emptyBody, APIKEY)
+			decisions, code := readDecisionsStreamResp(t, w)
+			require.Equal(t, 200, code)
+
+			got := make([]string, 0, len(decisions["new"]))
+			for _, d := range decisions["new"] {
+				got = append(got, *d.Value)
+			}
+
+			sort.Strings(got)
+			require.Equal(t, tc.want, nilIfEmpty(got))
+
+			// the cursor advances to the end of the table whatever the filter matched,
+			// otherwise a filtered bouncer would rescan a widening range forever
+			latest, err := lapi.DBClient.LatestDecisionID(ctx)
+			require.NoError(t, err)
+
+			b, err := lapi.DBClient.Ent.Bouncer.Get(ctx, 1)
+			require.NoError(t, err)
+			require.Equal(t, latest, b.StreamCursor)
+
+			// and nothing is resent
+			w = lapi.RecordResponse(t, ctx, "GET", "/v1/decisions/stream?"+tc.query, emptyBody, APIKEY)
+			decisions, code = readDecisionsStreamResp(t, w)
+			require.Equal(t, 200, code)
+			require.Empty(t, decisions["new"])
+		})
+	}
+}
+
+func seedOne(t *testing.T, ctx context.Context, lapi LAPI, value, origin, scenario, scope, dtype string) {
+	t.Helper()
+
+	rng, err := csnet.NewRange(value)
+	if scope == types.Ip {
+		require.NoError(t, err)
+	}
+
+	_, err = lapi.DBClient.Ent.Decision.Create().
+		SetUntil(time.Now().UTC().Add(time.Hour)).
+		SetScenario(scenario).
+		SetType(dtype).
+		SetScope(scope).
+		SetValue(value).
+		SetOrigin(origin).
+		SetStartIP(rng.Start.Addr).
+		SetEndIP(rng.End.Addr).
+		SetIPSize(int64(rng.Size())).
+		Save(ctx)
+	require.NoError(t, err)
+}
+
+func nilIfEmpty(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+
+	return s
 }

--- a/pkg/database/bouncers.go
+++ b/pkg/database/bouncers.go
@@ -140,6 +140,18 @@ func (c *Client) UpdateBouncerLastPull(ctx context.Context, lastPull time.Time, 
 	return nil
 }
 
+func (c *Client) UpdateBouncerStreamPull(ctx context.Context, lastPull time.Time, streamCursor int, id int) error {
+	_, err := c.Ent.Bouncer.UpdateOneID(id).
+		SetLastPull(lastPull).
+		SetStreamCursor(streamCursor).
+		Save(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to update bouncer stream pull in database: %w", err)
+	}
+
+	return nil
+}
+
 func (c *Client) UpdateBouncerIP(ctx context.Context, ipAddr string, id int) error {
 	_, err := c.Ent.Bouncer.UpdateOneID(id).SetIPAddress(ipAddr).Save(ctx)
 	if err != nil {

--- a/pkg/database/decisions.go
+++ b/pkg/database/decisions.go
@@ -54,6 +54,24 @@ func (c *Client) QueryAllDecisionsWithFilters(ctx context.Context, now time.Time
 	return data, nil
 }
 
+func (c *Client) LatestDecisionID(ctx context.Context) (int, error) {
+	latest, err := c.Ent.Decision.Query().
+		Select(decision.FieldID).
+		Order(ent.Desc(decision.FieldID)).
+		First(ctx)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return 0, nil
+		}
+
+		c.Log.Warningf("LatestDecisionID : %s", err)
+
+		return 0, fmt.Errorf("latest decision id: %w", QueryFail)
+	}
+
+	return latest.ID, nil
+}
+
 func (c *Client) QueryExpiredDecisionsWithFilters(ctx context.Context, now time.Time, filter map[string][]string) ([]*ent.Decision, error) {
 	query := c.Ent.Decision.Query().
 		Select(decision.FieldID, decision.FieldUntil, decision.FieldScenario, decision.FieldScope, decision.FieldValue, decision.FieldType, decision.FieldOrigin, decision.FieldUUID).
@@ -193,45 +211,6 @@ func (c *Client) QueryExpiredDecisionsSinceWithFilters(ctx context.Context, now 
 	if err != nil {
 		c.Log.Warningf("QueryExpiredDecisionsSinceWithFilters : %s", err)
 		return []*ent.Decision{}, fmt.Errorf("expired decisions with filters: %w", QueryFail)
-	}
-
-	return data, nil
-}
-
-func (c *Client) QueryNewDecisionsSinceWithFilters(ctx context.Context, now time.Time, since *time.Time, filter map[string][]string) ([]*ent.Decision, error) {
-	query := c.Ent.Decision.Query().
-		Select(decision.FieldID, decision.FieldUntil, decision.FieldScenario, decision.FieldScope, decision.FieldValue, decision.FieldType, decision.FieldOrigin, decision.FieldUUID).
-		Where(
-			decision.UntilGT(now),
-		)
-
-	errorMsg := "new decisions"
-
-	if since != nil {
-		query = query.Where(decision.CreatedAtGT(*since))
-
-		errorMsg = fmt.Sprintf("%s since %q", errorMsg, since)
-	}
-
-	// Allow a bouncer to ask for non-deduplicated results
-	if v, ok := filter["dedup"]; !ok || v[0] != "false" {
-		query = query.Where(longestDecisionForScopeTypeValue)
-	}
-
-	query, err := applyDecisionFilter(query, filter)
-	if err != nil {
-		c.Log.Warningf("QueryNewDecisionsSinceWithFilters : %s", err)
-
-		return nil, fmt.Errorf("%w: %s", QueryFail, errorMsg)
-	}
-
-	query = query.Order(ent.Asc(decision.FieldID))
-
-	data, err := query.All(ctx)
-	if err != nil {
-		c.Log.Warningf("QueryNewDecisionsSinceWithFilters : %s", err)
-
-		return nil, fmt.Errorf("%w: %s", QueryFail, errorMsg)
 	}
 
 	return data, nil

--- a/pkg/database/decisions_test.go
+++ b/pkg/database/decisions_test.go
@@ -1,0 +1,56 @@
+package database
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLatestDecisionID(t *testing.T) {
+	ctx := t.Context()
+	c := getDBClient(t, ctx)
+
+	latest, err := c.LatestDecisionID(ctx)
+	require.NoError(t, err)
+	require.Zero(t, latest, "empty table has no cursor")
+
+	var lastID int
+
+	for range 3 {
+		d, err := c.Ent.Decision.Create().
+			SetUntil(time.Now().UTC().Add(time.Hour)).
+			SetScenario("test").
+			SetType("ban").
+			SetScope("Ip").
+			SetValue("1.2.3.4").
+			SetOrigin("test").
+			Save(ctx)
+		require.NoError(t, err)
+
+		lastID = d.ID
+	}
+
+	latest, err = c.LatestDecisionID(ctx)
+	require.NoError(t, err)
+	require.Equal(t, lastID, latest)
+
+	// deleting the newest rows rewinds the cursor, but ids are never reused
+	_, err = c.Ent.Decision.Delete().Exec(ctx)
+	require.NoError(t, err)
+
+	latest, err = c.LatestDecisionID(ctx)
+	require.NoError(t, err)
+	require.Zero(t, latest)
+
+	d, err := c.Ent.Decision.Create().
+		SetUntil(time.Now().UTC().Add(time.Hour)).
+		SetScenario("test").
+		SetType("ban").
+		SetScope("Ip").
+		SetValue("1.2.3.5").
+		SetOrigin("test").
+		Save(ctx)
+	require.NoError(t, err)
+	require.Greater(t, d.ID, lastID, "decision ids must keep climbing across deletes")
+}

--- a/pkg/database/ent/bouncer.go
+++ b/pkg/database/ent/bouncer.go
@@ -35,6 +35,8 @@ type Bouncer struct {
 	Version string `json:"version"`
 	// LastPull holds the value of the "last_pull" field.
 	LastPull *time.Time `json:"last_pull"`
+	// StreamCursor holds the value of the "stream_cursor" field.
+	StreamCursor int `json:"stream_cursor,omitempty"`
 	// AuthType holds the value of the "auth_type" field.
 	AuthType string `json:"auth_type"`
 	// Osname holds the value of the "osname" field.
@@ -57,7 +59,7 @@ func (*Bouncer) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case bouncer.FieldRevoked, bouncer.FieldAutoCreated:
 			values[i] = new(sql.NullBool)
-		case bouncer.FieldID:
+		case bouncer.FieldID, bouncer.FieldStreamCursor:
 			values[i] = new(sql.NullInt64)
 		case bouncer.FieldName, bouncer.FieldAPIKey, bouncer.FieldIPAddress, bouncer.FieldType, bouncer.FieldVersion, bouncer.FieldAuthType, bouncer.FieldOsname, bouncer.FieldOsfamily, bouncer.FieldOsversion, bouncer.FieldFeatureflags:
 			values[i] = new(sql.NullString)
@@ -138,6 +140,12 @@ func (_m *Bouncer) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.LastPull = new(time.Time)
 				*_m.LastPull = value.Time
+			}
+		case bouncer.FieldStreamCursor:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field stream_cursor", values[i])
+			} else if value.Valid {
+				_m.StreamCursor = int(value.Int64)
 			}
 		case bouncer.FieldAuthType:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -238,6 +246,9 @@ func (_m *Bouncer) String() string {
 		builder.WriteString("last_pull=")
 		builder.WriteString(v.Format(time.ANSIC))
 	}
+	builder.WriteString(", ")
+	builder.WriteString("stream_cursor=")
+	builder.WriteString(fmt.Sprintf("%v", _m.StreamCursor))
 	builder.WriteString(", ")
 	builder.WriteString("auth_type=")
 	builder.WriteString(_m.AuthType)

--- a/pkg/database/ent/bouncer/bouncer.go
+++ b/pkg/database/ent/bouncer/bouncer.go
@@ -31,6 +31,8 @@ const (
 	FieldVersion = "version"
 	// FieldLastPull holds the string denoting the last_pull field in the database.
 	FieldLastPull = "last_pull"
+	// FieldStreamCursor holds the string denoting the stream_cursor field in the database.
+	FieldStreamCursor = "stream_cursor"
 	// FieldAuthType holds the string denoting the auth_type field in the database.
 	FieldAuthType = "auth_type"
 	// FieldOsname holds the string denoting the osname field in the database.
@@ -59,6 +61,7 @@ var Columns = []string{
 	FieldType,
 	FieldVersion,
 	FieldLastPull,
+	FieldStreamCursor,
 	FieldAuthType,
 	FieldOsname,
 	FieldOsfamily,
@@ -86,6 +89,8 @@ var (
 	UpdateDefaultUpdatedAt func() time.Time
 	// DefaultIPAddress holds the default value on creation for the "ip_address" field.
 	DefaultIPAddress string
+	// DefaultStreamCursor holds the default value on creation for the "stream_cursor" field.
+	DefaultStreamCursor int
 	// DefaultAuthType holds the default value on creation for the "auth_type" field.
 	DefaultAuthType string
 	// DefaultAutoCreated holds the default value on creation for the "auto_created" field.
@@ -143,6 +148,11 @@ func ByVersion(opts ...sql.OrderTermOption) OrderOption {
 // ByLastPull orders the results by the last_pull field.
 func ByLastPull(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLastPull, opts...).ToFunc()
+}
+
+// ByStreamCursor orders the results by the stream_cursor field.
+func ByStreamCursor(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldStreamCursor, opts...).ToFunc()
 }
 
 // ByAuthType orders the results by the auth_type field.

--- a/pkg/database/ent/bouncer/where.go
+++ b/pkg/database/ent/bouncer/where.go
@@ -99,6 +99,11 @@ func LastPull(v time.Time) predicate.Bouncer {
 	return predicate.Bouncer(sql.FieldEQ(FieldLastPull, v))
 }
 
+// StreamCursor applies equality check predicate on the "stream_cursor" field. It's identical to StreamCursorEQ.
+func StreamCursor(v int) predicate.Bouncer {
+	return predicate.Bouncer(sql.FieldEQ(FieldStreamCursor, v))
+}
+
 // AuthType applies equality check predicate on the "auth_type" field. It's identical to AuthTypeEQ.
 func AuthType(v string) predicate.Bouncer {
 	return predicate.Bouncer(sql.FieldEQ(FieldAuthType, v))
@@ -622,6 +627,46 @@ func LastPullIsNil() predicate.Bouncer {
 // LastPullNotNil applies the NotNil predicate on the "last_pull" field.
 func LastPullNotNil() predicate.Bouncer {
 	return predicate.Bouncer(sql.FieldNotNull(FieldLastPull))
+}
+
+// StreamCursorEQ applies the EQ predicate on the "stream_cursor" field.
+func StreamCursorEQ(v int) predicate.Bouncer {
+	return predicate.Bouncer(sql.FieldEQ(FieldStreamCursor, v))
+}
+
+// StreamCursorNEQ applies the NEQ predicate on the "stream_cursor" field.
+func StreamCursorNEQ(v int) predicate.Bouncer {
+	return predicate.Bouncer(sql.FieldNEQ(FieldStreamCursor, v))
+}
+
+// StreamCursorIn applies the In predicate on the "stream_cursor" field.
+func StreamCursorIn(vs ...int) predicate.Bouncer {
+	return predicate.Bouncer(sql.FieldIn(FieldStreamCursor, vs...))
+}
+
+// StreamCursorNotIn applies the NotIn predicate on the "stream_cursor" field.
+func StreamCursorNotIn(vs ...int) predicate.Bouncer {
+	return predicate.Bouncer(sql.FieldNotIn(FieldStreamCursor, vs...))
+}
+
+// StreamCursorGT applies the GT predicate on the "stream_cursor" field.
+func StreamCursorGT(v int) predicate.Bouncer {
+	return predicate.Bouncer(sql.FieldGT(FieldStreamCursor, v))
+}
+
+// StreamCursorGTE applies the GTE predicate on the "stream_cursor" field.
+func StreamCursorGTE(v int) predicate.Bouncer {
+	return predicate.Bouncer(sql.FieldGTE(FieldStreamCursor, v))
+}
+
+// StreamCursorLT applies the LT predicate on the "stream_cursor" field.
+func StreamCursorLT(v int) predicate.Bouncer {
+	return predicate.Bouncer(sql.FieldLT(FieldStreamCursor, v))
+}
+
+// StreamCursorLTE applies the LTE predicate on the "stream_cursor" field.
+func StreamCursorLTE(v int) predicate.Bouncer {
+	return predicate.Bouncer(sql.FieldLTE(FieldStreamCursor, v))
 }
 
 // AuthTypeEQ applies the EQ predicate on the "auth_type" field.

--- a/pkg/database/ent/bouncer_create.go
+++ b/pkg/database/ent/bouncer_create.go
@@ -124,6 +124,20 @@ func (_c *BouncerCreate) SetNillableLastPull(v *time.Time) *BouncerCreate {
 	return _c
 }
 
+// SetStreamCursor sets the "stream_cursor" field.
+func (_c *BouncerCreate) SetStreamCursor(v int) *BouncerCreate {
+	_c.mutation.SetStreamCursor(v)
+	return _c
+}
+
+// SetNillableStreamCursor sets the "stream_cursor" field if the given value is not nil.
+func (_c *BouncerCreate) SetNillableStreamCursor(v *int) *BouncerCreate {
+	if v != nil {
+		_c.SetStreamCursor(*v)
+	}
+	return _c
+}
+
 // SetAuthType sets the "auth_type" field.
 func (_c *BouncerCreate) SetAuthType(v string) *BouncerCreate {
 	_c.mutation.SetAuthType(v)
@@ -255,6 +269,10 @@ func (_c *BouncerCreate) defaults() {
 		v := bouncer.DefaultIPAddress
 		_c.mutation.SetIPAddress(v)
 	}
+	if _, ok := _c.mutation.StreamCursor(); !ok {
+		v := bouncer.DefaultStreamCursor
+		_c.mutation.SetStreamCursor(v)
+	}
 	if _, ok := _c.mutation.AuthType(); !ok {
 		v := bouncer.DefaultAuthType
 		_c.mutation.SetAuthType(v)
@@ -281,6 +299,9 @@ func (_c *BouncerCreate) check() error {
 	}
 	if _, ok := _c.mutation.Revoked(); !ok {
 		return &ValidationError{Name: "revoked", err: errors.New(`ent: missing required field "Bouncer.revoked"`)}
+	}
+	if _, ok := _c.mutation.StreamCursor(); !ok {
+		return &ValidationError{Name: "stream_cursor", err: errors.New(`ent: missing required field "Bouncer.stream_cursor"`)}
 	}
 	if _, ok := _c.mutation.AuthType(); !ok {
 		return &ValidationError{Name: "auth_type", err: errors.New(`ent: missing required field "Bouncer.auth_type"`)}
@@ -350,6 +371,10 @@ func (_c *BouncerCreate) createSpec() (*Bouncer, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.LastPull(); ok {
 		_spec.SetField(bouncer.FieldLastPull, field.TypeTime, value)
 		_node.LastPull = &value
+	}
+	if value, ok := _c.mutation.StreamCursor(); ok {
+		_spec.SetField(bouncer.FieldStreamCursor, field.TypeInt, value)
+		_node.StreamCursor = value
 	}
 	if value, ok := _c.mutation.AuthType(); ok {
 		_spec.SetField(bouncer.FieldAuthType, field.TypeString, value)
@@ -532,6 +557,24 @@ func (u *BouncerUpsert) UpdateLastPull() *BouncerUpsert {
 // ClearLastPull clears the value of the "last_pull" field.
 func (u *BouncerUpsert) ClearLastPull() *BouncerUpsert {
 	u.SetNull(bouncer.FieldLastPull)
+	return u
+}
+
+// SetStreamCursor sets the "stream_cursor" field.
+func (u *BouncerUpsert) SetStreamCursor(v int) *BouncerUpsert {
+	u.Set(bouncer.FieldStreamCursor, v)
+	return u
+}
+
+// UpdateStreamCursor sets the "stream_cursor" field to the value that was provided on create.
+func (u *BouncerUpsert) UpdateStreamCursor() *BouncerUpsert {
+	u.SetExcluded(bouncer.FieldStreamCursor)
+	return u
+}
+
+// AddStreamCursor adds v to the "stream_cursor" field.
+func (u *BouncerUpsert) AddStreamCursor(v int) *BouncerUpsert {
+	u.Add(bouncer.FieldStreamCursor, v)
 	return u
 }
 
@@ -793,6 +836,27 @@ func (u *BouncerUpsertOne) UpdateLastPull() *BouncerUpsertOne {
 func (u *BouncerUpsertOne) ClearLastPull() *BouncerUpsertOne {
 	return u.Update(func(s *BouncerUpsert) {
 		s.ClearLastPull()
+	})
+}
+
+// SetStreamCursor sets the "stream_cursor" field.
+func (u *BouncerUpsertOne) SetStreamCursor(v int) *BouncerUpsertOne {
+	return u.Update(func(s *BouncerUpsert) {
+		s.SetStreamCursor(v)
+	})
+}
+
+// AddStreamCursor adds v to the "stream_cursor" field.
+func (u *BouncerUpsertOne) AddStreamCursor(v int) *BouncerUpsertOne {
+	return u.Update(func(s *BouncerUpsert) {
+		s.AddStreamCursor(v)
+	})
+}
+
+// UpdateStreamCursor sets the "stream_cursor" field to the value that was provided on create.
+func (u *BouncerUpsertOne) UpdateStreamCursor() *BouncerUpsertOne {
+	return u.Update(func(s *BouncerUpsert) {
+		s.UpdateStreamCursor()
 	})
 }
 
@@ -1234,6 +1298,27 @@ func (u *BouncerUpsertBulk) UpdateLastPull() *BouncerUpsertBulk {
 func (u *BouncerUpsertBulk) ClearLastPull() *BouncerUpsertBulk {
 	return u.Update(func(s *BouncerUpsert) {
 		s.ClearLastPull()
+	})
+}
+
+// SetStreamCursor sets the "stream_cursor" field.
+func (u *BouncerUpsertBulk) SetStreamCursor(v int) *BouncerUpsertBulk {
+	return u.Update(func(s *BouncerUpsert) {
+		s.SetStreamCursor(v)
+	})
+}
+
+// AddStreamCursor adds v to the "stream_cursor" field.
+func (u *BouncerUpsertBulk) AddStreamCursor(v int) *BouncerUpsertBulk {
+	return u.Update(func(s *BouncerUpsert) {
+		s.AddStreamCursor(v)
+	})
+}
+
+// UpdateStreamCursor sets the "stream_cursor" field to the value that was provided on create.
+func (u *BouncerUpsertBulk) UpdateStreamCursor() *BouncerUpsertBulk {
+	return u.Update(func(s *BouncerUpsert) {
+		s.UpdateStreamCursor()
 	})
 }
 

--- a/pkg/database/ent/bouncer_update.go
+++ b/pkg/database/ent/bouncer_update.go
@@ -142,6 +142,27 @@ func (_u *BouncerUpdate) ClearLastPull() *BouncerUpdate {
 	return _u
 }
 
+// SetStreamCursor sets the "stream_cursor" field.
+func (_u *BouncerUpdate) SetStreamCursor(v int) *BouncerUpdate {
+	_u.mutation.ResetStreamCursor()
+	_u.mutation.SetStreamCursor(v)
+	return _u
+}
+
+// SetNillableStreamCursor sets the "stream_cursor" field if the given value is not nil.
+func (_u *BouncerUpdate) SetNillableStreamCursor(v *int) *BouncerUpdate {
+	if v != nil {
+		_u.SetStreamCursor(*v)
+	}
+	return _u
+}
+
+// AddStreamCursor adds value to the "stream_cursor" field.
+func (_u *BouncerUpdate) AddStreamCursor(v int) *BouncerUpdate {
+	_u.mutation.AddStreamCursor(v)
+	return _u
+}
+
 // SetAuthType sets the "auth_type" field.
 func (_u *BouncerUpdate) SetAuthType(v string) *BouncerUpdate {
 	_u.mutation.SetAuthType(v)
@@ -319,6 +340,12 @@ func (_u *BouncerUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if _u.mutation.LastPullCleared() {
 		_spec.ClearField(bouncer.FieldLastPull, field.TypeTime)
 	}
+	if value, ok := _u.mutation.StreamCursor(); ok {
+		_spec.SetField(bouncer.FieldStreamCursor, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedStreamCursor(); ok {
+		_spec.AddField(bouncer.FieldStreamCursor, field.TypeInt, value)
+	}
 	if value, ok := _u.mutation.AuthType(); ok {
 		_spec.SetField(bouncer.FieldAuthType, field.TypeString, value)
 	}
@@ -477,6 +504,27 @@ func (_u *BouncerUpdateOne) SetNillableLastPull(v *time.Time) *BouncerUpdateOne 
 // ClearLastPull clears the value of the "last_pull" field.
 func (_u *BouncerUpdateOne) ClearLastPull() *BouncerUpdateOne {
 	_u.mutation.ClearLastPull()
+	return _u
+}
+
+// SetStreamCursor sets the "stream_cursor" field.
+func (_u *BouncerUpdateOne) SetStreamCursor(v int) *BouncerUpdateOne {
+	_u.mutation.ResetStreamCursor()
+	_u.mutation.SetStreamCursor(v)
+	return _u
+}
+
+// SetNillableStreamCursor sets the "stream_cursor" field if the given value is not nil.
+func (_u *BouncerUpdateOne) SetNillableStreamCursor(v *int) *BouncerUpdateOne {
+	if v != nil {
+		_u.SetStreamCursor(*v)
+	}
+	return _u
+}
+
+// AddStreamCursor adds value to the "stream_cursor" field.
+func (_u *BouncerUpdateOne) AddStreamCursor(v int) *BouncerUpdateOne {
+	_u.mutation.AddStreamCursor(v)
 	return _u
 }
 
@@ -686,6 +734,12 @@ func (_u *BouncerUpdateOne) sqlSave(ctx context.Context) (_node *Bouncer, err er
 	}
 	if _u.mutation.LastPullCleared() {
 		_spec.ClearField(bouncer.FieldLastPull, field.TypeTime)
+	}
+	if value, ok := _u.mutation.StreamCursor(); ok {
+		_spec.SetField(bouncer.FieldStreamCursor, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedStreamCursor(); ok {
+		_spec.AddField(bouncer.FieldStreamCursor, field.TypeInt, value)
 	}
 	if value, ok := _u.mutation.AuthType(); ok {
 		_spec.SetField(bouncer.FieldAuthType, field.TypeString, value)

--- a/pkg/database/ent/migrate/schema.go
+++ b/pkg/database/ent/migrate/schema.go
@@ -151,6 +151,7 @@ var (
 		{Name: "type", Type: field.TypeString, Nullable: true},
 		{Name: "version", Type: field.TypeString, Nullable: true},
 		{Name: "last_pull", Type: field.TypeTime, Nullable: true},
+		{Name: "stream_cursor", Type: field.TypeInt, Default: 0},
 		{Name: "auth_type", Type: field.TypeString, Default: "api-key"},
 		{Name: "osname", Type: field.TypeString, Nullable: true},
 		{Name: "osfamily", Type: field.TypeString, Nullable: true},
@@ -167,7 +168,7 @@ var (
 			{
 				Name:    "bouncer_api_key_auth_type",
 				Unique:  false,
-				Columns: []*schema.Column{BouncersColumns[4], BouncersColumns[10]},
+				Columns: []*schema.Column{BouncersColumns[4], BouncersColumns[11]},
 			},
 			{
 				Name:    "bouncer_api_key_ip_address",

--- a/pkg/database/ent/mutation.go
+++ b/pkg/database/ent/mutation.go
@@ -4476,28 +4476,30 @@ func (m *AllowListItemMutation) ResetEdge(name string) error {
 // BouncerMutation represents an operation that mutates the Bouncer nodes in the graph.
 type BouncerMutation struct {
 	config
-	op            Op
-	typ           string
-	id            *int
-	created_at    *time.Time
-	updated_at    *time.Time
-	name          *string
-	api_key       *string
-	revoked       *bool
-	ip_address    *string
-	_type         *string
-	version       *string
-	last_pull     *time.Time
-	auth_type     *string
-	osname        *string
-	osfamily      *string
-	osversion     *string
-	featureflags  *string
-	auto_created  *bool
-	clearedFields map[string]struct{}
-	done          bool
-	oldValue      func(context.Context) (*Bouncer, error)
-	predicates    []predicate.Bouncer
+	op               Op
+	typ              string
+	id               *int
+	created_at       *time.Time
+	updated_at       *time.Time
+	name             *string
+	api_key          *string
+	revoked          *bool
+	ip_address       *string
+	_type            *string
+	version          *string
+	last_pull        *time.Time
+	stream_cursor    *int
+	addstream_cursor *int
+	auth_type        *string
+	osname           *string
+	osfamily         *string
+	osversion        *string
+	featureflags     *string
+	auto_created     *bool
+	clearedFields    map[string]struct{}
+	done             bool
+	oldValue         func(context.Context) (*Bouncer, error)
+	predicates       []predicate.Bouncer
 }
 
 var _ ent.Mutation = (*BouncerMutation)(nil)
@@ -4974,6 +4976,62 @@ func (m *BouncerMutation) ResetLastPull() {
 	delete(m.clearedFields, bouncer.FieldLastPull)
 }
 
+// SetStreamCursor sets the "stream_cursor" field.
+func (m *BouncerMutation) SetStreamCursor(i int) {
+	m.stream_cursor = &i
+	m.addstream_cursor = nil
+}
+
+// StreamCursor returns the value of the "stream_cursor" field in the mutation.
+func (m *BouncerMutation) StreamCursor() (r int, exists bool) {
+	v := m.stream_cursor
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldStreamCursor returns the old "stream_cursor" field's value of the Bouncer entity.
+// If the Bouncer object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BouncerMutation) OldStreamCursor(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldStreamCursor is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldStreamCursor requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldStreamCursor: %w", err)
+	}
+	return oldValue.StreamCursor, nil
+}
+
+// AddStreamCursor adds i to the "stream_cursor" field.
+func (m *BouncerMutation) AddStreamCursor(i int) {
+	if m.addstream_cursor != nil {
+		*m.addstream_cursor += i
+	} else {
+		m.addstream_cursor = &i
+	}
+}
+
+// AddedStreamCursor returns the value that was added to the "stream_cursor" field in this mutation.
+func (m *BouncerMutation) AddedStreamCursor() (r int, exists bool) {
+	v := m.addstream_cursor
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetStreamCursor resets all changes to the "stream_cursor" field.
+func (m *BouncerMutation) ResetStreamCursor() {
+	m.stream_cursor = nil
+	m.addstream_cursor = nil
+}
+
 // SetAuthType sets the "auth_type" field.
 func (m *BouncerMutation) SetAuthType(s string) {
 	m.auth_type = &s
@@ -5276,7 +5334,7 @@ func (m *BouncerMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *BouncerMutation) Fields() []string {
-	fields := make([]string, 0, 15)
+	fields := make([]string, 0, 16)
 	if m.created_at != nil {
 		fields = append(fields, bouncer.FieldCreatedAt)
 	}
@@ -5303,6 +5361,9 @@ func (m *BouncerMutation) Fields() []string {
 	}
 	if m.last_pull != nil {
 		fields = append(fields, bouncer.FieldLastPull)
+	}
+	if m.stream_cursor != nil {
+		fields = append(fields, bouncer.FieldStreamCursor)
 	}
 	if m.auth_type != nil {
 		fields = append(fields, bouncer.FieldAuthType)
@@ -5348,6 +5409,8 @@ func (m *BouncerMutation) Field(name string) (ent.Value, bool) {
 		return m.Version()
 	case bouncer.FieldLastPull:
 		return m.LastPull()
+	case bouncer.FieldStreamCursor:
+		return m.StreamCursor()
 	case bouncer.FieldAuthType:
 		return m.AuthType()
 	case bouncer.FieldOsname:
@@ -5387,6 +5450,8 @@ func (m *BouncerMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldVersion(ctx)
 	case bouncer.FieldLastPull:
 		return m.OldLastPull(ctx)
+	case bouncer.FieldStreamCursor:
+		return m.OldStreamCursor(ctx)
 	case bouncer.FieldAuthType:
 		return m.OldAuthType(ctx)
 	case bouncer.FieldOsname:
@@ -5471,6 +5536,13 @@ func (m *BouncerMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetLastPull(v)
 		return nil
+	case bouncer.FieldStreamCursor:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetStreamCursor(v)
+		return nil
 	case bouncer.FieldAuthType:
 		v, ok := value.(string)
 		if !ok {
@@ -5520,13 +5592,21 @@ func (m *BouncerMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *BouncerMutation) AddedFields() []string {
-	return nil
+	var fields []string
+	if m.addstream_cursor != nil {
+		fields = append(fields, bouncer.FieldStreamCursor)
+	}
+	return fields
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *BouncerMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	case bouncer.FieldStreamCursor:
+		return m.AddedStreamCursor()
+	}
 	return nil, false
 }
 
@@ -5535,6 +5615,13 @@ func (m *BouncerMutation) AddedField(name string) (ent.Value, bool) {
 // type.
 func (m *BouncerMutation) AddField(name string, value ent.Value) error {
 	switch name {
+	case bouncer.FieldStreamCursor:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddStreamCursor(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Bouncer numeric field %s", name)
 }
@@ -5639,6 +5726,9 @@ func (m *BouncerMutation) ResetField(name string) error {
 		return nil
 	case bouncer.FieldLastPull:
 		m.ResetLastPull()
+		return nil
+	case bouncer.FieldStreamCursor:
+		m.ResetStreamCursor()
 		return nil
 	case bouncer.FieldAuthType:
 		m.ResetAuthType()

--- a/pkg/database/ent/runtime.go
+++ b/pkg/database/ent/runtime.go
@@ -98,12 +98,16 @@ func init() {
 	bouncerDescIPAddress := bouncerFields[5].Descriptor()
 	// bouncer.DefaultIPAddress holds the default value on creation for the ip_address field.
 	bouncer.DefaultIPAddress = bouncerDescIPAddress.Default.(string)
+	// bouncerDescStreamCursor is the schema descriptor for stream_cursor field.
+	bouncerDescStreamCursor := bouncerFields[9].Descriptor()
+	// bouncer.DefaultStreamCursor holds the default value on creation for the stream_cursor field.
+	bouncer.DefaultStreamCursor = bouncerDescStreamCursor.Default.(int)
 	// bouncerDescAuthType is the schema descriptor for auth_type field.
-	bouncerDescAuthType := bouncerFields[9].Descriptor()
+	bouncerDescAuthType := bouncerFields[10].Descriptor()
 	// bouncer.DefaultAuthType holds the default value on creation for the auth_type field.
 	bouncer.DefaultAuthType = bouncerDescAuthType.Default.(string)
 	// bouncerDescAutoCreated is the schema descriptor for auto_created field.
-	bouncerDescAutoCreated := bouncerFields[14].Descriptor()
+	bouncerDescAutoCreated := bouncerFields[15].Descriptor()
 	// bouncer.DefaultAutoCreated holds the default value on creation for the auto_created field.
 	bouncer.DefaultAutoCreated = bouncerDescAutoCreated.Default.(bool)
 	configitemFields := schema.ConfigItem{}.Fields()

--- a/pkg/database/ent/schema/bouncer.go
+++ b/pkg/database/ent/schema/bouncer.go
@@ -30,6 +30,10 @@ func (Bouncer) Fields() []ent.Field {
 		field.String("type").Optional().StructTag(`json:"type"`),
 		field.String("version").Optional().StructTag(`json:"version"`),
 		field.Time("last_pull").Nillable().Optional().StructTag(`json:"last_pull"`),
+		// Highest decision id already streamed to this bouncer. Distinct from last_pull,
+		// which is a wall clock heartbeat: a decision can commit after a pull that could
+		// not see it yet, so a timestamp can never be a safe cursor.
+		field.Int("stream_cursor").Default(0),
 		field.String("auth_type").StructTag(`json:"auth_type"`).Default(types.ApiKeyAuthType),
 		field.String("osname").Optional(),
 		field.String("osfamily").Optional(),


### PR DESCRIPTION
We currently use the timestamp of the last pull from a bouncer to compute the delta that needs to be sent on a refresh.

A blocklist import sets `created_at` inside a transaction, so a pull while that transaction is still open uses a pre-commit snapshot, sends nothing, and still advances `last_pull` past rows that have not committed yet, meaning the bouncer will never receive them.

Adds `bouncers.stream_cursor`, the highest decision id visible when the request starts reading, and makes the delta `id > cursor`. Anything not yet visible belongs to an uncommitted transaction and will get a higher id, so the cursor cannot step over it .

The delta and startup queries collapse into one — a startup resync is the same query with a zero cursor. `QueryNewDecisionsSinceWithFilters` and the `created_at` predicate are removed.

`stream_cursor` defaults to 0, so every existing bouncer receives one full set of active decisions on its first pull after upgrade, then runs on the cursor.

We keep the timestamp method for deletion, as there are not order guarantee (insertion order is not always the same as expiration order, and a user can delete any decision at any time).

Fixes crowdsecurity/cs-firewall-bouncer#508.
