### PR TITLE
Usage metrics: set a maximum payload size

### DIFF
--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -54,6 +54,7 @@ type apic struct {
 	metricsIntervalFirst      time.Duration
 	usageMetricsInterval      time.Duration
 	usageMetricsIntervalFirst time.Duration
+	usageMetricsBatchBytes    int
 	dbClient                  *database.Client
 	apiClient                 *apiclient.ApiClient
 	AlertsAddChan             chan []*models.Alert
@@ -210,6 +211,7 @@ func NewAPIC(ctx context.Context, config *csconfig.OnlineApiClientCfg, dbClient 
 		metricsIntervalFirst:      randomDuration(metricsIntervalDefault, metricsIntervalDelta),
 		usageMetricsInterval:      usageMetricsInterval,
 		usageMetricsIntervalFirst: randomDuration(usageMetricsInterval, usageMetricsIntervalDelta),
+		usageMetricsBatchBytes:    usageMetricsBatchBytes,
 		isPulling:                 make(chan bool, 1),
 		whitelists:                apicWhitelist,
 		pullBlocklists:            *config.PullConfig.Blocklists,

--- a/pkg/apiserver/apic_metrics.go
+++ b/pkg/apiserver/apic_metrics.go
@@ -335,8 +335,6 @@ func (a *apic) pushUsageMetrics(ctx context.Context) {
 		rcs[bouncer.Name] = bouncer
 	}
 
-	// rides on the first request, which goes out even with nothing pending: it is how the console
-	// learns our version and console options
 	lapi := a.lapiMetrics()
 	afterID := 0
 	sent := 0

--- a/pkg/apiserver/apic_metrics.go
+++ b/pkg/apiserver/apic_metrics.go
@@ -3,6 +3,7 @@ package apiserver
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"net/http"
 	"slices"
 	"strings"
@@ -13,178 +14,387 @@ import (
 	"github.com/crowdsecurity/go-cs-lib/ptr"
 	"github.com/crowdsecurity/go-cs-lib/version"
 
-	"github.com/crowdsecurity/crowdsec/pkg/csconfig"
+	"github.com/crowdsecurity/crowdsec/pkg/database/ent"
+	"github.com/crowdsecurity/crowdsec/pkg/database/ent/metric"
 	"github.com/crowdsecurity/crowdsec/pkg/fflag"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
+)
+
+const (
+	// what the CAPI refuses: "http code 415, response: HTTP content length exceeded 10485760 bytes"
+	capiBodyLimit = 10 * 1024 * 1024
+
+	// We budget on uncompressed bytes while the request body is gzipped, so this already
+	// over-estimates what the CAPI measures. The slack covers the json structure and the lapi block.
+	usageMetricsBatchBytes = capiBodyLimit - 1024*1024
+
+	// Bounds the number of source envelopes in a batch, and keeps the id list we mark as sent
+	// under the sqlite variable limit (cf. paginationSize in pkg/database/alerts.go).
+	usageMetricsBatchRows = 256
+
+	// rows read per query while filling a batch
+	usageMetricsPageSize = 32
+
+	// A snapshot describes a 30 minutes window. Once it is a day late the console has nothing
+	// useful left to do with it, so we stop dragging it along.
+	usageMetricsMaxAge = 24 * time.Hour
 )
 
 type dbPayload struct {
 	Metrics []*models.DetailedMetrics `json:"metrics"`
 }
 
-func (a *apic) GetUsageMetrics(ctx context.Context) (*models.AllMetrics, []int, error) {
-	allMetrics := &models.AllMetrics{}
-	metricsIDs := make([]int, 0)
+// usageMetricsBatch is one CAPI request worth of the backlog.
+type usageMetricsBatch struct {
+	metrics *models.AllMetrics
+	// rows settled by this batch, whether the CAPI takes them or refuses them
+	ids []int
+	// highest row id in the batch, to feed back as the cursor for the next one
+	lastID int
+}
 
-	lps, err := a.dbClient.ListMachines(ctx)
+func newUsageMetricsBatch(lps map[string]*models.LogProcessorsMetrics, rcs map[string]*models.RemediationComponentsMetrics, ids []int, lastID int) *usageMetricsBatch {
+	metrics := &models.AllMetrics{
+		// force actual slices to avoid non existing fields in the json
+		LogProcessors:         make([]*models.LogProcessorsMetrics, 0, len(lps)),
+		RemediationComponents: make([]*models.RemediationComponentsMetrics, 0, len(rcs)),
+	}
+
+	// sorted, to keep the payload stable
+	for _, name := range slices.Sorted(maps.Keys(lps)) {
+		metrics.LogProcessors = append(metrics.LogProcessors, lps[name])
+	}
+
+	for _, name := range slices.Sorted(maps.Keys(rcs)) {
+		metrics.RemediationComponents = append(metrics.RemediationComponents, rcs[name])
+	}
+
+	return &usageMetricsBatch{metrics: metrics, ids: ids, lastID: lastID}
+}
+
+// envelopeSize is how much a source adds to a request on top of the payloads it carries. It is not
+// negligible: hub_items alone is tens of kilobytes for a log processor with a large hub.
+func envelopeSize(v any) int {
+	serialized, err := json.Marshal(v)
 	if err != nil {
-		return nil, nil, err
+		return 0
 	}
 
-	bouncers, err := a.dbClient.ListBouncers(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
+	return len(serialized)
+}
 
-	for _, bouncer := range bouncers {
-		dbMetrics, err := a.dbClient.GetBouncerUsageMetricsByName(ctx, bouncer.Name)
-		if err != nil {
-			log.Errorf("unable to get bouncer usage metrics: %s", err)
-			continue
-		}
+func lpBaseMetrics(lp *ent.Machine) *models.LogProcessorsMetrics {
+	hubItems := models.HubItems{}
 
-		rcMetrics := models.RemediationComponentsMetrics{}
-
-		rcMetrics.Os = &models.OSversion{
-			Name:    &bouncer.Osname,
-			Family:  bouncer.Osfamily,
-			Version: &bouncer.Osversion,
-		}
-		rcMetrics.Type = bouncer.Type
-		rcMetrics.FeatureFlags = strings.Split(bouncer.Featureflags, ",")
-		rcMetrics.Version = &bouncer.Version
-		rcMetrics.Name = bouncer.Name
-
-		rcMetrics.LastPull = 0
-		if bouncer.LastPull != nil {
-			rcMetrics.LastPull = bouncer.LastPull.UTC().Unix()
-		}
-
-		rcMetrics.Metrics = make([]*models.DetailedMetrics, 0)
-
-		// Might seem weird, but we duplicate the bouncers if we have multiple unsent metrics
-		for _, dbMetric := range dbMetrics {
-			dbPayload := &dbPayload{}
-			// Append no matter what, if we cannot unmarshal, there's no way we'll be able to fix it automatically
-			metricsIDs = append(metricsIDs, dbMetric.ID)
-
-			err := json.Unmarshal([]byte(dbMetric.Payload), dbPayload)
-			if err != nil {
-				log.Errorf("unable to parse bouncer metric (%s)", err)
-				continue
-			}
-
-			rcMetrics.Metrics = append(rcMetrics.Metrics, dbPayload.Metrics...)
-		}
-
-		allMetrics.RemediationComponents = append(allMetrics.RemediationComponents, &rcMetrics)
-	}
-
-	for _, lp := range lps {
-		dbMetrics, err := a.dbClient.GetLPUsageMetricsByMachineID(ctx, lp.MachineId, true)
-		if err != nil {
-			log.Errorf("unable to get LP usage metrics: %s", err)
-			continue
-		}
-
-		lpMetrics := models.LogProcessorsMetrics{}
-
-		lpMetrics.Os = &models.OSversion{
-			Name:    &lp.Osname,
-			Family:  lp.Osfamily,
-			Version: &lp.Osversion,
-		}
-		lpMetrics.FeatureFlags = strings.Split(lp.Featureflags, ",")
-		lpMetrics.Version = &lp.Version
-		lpMetrics.Name = lp.MachineId
-
-		lpMetrics.LastPush = 0
-		if lp.LastPush != nil {
-			lpMetrics.LastPush = lp.LastPush.UTC().Unix()
-		}
-
-		lpMetrics.LastUpdate = lp.UpdatedAt.UTC().Unix()
-		lpMetrics.Datasources = lp.Datasources
-
-		hubItems := models.HubItems{}
-
-		if lp.Hubstate != nil {
-			// must carry over the hub state even if nothing is installed
-			for itemType, items := range lp.Hubstate {
-				hubItems[itemType] = []models.HubItem{}
-				for _, item := range items {
-					hubItems[itemType] = append(hubItems[itemType], models.HubItem{
-						Name:    item.Name,
-						Status:  item.Status,
-						Version: item.Version,
-					})
-				}
+	if lp.Hubstate != nil {
+		// must carry over the hub state even if nothing is installed
+		for itemType, items := range lp.Hubstate {
+			hubItems[itemType] = []models.HubItem{}
+			for _, item := range items {
+				hubItems[itemType] = append(hubItems[itemType], models.HubItem{
+					Name:    item.Name,
+					Status:  item.Status,
+					Version: item.Version,
+				})
 			}
 		}
-
-		lpMetrics.HubItems = hubItems
-
-		lpMetrics.Metrics = make([]*models.DetailedMetrics, 0)
-
-		for _, dbMetric := range dbMetrics {
-			dbPayload := &dbPayload{}
-			// Append no matter what, if we cannot unmarshal, there's no way we'll be able to fix it automatically
-			metricsIDs = append(metricsIDs, dbMetric.ID)
-
-			err := json.Unmarshal([]byte(dbMetric.Payload), dbPayload)
-			if err != nil {
-				log.Errorf("unable to parse log processor metric (%s)", err)
-				continue
-			}
-
-			lpMetrics.Metrics = append(lpMetrics.Metrics, dbPayload.Metrics...)
-		}
-
-		allMetrics.LogProcessors = append(allMetrics.LogProcessors, &lpMetrics)
 	}
 
-	// FIXME: all of this should only be done once on startup/reload
-	consoleOptions := strings.Join(csconfig.GetConfig().API.Server.ConsoleConfig.EnabledOptions(), ",")
-	allMetrics.Lapi = &models.LapiMetrics{
+	ret := &models.LogProcessorsMetrics{
+		Datasources: lp.Datasources,
+		HubItems:    hubItems,
+		LastUpdate:  lp.UpdatedAt.UTC().Unix(),
+		Name:        lp.MachineId,
+	}
+
+	if lp.LastPush != nil {
+		ret.LastPush = lp.LastPush.UTC().Unix()
+	}
+
+	ret.Os = &models.OSversion{
+		Name:    &lp.Osname,
+		Family:  lp.Osfamily,
+		Version: &lp.Osversion,
+	}
+	ret.FeatureFlags = strings.Split(lp.Featureflags, ",")
+	ret.Version = &lp.Version
+	ret.Metrics = make([]*models.DetailedMetrics, 0)
+
+	return ret
+}
+
+func rcBaseMetrics(rc *ent.Bouncer) *models.RemediationComponentsMetrics {
+	ret := &models.RemediationComponentsMetrics{
+		Name: rc.Name,
+		Type: rc.Type,
+	}
+
+	if rc.LastPull != nil {
+		ret.LastPull = rc.LastPull.UTC().Unix()
+	}
+
+	ret.Os = &models.OSversion{
+		Name:    &rc.Osname,
+		Family:  rc.Osfamily,
+		Version: &rc.Osversion,
+	}
+	ret.FeatureFlags = strings.Split(rc.Featureflags, ",")
+	ret.Version = &rc.Version
+	ret.Metrics = make([]*models.DetailedMetrics, 0)
+
+	return ret
+}
+
+func (a *apic) lapiMetrics() *models.LapiMetrics {
+	osName, osFamily, osVersion := version.DetectOS()
+
+	ret := &models.LapiMetrics{
 		ConsoleOptions: models.ConsoleOptions{
-			consoleOptions,
+			strings.Join(a.consoleConfig.EnabledOptions(), ","),
 		},
 	}
 
-	osName, osFamily, osVersion := version.DetectOS()
-
-	allMetrics.Lapi.Os = &models.OSversion{
+	ret.Os = &models.OSversion{
 		Name:    &osName,
 		Family:  osFamily,
 		Version: &osVersion,
 	}
-	allMetrics.Lapi.Version = new(version.String())
-	allMetrics.Lapi.FeatureFlags = fflag.Crowdsec.GetEnabledFeatures()
-
-	allMetrics.Lapi.Metrics = make([]*models.DetailedMetrics, 0)
-
-	allMetrics.Lapi.Metrics = append(allMetrics.Lapi.Metrics, &models.DetailedMetrics{
+	ret.Version = new(version.String())
+	ret.FeatureFlags = fflag.Crowdsec.GetEnabledFeatures()
+	ret.Metrics = []*models.DetailedMetrics{{
 		Meta: &models.MetricsMeta{
 			UtcNowTimestamp:   new(time.Now().UTC().Unix()),
 			WindowSizeSeconds: new(int64(a.metricsInterval.Seconds())),
 		},
 		Items: make([]*models.MetricsDetailItem, 0),
-	})
+	}}
 
-	// Force an actual slice to avoid non existing fields in the json
-	if allMetrics.RemediationComponents == nil {
-		allMetrics.RemediationComponents = make([]*models.RemediationComponentsMetrics, 0)
-	}
-
-	if allMetrics.LogProcessors == nil {
-		allMetrics.LogProcessors = make([]*models.LogProcessorsMetrics, 0)
-	}
-
-	return allMetrics, metricsIDs, nil
+	return ret
 }
 
-func (a *apic) MarkUsageMetricsAsSent(ctx context.Context, ids []int) error {
-	return a.dbClient.MarkUsageMetricsAsSent(ctx, ids)
+// nextUsageMetricsBatch folds the rows after afterID into a single request worth of metrics,
+// bounded by usageMetricsBatchBytes so that neither the request nor our memory usage depends on
+// how much of a backlog we have. It returns nil when nothing is pending.
+func (a *apic) nextUsageMetricsBatch(ctx context.Context, afterID int, lps map[string]*ent.Machine, rcs map[string]*ent.Bouncer) (*usageMetricsBatch, error) {
+	var (
+		lpMetrics = make(map[string]*models.LogProcessorsMetrics)
+		rcMetrics = make(map[string]*models.RemediationComponentsMetrics)
+		ids       []int
+		size      int
+	)
+
+	lastID := afterID
+
+readLoop:
+	for len(ids) < usageMetricsBatchRows && size < a.usageMetricsBatchBytes {
+		limit := min(usageMetricsPageSize, usageMetricsBatchRows-len(ids))
+
+		rows, err := a.dbClient.GetUnsentMetrics(ctx, lastID, limit)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, row := range rows {
+			// a row larger than the whole budget goes out on its own: leaving it behind would
+			// block everything queued after it
+			if len(ids) > 0 && size+len(row.Payload) > a.usageMetricsBatchBytes {
+				break readLoop
+			}
+
+			// account for the row before anything can go wrong with it, or it stays pending forever
+			lastID = row.ID
+			ids = append(ids, row.ID)
+			size += len(row.Payload)
+
+			payload := &dbPayload{}
+			if err := json.Unmarshal([]byte(row.Payload), payload); err != nil {
+				log.Errorf("unable to parse %s usage metrics from %s: %s", row.GeneratedType, row.GeneratedBy, err)
+				continue
+			}
+
+			switch row.GeneratedType {
+			case metric.GeneratedTypeLP:
+				lp, ok := lps[row.GeneratedBy]
+				if !ok {
+					// the log processor is gone, there is nothing left to attach these to
+					continue
+				}
+
+				met, ok := lpMetrics[row.GeneratedBy]
+				if !ok {
+					met = lpBaseMetrics(lp)
+					lpMetrics[row.GeneratedBy] = met
+					size += envelopeSize(met)
+				}
+
+				met.Metrics = append(met.Metrics, payload.Metrics...)
+			case metric.GeneratedTypeRC:
+				rc, ok := rcs[row.GeneratedBy]
+				if !ok {
+					continue
+				}
+
+				met, ok := rcMetrics[row.GeneratedBy]
+				if !ok {
+					met = rcBaseMetrics(rc)
+					rcMetrics[row.GeneratedBy] = met
+					size += envelopeSize(met)
+				}
+
+				met.Metrics = append(met.Metrics, payload.Metrics...)
+			}
+		}
+
+		if len(rows) < limit {
+			break
+		}
+	}
+
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	return newUsageMetricsBatch(lpMetrics, rcMetrics, ids, lastID), nil
+}
+
+// usageMetricsBatchRefused reports whether the CAPI turned down the request because of what we
+// sent. It would refuse the same body again, so the batch has to be dropped or it blocks
+// everything queued behind it. The listed statuses are about our credentials, our request rate or
+// the route rather than the body, so retrying those later can work.
+func usageMetricsBatchRefused(code int) bool {
+	switch code {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound,
+		http.StatusRequestTimeout, http.StatusTooManyRequests:
+		return false
+	}
+
+	return code >= http.StatusBadRequest && code < http.StatusInternalServerError
+}
+
+type usageMetricsResult int
+
+const (
+	usageMetricsAccepted usageMetricsResult = iota
+	usageMetricsDropped
+	usageMetricsRetryLater
+)
+
+// sendUsageMetricsBatch pushes one batch and settles its rows.
+func (a *apic) sendUsageMetricsBatch(ctx context.Context, batch *usageMetricsBatch) usageMetricsResult {
+	result := usageMetricsAccepted
+
+	_, resp, err := a.apiClient.UsageMetrics.Add(ctx, batch.metrics)
+	if err != nil {
+		log.Errorf("unable to send usage metrics: %s", err)
+
+		if resp == nil || resp.Response == nil {
+			// most likely a transient network error, it will be retried later
+			return usageMetricsRetryLater
+		}
+
+		if !usageMetricsBatchRefused(resp.Response.StatusCode) {
+			return usageMetricsRetryLater
+		}
+
+		// The CAPI will never accept this payload. Drop it, or we send it again on every run,
+		// bigger every time, until the LAPI runs out of memory.
+		log.Errorf("dropping %d usage metrics refused by the CAPI (http code %d)", len(batch.ids), resp.Response.StatusCode)
+
+		result = usageMetricsDropped
+	}
+
+	if len(batch.ids) == 0 {
+		return result
+	}
+
+	if err := a.dbClient.MarkUsageMetricsAsSent(ctx, batch.ids); err != nil {
+		log.Errorf("unable to mark usage metrics as sent: %s", err)
+		return usageMetricsRetryLater
+	}
+
+	return result
+}
+
+// pushUsageMetrics drains the pending usage metrics, one bounded batch per request.
+func (a *apic) pushUsageMetrics(ctx context.Context) {
+	dropped, err := a.dbClient.MarkStaleUsageMetricsAsSent(ctx, time.Now().UTC().Add(-usageMetricsMaxAge))
+	if err != nil {
+		log.Errorf("unable to drop stale usage metrics: %s", err)
+	} else if dropped > 0 {
+		log.Warnf("dropped %d usage metrics older than %s", dropped, usageMetricsMaxAge)
+	}
+
+	machines, err := a.dbClient.ListMachines(ctx)
+	if err != nil {
+		log.Errorf("unable to get log processors: %s", err)
+		return
+	}
+
+	bouncers, err := a.dbClient.ListBouncers(ctx)
+	if err != nil {
+		log.Errorf("unable to get remediation components: %s", err)
+		return
+	}
+
+	lps := make(map[string]*ent.Machine, len(machines))
+	for _, machine := range machines {
+		lps[machine.MachineId] = machine
+	}
+
+	rcs := make(map[string]*ent.Bouncer, len(bouncers))
+	for _, bouncer := range bouncers {
+		rcs[bouncer.Name] = bouncer
+	}
+
+	// The lapi block rides on the first request, which goes out even when nothing is pending:
+	// it is how the console learns our version and console options.
+	lapi := a.lapiMetrics()
+	afterID := 0
+	sent := 0
+
+	// report what went out even when the drain stops halfway
+	defer func() {
+		log.Infof("Sent %d usage metrics", sent)
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-a.metricsTomb.Dying():
+			return
+		default:
+		}
+
+		batch, err := a.nextUsageMetricsBatch(ctx, afterID, lps, rcs)
+		if err != nil {
+			log.Errorf("unable to get usage metrics: %s", err)
+			return
+		}
+
+		if batch == nil {
+			if lapi == nil {
+				break
+			}
+
+			batch = newUsageMetricsBatch(nil, nil, nil, afterID)
+		}
+
+		if lapi != nil {
+			batch.metrics.Lapi = lapi
+			lapi = nil
+		}
+
+		switch a.sendUsageMetricsBatch(ctx, batch) {
+		case usageMetricsRetryLater:
+			return
+		case usageMetricsAccepted:
+			sent += len(batch.ids)
+		case usageMetricsDropped:
+		}
+
+		afterID = batch.lastID
+	}
 }
 
 func (a *apic) GetMetrics(ctx context.Context) (*models.Metrics, error) {
@@ -356,35 +566,7 @@ func (a *apic) SendUsageMetrics(ctx context.Context) {
 				ticker.Reset(a.usageMetricsInterval)
 			}
 
-			metrics, metricsID, err := a.GetUsageMetrics(ctx)
-			if err != nil {
-				log.Errorf("unable to get usage metrics: %s", err)
-				continue
-			}
-
-			_, resp, err := a.apiClient.UsageMetrics.Add(ctx, metrics)
-			if err != nil {
-				log.Errorf("unable to send usage metrics: %s", err)
-
-				if resp == nil || resp.Response == nil {
-					// Most likely a transient network error, it will be retried later
-					continue
-				}
-
-				if resp.Response.StatusCode >= http.StatusBadRequest && resp.Response.StatusCode != http.StatusUnprocessableEntity {
-					// In case of 422, mark the metrics as sent anyway, the API did not like what we sent,
-					// and it's unlikely we'll be able to fix it
-					continue
-				}
-			}
-
-			err = a.MarkUsageMetricsAsSent(ctx, metricsID)
-			if err != nil {
-				log.Errorf("unable to mark usage metrics as sent: %s", err)
-				continue
-			}
-
-			log.Infof("Sent %d usage metrics", len(metricsID))
+			a.pushUsageMetrics(ctx)
 		}
 	}
 }

--- a/pkg/apiserver/apic_metrics.go
+++ b/pkg/apiserver/apic_metrics.go
@@ -21,22 +21,17 @@ import (
 )
 
 const (
-	// what the CAPI refuses: "http code 415, response: HTTP content length exceeded 10485760 bytes"
-	capiBodyLimit = 10 * 1024 * 1024
+	// The CAPI answers 413 above 6MiB, measured on the body *after* json escaping (it hands ours
+	// to its backend inside a json string). Escaping inflates metrics payloads by ~18%, so
+	// budgeting unescaped bytes at 4MiB keeps a fifth of the limit spare.
+	usageMetricsBatchBytes = 4 * 1024 * 1024
 
-	// We budget on uncompressed bytes while the request body is gzipped, so this already
-	// over-estimates what the CAPI measures. The slack covers the json structure and the lapi block.
-	usageMetricsBatchBytes = capiBodyLimit - 1024*1024
-
-	// Bounds the number of source envelopes in a batch, and keeps the id list we mark as sent
-	// under the sqlite variable limit (cf. paginationSize in pkg/database/alerts.go).
+	// also keeps the id list we mark as sent under the sqlite variable limit
 	usageMetricsBatchRows = 256
 
-	// rows read per query while filling a batch
 	usageMetricsPageSize = 32
 
-	// A snapshot describes a 30 minutes window. Once it is a day late the console has nothing
-	// useful left to do with it, so we stop dragging it along.
+	// past that, the console has nothing useful left to do with a snapshot
 	usageMetricsMaxAge = 24 * time.Hour
 )
 
@@ -47,9 +42,9 @@ type dbPayload struct {
 // usageMetricsBatch is one CAPI request worth of the backlog.
 type usageMetricsBatch struct {
 	metrics *models.AllMetrics
-	// rows settled by this batch, whether the CAPI takes them or refuses them
+	// settled by this batch, whether the CAPI takes them or refuses them
 	ids []int
-	// highest row id in the batch, to feed back as the cursor for the next one
+	// cursor for the next batch
 	lastID int
 }
 
@@ -72,8 +67,7 @@ func newUsageMetricsBatch(lps map[string]*models.LogProcessorsMetrics, rcs map[s
 	return &usageMetricsBatch{metrics: metrics, ids: ids, lastID: lastID}
 }
 
-// envelopeSize is how much a source adds to a request on top of the payloads it carries. It is not
-// negligible: hub_items alone is tens of kilobytes for a log processor with a large hub.
+// envelopeSize is what a source costs on top of its payloads: hub_items alone is tens of kilobytes.
 func envelopeSize(v any) int {
 	serialized, err := json.Marshal(v)
 	if err != nil {
@@ -172,9 +166,8 @@ func (a *apic) lapiMetrics() *models.LapiMetrics {
 	return ret
 }
 
-// nextUsageMetricsBatch folds the rows after afterID into a single request worth of metrics,
-// bounded by usageMetricsBatchBytes so that neither the request nor our memory usage depends on
-// how much of a backlog we have. It returns nil when nothing is pending.
+// nextUsageMetricsBatch folds the rows after afterID into one request worth of metrics, so that
+// neither the request nor our memory usage depends on the size of the backlog. Nil when drained.
 func (a *apic) nextUsageMetricsBatch(ctx context.Context, afterID int, lps map[string]*ent.Machine, rcs map[string]*ent.Bouncer) (*usageMetricsBatch, error) {
 	var (
 		lpMetrics = make(map[string]*models.LogProcessorsMetrics)
@@ -195,13 +188,12 @@ readLoop:
 		}
 
 		for _, row := range rows {
-			// a row larger than the whole budget goes out on its own: leaving it behind would
-			// block everything queued after it
+			// a row over budget on its own would otherwise block everything queued behind it
 			if len(ids) > 0 && size+len(row.Payload) > a.usageMetricsBatchBytes {
 				break readLoop
 			}
 
-			// account for the row before anything can go wrong with it, or it stays pending forever
+			// account for it first, or a row we choke on stays pending forever
 			lastID = row.ID
 			ids = append(ids, row.ID)
 			size += len(row.Payload)
@@ -216,7 +208,7 @@ readLoop:
 			case metric.GeneratedTypeLP:
 				lp, ok := lps[row.GeneratedBy]
 				if !ok {
-					// the log processor is gone, there is nothing left to attach these to
+					// the log processor is gone, nothing left to attach these to
 					continue
 				}
 
@@ -257,10 +249,8 @@ readLoop:
 	return newUsageMetricsBatch(lpMetrics, rcMetrics, ids, lastID), nil
 }
 
-// usageMetricsBatchRefused reports whether the CAPI turned down the request because of what we
-// sent. It would refuse the same body again, so the batch has to be dropped or it blocks
-// everything queued behind it. The listed statuses are about our credentials, our request rate or
-// the route rather than the body, so retrying those later can work.
+// usageMetricsBatchRefused reports whether the CAPI turned us down over the body itself, in which
+// case resending it is pointless. The listed statuses are about credentials, rate or route.
 func usageMetricsBatchRefused(code int) bool {
 	switch code {
 	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound,
@@ -296,8 +286,7 @@ func (a *apic) sendUsageMetricsBatch(ctx context.Context, batch *usageMetricsBat
 			return usageMetricsRetryLater
 		}
 
-		// The CAPI will never accept this payload. Drop it, or we send it again on every run,
-		// bigger every time, until the LAPI runs out of memory.
+		// drop it, or we resend it every run, bigger every time, until we run out of memory
 		log.Errorf("dropping %d usage metrics refused by the CAPI (http code %d)", len(batch.ids), resp.Response.StatusCode)
 
 		result = usageMetricsDropped
@@ -346,13 +335,13 @@ func (a *apic) pushUsageMetrics(ctx context.Context) {
 		rcs[bouncer.Name] = bouncer
 	}
 
-	// The lapi block rides on the first request, which goes out even when nothing is pending:
-	// it is how the console learns our version and console options.
+	// rides on the first request, which goes out even with nothing pending: it is how the console
+	// learns our version and console options
 	lapi := a.lapiMetrics()
 	afterID := 0
 	sent := 0
 
-	// report what went out even when the drain stops halfway
+	// report progress even when the drain stops halfway
 	defer func() {
 		log.Infof("Sent %d usage metrics", sent)
 	}()

--- a/pkg/apiserver/apic_test.go
+++ b/pkg/apiserver/apic_test.go
@@ -75,10 +75,11 @@ func getAPIC(t *testing.T, ctx context.Context) *apic {
 			ShareCustomScenarios:  new(false),
 			ShareContext:          new(false),
 		},
-		isPulling:      make(chan bool, 1),
-		shareSignals:   true,
-		pullBlocklists: true,
-		pullCommunity:  true,
+		isPulling:              make(chan bool, 1),
+		usageMetricsBatchBytes: usageMetricsBatchBytes,
+		shareSignals:           true,
+		pullBlocklists:         true,
+		pullCommunity:          true,
 	}
 }
 

--- a/pkg/apiserver/apic_usage_metrics_test.go
+++ b/pkg/apiserver/apic_usage_metrics_test.go
@@ -24,8 +24,7 @@ import (
 
 const usageMetricsURL = "http://api.crowdsec.net/api/usage-metrics"
 
-// usageMetricsPayload is a stored metrics row: one window, padded to roughly size bytes so a test
-// can decide how many of them fit in a batch.
+// usageMetricsPayload is a stored row: one window, padded to roughly size bytes.
 func usageMetricsPayload(name string, size int) string {
 	build := func(source string) string {
 		return fmt.Sprintf(
@@ -92,7 +91,7 @@ func pendingMetrics(t *testing.T, ctx context.Context, api *apic) []*ent.Metric 
 	return pending
 }
 
-// mockCAPI answers every usage-metrics push with status, and records what was sent.
+// mockCAPI answers every push with status and records what was sent.
 func mockCAPI(t *testing.T, api *apic, status int) *[]*models.AllMetrics {
 	t.Helper()
 
@@ -109,8 +108,6 @@ func mockCAPI(t *testing.T, api *apic, status int) *[]*models.AllMetrics {
 			body, err = io.ReadAll(reader)
 			require.NoError(t, err)
 		}
-
-		require.Less(t, len(body), capiBodyLimit)
 
 		received := &models.AllMetrics{}
 		require.NoError(t, json.Unmarshal(body, received))
@@ -154,7 +151,7 @@ func TestAPICNextUsageMetricsBatch(t *testing.T) {
 	addMachine(t, ctx, api, "lp1")
 	addBouncer(t, ctx, api, "rc1")
 
-	// 4 rows of ~1kB for lp1, then 1 for rc1, then one from a machine that no longer exists
+	// lp1, then rc1, then a machine that no longer exists
 	lpIDs := addMetrics(t, ctx, api, metric.GeneratedTypeLP, "lp1", time.Now().UTC(),
 		usageMetricsPayload("a", 1024),
 		usageMetricsPayload("b", 1024),
@@ -209,7 +206,7 @@ func TestAPICNextUsageMetricsBatchOversizedRow(t *testing.T) {
 
 	api.usageMetricsBatchBytes = 1024
 
-	// a row bigger than the whole budget must go out on its own, or it blocks everything behind it
+	// must go out on its own, or it blocks everything behind it
 	batch, err := api.nextUsageMetricsBatch(ctx, 0, map[string]*ent.Machine{"lp1": api.dbClient.Ent.Machine.Query().OnlyX(ctx)}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, batch)

--- a/pkg/apiserver/apic_usage_metrics_test.go
+++ b/pkg/apiserver/apic_usage_metrics_test.go
@@ -1,0 +1,385 @@
+package apiserver
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
+	"github.com/crowdsecurity/crowdsec/pkg/database/ent"
+	"github.com/crowdsecurity/crowdsec/pkg/database/ent/metric"
+	"github.com/crowdsecurity/crowdsec/pkg/models"
+)
+
+const usageMetricsURL = "http://api.crowdsec.net/api/usage-metrics"
+
+// usageMetricsPayload is a stored metrics row: one window, padded to roughly size bytes so a test
+// can decide how many of them fit in a batch.
+func usageMetricsPayload(name string, size int) string {
+	build := func(source string) string {
+		return fmt.Sprintf(
+			`{"metrics":[{"meta":{"utc_now_timestamp":42,"window_size_seconds":42},"items":[{"name":"read","unit":"line","value":42,"labels":{"source":%q}}]}]}`,
+			source)
+	}
+
+	if padding := size - len(build(name)); padding > 0 {
+		name += strings.Repeat("a", padding)
+	}
+
+	return build(name)
+}
+
+func addMachine(t *testing.T, ctx context.Context, api *apic, machineID string) {
+	t.Helper()
+
+	api.dbClient.Ent.Machine.Create().
+		SetMachineId(machineID).
+		SetPassword(testPassword.String()).
+		SetIpAddress("1.2.3.4").
+		SetScenarios("crowdsecurity/test").
+		SetLastPush(time.Time{}).
+		SetUpdatedAt(time.Time{}).
+		ExecX(ctx)
+}
+
+func addBouncer(t *testing.T, ctx context.Context, api *apic, name string) {
+	t.Helper()
+
+	api.dbClient.Ent.Bouncer.Create().
+		SetIPAddress("1.2.3.6").
+		SetName(name).
+		SetAPIKey("foobar").
+		SetRevoked(false).
+		SetLastPull(time.Time{}).
+		ExecX(ctx)
+}
+
+func addMetrics(t *testing.T, ctx context.Context, api *apic, generatedType metric.GeneratedType, generatedBy string, receivedAt time.Time, payloads ...string) []int {
+	t.Helper()
+
+	ids := make([]int, 0, len(payloads))
+
+	for _, payload := range payloads {
+		row := api.dbClient.Ent.Metric.Create().
+			SetGeneratedType(generatedType).
+			SetGeneratedBy(generatedBy).
+			SetReceivedAt(receivedAt).
+			SetPayload(payload).
+			SaveX(ctx)
+		ids = append(ids, row.ID)
+	}
+
+	return ids
+}
+
+func pendingMetrics(t *testing.T, ctx context.Context, api *apic) []*ent.Metric {
+	t.Helper()
+
+	pending, err := api.dbClient.GetUnsentMetrics(ctx, 0, 1000)
+	require.NoError(t, err)
+
+	return pending
+}
+
+// mockCAPI answers every usage-metrics push with status, and records what was sent.
+func mockCAPI(t *testing.T, api *apic, status int) *[]*models.AllMetrics {
+	t.Helper()
+
+	sent := &[]*models.AllMetrics{}
+
+	httpmock.RegisterResponder("POST", usageMetricsURL, func(req *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+
+		if req.Header.Get("Content-Encoding") == "gzip" {
+			reader, err := gzip.NewReader(bytes.NewReader(body))
+			require.NoError(t, err)
+
+			body, err = io.ReadAll(reader)
+			require.NoError(t, err)
+		}
+
+		require.Less(t, len(body), capiBodyLimit)
+
+		received := &models.AllMetrics{}
+		require.NoError(t, json.Unmarshal(body, received))
+
+		*sent = append(*sent, received)
+
+		return httpmock.NewBytesResponse(status, []byte("{}")), nil
+	})
+
+	apiURL, err := url.ParseRequestURI("http://api.crowdsec.net/")
+	require.NoError(t, err)
+
+	apiClient, err := apiclient.NewDefaultClient(apiURL, "/api", "", nil)
+	require.NoError(t, err)
+
+	api.apiClient = apiClient
+
+	return sent
+}
+
+func windowCount(sent []*models.AllMetrics) int {
+	count := 0
+
+	for _, met := range sent {
+		for _, lp := range met.LogProcessors {
+			count += len(lp.Metrics)
+		}
+
+		for _, rc := range met.RemediationComponents {
+			count += len(rc.Metrics)
+		}
+	}
+
+	return count
+}
+
+func TestAPICNextUsageMetricsBatch(t *testing.T) {
+	ctx := t.Context()
+	api := getAPIC(t, ctx)
+
+	addMachine(t, ctx, api, "lp1")
+	addBouncer(t, ctx, api, "rc1")
+
+	// 4 rows of ~1kB for lp1, then 1 for rc1, then one from a machine that no longer exists
+	lpIDs := addMetrics(t, ctx, api, metric.GeneratedTypeLP, "lp1", time.Now().UTC(),
+		usageMetricsPayload("a", 1024),
+		usageMetricsPayload("b", 1024),
+		usageMetricsPayload("c", 1024),
+		usageMetricsPayload("d", 1024),
+	)
+	rcIDs := addMetrics(t, ctx, api, metric.GeneratedTypeRC, "rc1", time.Now().UTC(), usageMetricsPayload("e", 1024))
+	goneIDs := addMetrics(t, ctx, api, metric.GeneratedTypeLP, "deleted", time.Now().UTC(), usageMetricsPayload("f", 1024))
+
+	lps := map[string]*ent.Machine{"lp1": api.dbClient.Ent.Machine.Query().OnlyX(ctx)}
+	rcs := map[string]*ent.Bouncer{"rc1": api.dbClient.Ent.Bouncer.Query().OnlyX(ctx)}
+
+	api.usageMetricsBatchBytes = 2500
+
+	batch, err := api.nextUsageMetricsBatch(ctx, 0, lps, rcs)
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	require.Equal(t, lpIDs[:2], batch.ids, "the byte budget cuts the batch short")
+	require.Equal(t, lpIDs[1], batch.lastID)
+	require.Len(t, batch.metrics.LogProcessors, 1, "rows of the same source are folded into one entry")
+	require.Len(t, batch.metrics.LogProcessors[0].Metrics, 2)
+	require.Empty(t, batch.metrics.RemediationComponents)
+
+	batch, err = api.nextUsageMetricsBatch(ctx, batch.lastID, lps, rcs)
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	require.Equal(t, lpIDs[2:], batch.ids, "the cursor picks up where the previous batch stopped")
+
+	batch, err = api.nextUsageMetricsBatch(ctx, batch.lastID, lps, rcs)
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	require.Equal(t, append(rcIDs, goneIDs...), batch.ids,
+		"rows of a deleted source are settled even though nothing carries them")
+	require.Len(t, batch.metrics.RemediationComponents, 1)
+	require.Empty(t, batch.metrics.LogProcessors)
+
+	batch, err = api.nextUsageMetricsBatch(ctx, batch.lastID, lps, rcs)
+	require.NoError(t, err)
+	require.Nil(t, batch, "a nil batch means the backlog is drained")
+}
+
+func TestAPICNextUsageMetricsBatchOversizedRow(t *testing.T) {
+	ctx := t.Context()
+	api := getAPIC(t, ctx)
+
+	addMachine(t, ctx, api, "lp1")
+
+	ids := addMetrics(t, ctx, api, metric.GeneratedTypeLP, "lp1", time.Now().UTC(),
+		usageMetricsPayload("a", 8192),
+		usageMetricsPayload("b", 128),
+	)
+
+	api.usageMetricsBatchBytes = 1024
+
+	// a row bigger than the whole budget must go out on its own, or it blocks everything behind it
+	batch, err := api.nextUsageMetricsBatch(ctx, 0, map[string]*ent.Machine{"lp1": api.dbClient.Ent.Machine.Query().OnlyX(ctx)}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	require.Equal(t, ids[:1], batch.ids)
+
+	batch, err = api.nextUsageMetricsBatch(ctx, batch.lastID, map[string]*ent.Machine{"lp1": api.dbClient.Ent.Machine.Query().OnlyX(ctx)}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	require.Equal(t, ids[1:], batch.ids)
+}
+
+func TestAPICNextUsageMetricsBatchUnparseable(t *testing.T) {
+	ctx := t.Context()
+	api := getAPIC(t, ctx)
+
+	addMachine(t, ctx, api, "lp1")
+
+	ids := addMetrics(t, ctx, api, metric.GeneratedTypeLP, "lp1", time.Now().UTC(), "not json")
+
+	batch, err := api.nextUsageMetricsBatch(ctx, 0, map[string]*ent.Machine{"lp1": api.dbClient.Ent.Machine.Query().OnlyX(ctx)}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	require.Equal(t, ids, batch.ids, "a row we cannot parse is settled, not retried forever")
+	require.Empty(t, batch.metrics.LogProcessors)
+}
+
+func TestAPICPushUsageMetrics(t *testing.T) {
+	ctx := t.Context()
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	t.Run("a backlog over the budget goes out in several requests", func(t *testing.T) {
+		api := getAPIC(t, ctx)
+		sent := mockCAPI(t, api, http.StatusOK)
+
+		addMachine(t, ctx, api, "lp1")
+		addMetrics(t, ctx, api, metric.GeneratedTypeLP, "lp1", time.Now().UTC(),
+			usageMetricsPayload("a", 1024),
+			usageMetricsPayload("b", 1024),
+			usageMetricsPayload("c", 1024),
+			usageMetricsPayload("d", 1024),
+			usageMetricsPayload("e", 1024),
+			usageMetricsPayload("f", 1024),
+		)
+
+		api.usageMetricsBatchBytes = 2500
+
+		httpmock.ZeroCallCounters()
+		api.pushUsageMetrics(ctx)
+
+		require.Greater(t, httpmock.GetCallCountInfo()["POST "+usageMetricsURL], 1)
+		require.Equal(t, 6, windowCount(*sent), "every window is sent exactly once")
+		require.Empty(t, pendingMetrics(t, ctx, api))
+		require.NotNil(t, (*sent)[0].Lapi, "the lapi block rides on the first request")
+		require.Nil(t, (*sent)[1].Lapi)
+	})
+
+	t.Run("nothing pending still reports the lapi", func(t *testing.T) {
+		api := getAPIC(t, ctx)
+		sent := mockCAPI(t, api, http.StatusOK)
+
+		httpmock.ZeroCallCounters()
+		api.pushUsageMetrics(ctx)
+
+		require.Equal(t, 1, httpmock.GetCallCountInfo()["POST "+usageMetricsURL])
+		require.Len(t, *sent, 1)
+		require.NotNil(t, (*sent)[0].Lapi)
+		require.Empty(t, (*sent)[0].LogProcessors)
+	})
+
+	t.Run("a refused batch is dropped instead of growing forever", func(t *testing.T) {
+		api := getAPIC(t, ctx)
+		mockCAPI(t, api, http.StatusUnsupportedMediaType)
+
+		addMachine(t, ctx, api, "lp1")
+		addMetrics(t, ctx, api, metric.GeneratedTypeLP, "lp1", time.Now().UTC(),
+			usageMetricsPayload("a", 1024),
+			usageMetricsPayload("b", 1024),
+			usageMetricsPayload("c", 1024),
+			usageMetricsPayload("d", 1024),
+		)
+
+		api.usageMetricsBatchBytes = 2500
+
+		httpmock.ZeroCallCounters()
+		api.pushUsageMetrics(ctx)
+
+		require.Empty(t, pendingMetrics(t, ctx, api), "refused metrics are settled, not queued again")
+
+		// the next run has nothing left to resend
+		calls := httpmock.GetCallCountInfo()["POST "+usageMetricsURL]
+
+		api.pushUsageMetrics(ctx)
+		require.Equal(t, calls+1, httpmock.GetCallCountInfo()["POST "+usageMetricsURL])
+	})
+
+	t.Run("a retryable failure leaves the backlog alone", func(t *testing.T) {
+		for _, status := range []int{http.StatusInternalServerError, http.StatusTooManyRequests, http.StatusUnauthorized} {
+			t.Run(http.StatusText(status), func(t *testing.T) {
+				api := getAPIC(t, ctx)
+				mockCAPI(t, api, status)
+
+				addMachine(t, ctx, api, "lp1")
+				ids := addMetrics(t, ctx, api, metric.GeneratedTypeLP, "lp1", time.Now().UTC(),
+					usageMetricsPayload("a", 1024),
+					usageMetricsPayload("b", 1024),
+					usageMetricsPayload("c", 1024),
+					usageMetricsPayload("d", 1024),
+				)
+
+				api.usageMetricsBatchBytes = 2500
+
+				httpmock.ZeroCallCounters()
+				api.pushUsageMetrics(ctx)
+
+				require.Equal(t, 1, httpmock.GetCallCountInfo()["POST "+usageMetricsURL], "the drain stops at the first failure")
+				require.Len(t, pendingMetrics(t, ctx, api), len(ids))
+
+				// once the CAPI is back, the whole backlog goes out
+				sent := mockCAPI(t, api, http.StatusOK)
+				api.pushUsageMetrics(ctx)
+
+				require.Equal(t, 4, windowCount(*sent))
+				require.Empty(t, pendingMetrics(t, ctx, api))
+			})
+		}
+	})
+
+	t.Run("metrics too old to be worth pushing are given up on", func(t *testing.T) {
+		api := getAPIC(t, ctx)
+		sent := mockCAPI(t, api, http.StatusOK)
+
+		addMachine(t, ctx, api, "lp1")
+		addMetrics(t, ctx, api, metric.GeneratedTypeLP, "lp1", time.Now().UTC().Add(-2*usageMetricsMaxAge),
+			usageMetricsPayload("old", 1024))
+		addMetrics(t, ctx, api, metric.GeneratedTypeLP, "lp1", time.Now().UTC(),
+			usageMetricsPayload("fresh", 1024))
+
+		httpmock.ZeroCallCounters()
+		api.pushUsageMetrics(ctx)
+
+		require.Equal(t, 1, windowCount(*sent), "only the fresh window is sent")
+		require.Empty(t, pendingMetrics(t, ctx, api), "the stale one stops being pending")
+	})
+}
+
+func TestUsageMetricsBatchRefused(t *testing.T) {
+	tests := []struct {
+		code    int
+		refused bool
+	}{
+		{http.StatusOK, false},
+		{http.StatusBadRequest, true},
+		{http.StatusRequestEntityTooLarge, true},
+		{http.StatusUnsupportedMediaType, true},
+		{http.StatusUnprocessableEntity, true},
+		{http.StatusUnauthorized, false},
+		{http.StatusForbidden, false},
+		{http.StatusNotFound, false},
+		{http.StatusRequestTimeout, false},
+		{http.StatusTooManyRequests, false},
+		{http.StatusInternalServerError, false},
+		{http.StatusBadGateway, false},
+		{http.StatusServiceUnavailable, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(http.StatusText(tc.code), func(t *testing.T) {
+			require.Equal(t, tc.refused, usageMetricsBatchRefused(tc.code))
+		})
+	}
+}

--- a/pkg/database/ent/migrate/schema.go
+++ b/pkg/database/ent/migrate/schema.go
@@ -376,6 +376,18 @@ var (
 		Name:       "metrics",
 		Columns:    MetricsColumns,
 		PrimaryKey: []*schema.Column{MetricsColumns[0]},
+		Indexes: []*schema.Index{
+			{
+				Name:    "metric_received_at",
+				Unique:  false,
+				Columns: []*schema.Column{MetricsColumns[3]},
+			},
+			{
+				Name:    "metric_generated_type_generated_by_pushed_at",
+				Unique:  false,
+				Columns: []*schema.Column{MetricsColumns[1], MetricsColumns[2], MetricsColumns[4]},
+			},
+		},
 	}
 	// AllowListAllowlistItemsColumns holds the columns for the "allow_list_allowlist_items" table.
 	AllowListAllowlistItemsColumns = []*schema.Column{

--- a/pkg/database/ent/schema/metric.go
+++ b/pkg/database/ent/schema/metric.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
 )
 
 // Metric is actually a set of metrics collected by a device
@@ -30,5 +31,14 @@ func (Metric) Fields() []ent.Field {
 		field.Text("payload").
 			Immutable().
 			Comment("The actual metrics (item0)"),
+	}
+}
+
+func (Metric) Indexes() []ent.Index {
+	return []ent.Index{
+		// the flush job deletes by age, every minute
+		index.Fields("received_at"),
+		// cscli machines inspect
+		index.Fields("generated_type", "generated_by", "pushed_at"),
 	}
 }

--- a/pkg/database/metrics.go
+++ b/pkg/database/metrics.go
@@ -73,3 +73,42 @@ func (c *Client) MarkUsageMetricsAsSent(ctx context.Context, ids []int) error {
 
 	return nil
 }
+
+// GetUnsentMetrics returns up to limit metrics that have not been pushed to CAPI yet, across all
+// sources, ordered by id and starting after afterID. Callers walk the backlog by passing back the
+// id of the last row they consumed.
+func (c *Client) GetUnsentMetrics(ctx context.Context, afterID int, limit int) ([]*ent.Metric, error) {
+	metrics, err := c.Ent.Metric.Query().
+		Where(
+			metric.PushedAtIsNil(),
+			metric.IDGT(afterID),
+		).
+		Order(ent.Asc(metric.FieldID)).
+		Limit(limit).
+		All(ctx)
+	if err != nil {
+		c.Log.Warningf("GetUnsentMetrics: %s", err)
+		return nil, fmt.Errorf("getting unsent usage metrics: %w", err)
+	}
+
+	return metrics, nil
+}
+
+// MarkStaleUsageMetricsAsSent gives up on metrics that are too old to be worth pushing. The rows
+// stay around until the age flush, so cscli still reports them, but they stop being pending: a
+// CAPI outage cannot leave an ever-growing backlog behind.
+func (c *Client) MarkStaleUsageMetricsAsSent(ctx context.Context, before time.Time) (int, error) {
+	updated, err := c.Ent.Metric.Update().
+		Where(
+			metric.PushedAtIsNil(),
+			metric.ReceivedAtLT(before),
+		).
+		SetPushedAt(time.Now().UTC()).
+		Save(ctx)
+	if err != nil {
+		c.Log.Warningf("MarkStaleUsageMetricsAsSent: %s", err)
+		return 0, fmt.Errorf("marking stale usage metrics as sent: %w", err)
+	}
+
+	return updated, nil
+}

--- a/pkg/database/metrics.go
+++ b/pkg/database/metrics.go
@@ -74,9 +74,8 @@ func (c *Client) MarkUsageMetricsAsSent(ctx context.Context, ids []int) error {
 	return nil
 }
 
-// GetUnsentMetrics returns up to limit metrics that have not been pushed to CAPI yet, across all
-// sources, ordered by id and starting after afterID. Callers walk the backlog by passing back the
-// id of the last row they consumed.
+// GetUnsentMetrics returns metrics not pushed to CAPI yet, across all sources, ordered by id.
+// Callers walk the backlog by passing back the id of the last row they consumed.
 func (c *Client) GetUnsentMetrics(ctx context.Context, afterID int, limit int) ([]*ent.Metric, error) {
 	metrics, err := c.Ent.Metric.Query().
 		Where(
@@ -94,9 +93,8 @@ func (c *Client) GetUnsentMetrics(ctx context.Context, afterID int, limit int) (
 	return metrics, nil
 }
 
-// MarkStaleUsageMetricsAsSent gives up on metrics that are too old to be worth pushing. The rows
-// stay around until the age flush, so cscli still reports them, but they stop being pending: a
-// CAPI outage cannot leave an ever-growing backlog behind.
+// MarkStaleUsageMetricsAsSent gives up on metrics too old to be worth pushing, so a CAPI outage
+// cannot leave a growing backlog behind. The rows live on until the age flush, for cscli.
 func (c *Client) MarkStaleUsageMetricsAsSent(ctx context.Context, before time.Time) (int, error) {
 	updated, err := c.Ent.Metric.Update().
 		Where(

--- a/pkg/database/metrics_test.go
+++ b/pkg/database/metrics_test.go
@@ -1,0 +1,112 @@
+package database
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/crowdsecurity/crowdsec/pkg/database/ent/metric"
+)
+
+func TestGetUnsentMetrics(t *testing.T) {
+	ctx := t.Context()
+	dbClient := getDBClient(t, ctx)
+
+	now := time.Now().UTC()
+
+	// 3 unsent LP rows, 2 unsent RC rows, and one that was already pushed
+	ids := make([]int, 0, 6)
+
+	for i := range 3 {
+		m, err := dbClient.CreateMetric(ctx, metric.GeneratedTypeLP, "lp1", now.Add(time.Duration(i)*time.Minute), `{"metrics":[]}`)
+		require.NoError(t, err)
+		ids = append(ids, m.ID)
+	}
+
+	for range 2 {
+		m, err := dbClient.CreateMetric(ctx, metric.GeneratedTypeRC, "rc1", now, `{"metrics":[]}`)
+		require.NoError(t, err)
+		ids = append(ids, m.ID)
+	}
+
+	pushed, err := dbClient.CreateMetric(ctx, metric.GeneratedTypeLP, "lp1", now, `{"metrics":[]}`)
+	require.NoError(t, err)
+	require.NoError(t, dbClient.MarkUsageMetricsAsSent(ctx, []int{pushed.ID}))
+
+	tests := []struct {
+		name     string
+		afterID  int
+		limit    int
+		expected []int
+	}{
+		{
+			name:     "everything pending, both types, already pushed rows excluded",
+			afterID:  0,
+			limit:    10,
+			expected: ids,
+		},
+		{
+			name:     "limit is honored, rows come back in id order",
+			afterID:  0,
+			limit:    2,
+			expected: ids[:2],
+		},
+		{
+			name:     "afterID skips the rows already consumed",
+			afterID:  ids[2],
+			limit:    10,
+			expected: ids[3:],
+		},
+		{
+			name:     "nothing left after the last row",
+			afterID:  ids[len(ids)-1],
+			limit:    10,
+			expected: []int{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			metrics, err := dbClient.GetUnsentMetrics(ctx, tc.afterID, tc.limit)
+			require.NoError(t, err)
+
+			got := make([]int, 0, len(metrics))
+			for _, m := range metrics {
+				got = append(got, m.ID)
+			}
+
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestMarkStaleUsageMetricsAsSent(t *testing.T) {
+	ctx := t.Context()
+	dbClient := getDBClient(t, ctx)
+
+	now := time.Now().UTC()
+
+	stale, err := dbClient.CreateMetric(ctx, metric.GeneratedTypeLP, "lp1", now.Add(-48*time.Hour), `{"metrics":[]}`)
+	require.NoError(t, err)
+
+	fresh, err := dbClient.CreateMetric(ctx, metric.GeneratedTypeLP, "lp1", now, `{"metrics":[]}`)
+	require.NoError(t, err)
+
+	dropped, err := dbClient.MarkStaleUsageMetricsAsSent(ctx, now.Add(-24*time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 1, dropped)
+
+	pending, err := dbClient.GetUnsentMetrics(ctx, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	require.Equal(t, fresh.ID, pending[0].ID)
+
+	// running it again is a no-op: the stale row is no longer pending
+	dropped, err = dbClient.MarkStaleUsageMetricsAsSent(ctx, now.Add(-24*time.Hour))
+	require.NoError(t, err)
+	require.Zero(t, dropped)
+
+	staleRow := dbClient.Ent.Metric.GetX(ctx, stale.ID)
+	require.NotNil(t, staleRow.PushedAt)
+}


### PR DESCRIPTION
Implement a hard limit on the payload for usage metrics to avoid memory consumption issues, or payload refused by CAPI that would lead to a snowball effect (payload is refused, but not marked as sent, we keep it for the next push, which will contain the new metrics, which would fail, and so on).

Also consider error response code as not retryable by default, and add exceptions for auth-related (401, 403) or rate limiting/not found.

Fixes #4603