### PR TITLE
fix: [email_notifications] email notifications fail when running in rootless ...

### DIFF
--- a/pkg/csplugin/utils.go
+++ b/pkg/csplugin/utils.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"math"
 	"os"
 	"os/exec"
@@ -18,6 +17,8 @@ import (
 
 	"golang.org/x/sys/unix"
 )
+
+const rootUID = 0
 
 func (pb *PluginBroker) CreateCmd(ctx context.Context, binaryPath string) (*exec.Cmd, error) {
 	var err error
@@ -93,26 +94,29 @@ func getProcessAttr(username string, groupname string) (*unix.SysProcAttr, error
 }
 
 func pluginIsValid(path string) error {
-	var details fs.FileInfo
-	var err error
-
-	// check if it exists
-	if details, err = os.Stat(path); err != nil {
-		return fmt.Errorf("plugin at %s does not exist: %w", path, err)
-	}
-
-	// check if it is owned by current user
 	currentUser, err := user.Current()
 	if err != nil {
 		return fmt.Errorf("while getting current user: %w", err)
 	}
-	currentUID, err := getUID(currentUser.Username)
+
+	return pluginIsValidForUser(path, currentUser)
+}
+
+func pluginIsValidForUser(path string, u *user.User) error {
+	// check if it exists
+	details, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("while looking up the current uid: %w", err)
+		return fmt.Errorf("plugin at %s does not exist: %w", path, err)
 	}
+
+	uid, err := strconv.ParseUint(u.Uid, 10, 32)
+	if err != nil {
+		return fmt.Errorf("while parsing the uid of user '%s': %w", u.Username, err)
+	}
+
 	stat := details.Sys().(*syscall.Stat_t)
-	if stat.Uid != currentUID {
-		return fmt.Errorf("plugin at %s is not owned by user '%s'", path, currentUser.Username)
+	if stat.Uid != uint32(uid) && stat.Uid != rootUID {
+		return fmt.Errorf("plugin at %s is not owned by root or by the current user '%s', but by uid %d", path, u.Username, stat.Uid)
 	}
 
 	mode := details.Mode()

--- a/pkg/csplugin/utils_test.go
+++ b/pkg/csplugin/utils_test.go
@@ -1,11 +1,16 @@
-//go:build linux || freebsd || netbsd || openbsd || solaris || !windows
+//go:build linux || freebsd || netbsd || openbsd || solaris || (!windows && !js)
 
 package csplugin
 
 import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/crowdsecurity/go-cs-lib/cstest"
 )
@@ -43,6 +48,111 @@ func TestGetPluginNameAndTypeFromPath(t *testing.T) {
 
 			assert.Equal(t, tc.want, got)
 			assert.Equal(t, tc.want1, got1)
+		})
+	}
+}
+
+func writePlugin(t *testing.T, dir string, name string, mode os.FileMode) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"), mode))
+	require.NoError(t, os.Chmod(path, mode))
+
+	return path
+}
+
+func rootOwnedPlugin(t *testing.T, dir string) (string, bool) {
+	t.Helper()
+
+	if os.Geteuid() == rootUID {
+		return writePlugin(t, dir, "notification-root", 0o755), true
+	}
+
+	for _, candidate := range []string{"/bin/true", "/usr/bin/env"} {
+		details, err := os.Stat(candidate)
+		if err != nil {
+			continue
+		}
+
+		if details.Sys().(*syscall.Stat_t).Uid == rootUID && details.Mode().Perm()&0o022 == 0 {
+			return candidate, true
+		}
+	}
+
+	return "", false
+}
+
+func skipUnless(cond bool, reason string) string {
+	if cond {
+		return ""
+	}
+
+	return reason
+}
+
+func TestPluginIsValidForUser(t *testing.T) {
+	dir := t.TempDir()
+
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	otherUser := &user.User{Uid: "12345", Username: "not-the-current-user"}
+
+	rootPath, hasRootPath := rootOwnedPlugin(t, dir)
+
+	tests := []struct {
+		name        string
+		path        string
+		user        *user.User
+		expectedErr string
+		skip        string
+	}{
+		{
+			name: "owned by the current user",
+			path: writePlugin(t, dir, "notification-mine", 0o755),
+			user: currentUser,
+		},
+		{
+			name: "owned by root, running as another user",
+			path: rootPath,
+			user: otherUser,
+			skip: skipUnless(hasRootPath, "no root-owned executable available"),
+		},
+		{
+			name:        "owned by neither the current user nor root",
+			path:        writePlugin(t, dir, "notification-foreign", 0o755),
+			user:        otherUser,
+			expectedErr: "is not owned by root or by the current user 'not-the-current-user'",
+			skip:        skipUnless(os.Geteuid() != rootUID, "running as root, new files are root-owned"),
+		},
+		{
+			name:        "world writable",
+			path:        writePlugin(t, dir, "notification-world", 0o757),
+			user:        currentUser,
+			expectedErr: "is world writable, world writable plugins are invalid",
+		},
+		{
+			name:        "group writable",
+			path:        writePlugin(t, dir, "notification-group", 0o775),
+			user:        currentUser,
+			expectedErr: "is group writable, group writable plugins are invalid",
+		},
+		{
+			name:        "does not exist",
+			path:        filepath.Join(dir, "notification-missing"),
+			user:        currentUser,
+			expectedErr: "does not exist",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.skip != "" {
+				t.Skip(tc.skip)
+			}
+
+			cstest.RequireErrorContains(t, pluginIsValidForUser(tc.path, tc.user), tc.expectedErr)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #3832

## Root cause

Plugin ownership check requires the plugin binary to be owned by the process user, rejecting root-owned plugins

## Changes

- pluginIsValid now accepts a plugin owned by root in addition to the current user (root-owned, non group/world-writable binaries cannot be tampered with by the unprivileged crowdsec user), matching the Windows check which already allows SYSTEM/Administrators or the current user. Ownership logic was split into pluginIsValidForUser for testability, the uid is taken from user.Current() instead of a second NSS lookup by name, and the error message now reports the actual owner uid. Added a table-driven regression test.