### PR TITLE
fix: lookup www.arvancloud.ir on 192.168.1.254:53: no such host

### DIFF
--- a/pkg/hubops/datarefresh.go
+++ b/pkg/hubops/datarefresh.go
@@ -2,6 +2,7 @@ package hubops
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -43,18 +44,26 @@ func (*DataRefreshCommand) Prepare(_ *ActionPlan) (bool, error) {
 }
 
 func (c *DataRefreshCommand) Run(ctx context.Context, plan *ActionPlan) error {
+	var errs []error
+
 	for _, itemType := range cwhub.ItemTypes {
 		for _, item := range plan.hub.GetInstalledByType(itemType, true) {
+			if err := ctx.Err(); err != nil {
+				errs = append(errs, err)
+
+				return errors.Join(errs...)
+			}
+
 			needReload, err := DownloadDataIfNeeded(ctx, plan.hub, item, c.Force)
 			if err != nil {
-				return err
+				errs = append(errs, err)
 			}
 
 			plan.ReloadNeeded = plan.ReloadNeeded || needReload
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (*DataRefreshCommand) OperationType() string {

--- a/pkg/hubops/download.go
+++ b/pkg/hubops/download.go
@@ -101,6 +101,8 @@ type DataSet struct {
 func downloadDataSet(ctx context.Context, dataFolder string, force bool, reader io.Reader) (bool, error) {
 	needReload := false
 
+	var errs []error
+
 	dec := yaml.NewDecoder(reader)
 
 	for {
@@ -111,7 +113,9 @@ func downloadDataSet(ctx context.Context, dataFolder string, force bool, reader 
 				break
 			}
 
-			return needReload, fmt.Errorf("while reading file: %w", err)
+			errs = append(errs, fmt.Errorf("while reading file: %w", err))
+
+			break
 		}
 
 		for _, dataS := range data.Data {
@@ -119,17 +123,31 @@ func downloadDataSet(ctx context.Context, dataFolder string, force bool, reader 
 				continue
 			}
 
-			// twopenny validation
-			if u, err := url.Parse(dataS.SourceURL); err != nil {
-				return false, err
-			} else if u.Scheme == "" {
-				return false, fmt.Errorf("a valid URL was expected (note: local items can download data too): %s", dataS.SourceURL)
+			if err := ctx.Err(); err != nil {
+				errs = append(errs, err)
+
+				return needReload, errors.Join(errs...)
 			}
 
-			// XXX: check context cancellation
+			// twopenny validation
+			u, err := url.Parse(dataS.SourceURL)
+			if err != nil {
+				errs = append(errs, err)
+
+				continue
+			}
+
+			if u.Scheme == "" {
+				errs = append(errs, fmt.Errorf("a valid URL was expected (note: local items can download data too): %s", dataS.SourceURL))
+
+				continue
+			}
+
 			destPath, err := cwhub.SafePath(dataFolder, dataS.DestPath)
 			if err != nil {
-				return needReload, err
+				errs = append(errs, err)
+
+				continue
 			}
 
 			d := downloader.
@@ -150,14 +168,16 @@ func downloadDataSet(ctx context.Context, dataFolder string, force bool, reader 
 
 			downloaded, err := d.Download(ctx, dataS.SourceURL)
 			if err != nil {
-				return needReload, fmt.Errorf("while getting data: %w", err)
+				errs = append(errs, fmt.Errorf("while getting data: %w", err))
+
+				continue
 			}
 
 			needReload = needReload || downloaded
 		}
 	}
 
-	return needReload, nil
+	return needReload, errors.Join(errs...)
 }
 
 func (c *DownloadCommand) Run(ctx context.Context, plan *ActionPlan) error {


### PR DESCRIPTION
Fixes #4436

## Root cause

hub upgrade aborts on first failing third-party data source

## Changes

- downloadDataSet and DataRefreshCommand.Run now collect errors and keep going instead of returning on the first failure (still returning a joined error, so the exit code and messages are unchanged), aborting early only if the context is canceled. Added pkg/hubops/download_test.go covering that a failing/invalid data source no longer skips the following ones.