### PR TITLE
CI: fix CAPI pull test on windows

### DIFF
--- a/pkg/apiserver/apic.go
+++ b/pkg/apiserver/apic.go
@@ -1061,7 +1061,14 @@ func (a *apic) Pull(ctx context.Context) error {
 			toldOnce = true
 		}
 
-		time.Sleep(1 * time.Second)
+		select {
+		case <-time.After(1 * time.Second):
+		case <-a.pullTomb.Dying():
+			a.metricsTomb.Kill(nil)
+			a.pushTomb.Kill(nil)
+
+			return nil
+		}
 	}
 
 	if err := a.PullTop(ctx, false); err != nil {

--- a/pkg/apiserver/apic_test.go
+++ b/pkg/apiserver/apic_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
-	"os"
 	"path/filepath"
 	"reflect"
 	"sync"
@@ -90,6 +89,26 @@ func absDiff(a int, b int) int {
 	}
 
 	return c
+}
+
+// safeBuffer collects log output written by a background goroutine while the test reads it.
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.String()
 }
 
 func assertTotalDecisionCount(t *testing.T, ctx context.Context, dbClient *database.Client, count int) {
@@ -1145,21 +1164,45 @@ func TestAPICPull(t *testing.T) {
 			)))
 			tc.setUp()
 
-			var buf bytes.Buffer
+			buf := &safeBuffer{}
+
+			oldOut := logrus.StandardLogger().Out
+			logrus.SetOutput(buf)
+
+			t.Cleanup(func() { logrus.SetOutput(oldOut) })
+
+			pullDone := make(chan error, 1)
 
 			go func() {
-				logrus.SetOutput(&buf)
-
-				if err := api.Pull(ctx); err != nil {
-					panic(err)
-				}
+				pullDone <- api.Pull(ctx)
 			}()
 
-			// Slightly long because the CI runner for windows are slow, and this can lead to random failure
-			time.Sleep(time.Millisecond * 500)
-			logrus.SetOutput(os.Stderr)
-			assert.Contains(t, buf.String(), tc.logContains)
-			assertTotalDecisionCount(t, ctx, api.dbClient, tc.expectedDecisionCount)
+			// join the pull routine before the buffer and the db go away, even if an assertion below fails
+			t.Cleanup(func() {
+				api.Shutdown()
+
+				select {
+				case err := <-pullDone:
+					assert.NoError(t, err)
+				case <-time.After(10 * time.Second):
+					t.Error("Pull() did not return after Shutdown()")
+				}
+			})
+
+			if tc.logContains != "" {
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Contains(c, buf.String(), tc.logContains)
+				}, 10*time.Second, 20*time.Millisecond)
+			}
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				decisions, err := api.dbClient.Ent.Decision.Query().All(ctx)
+				if !assert.NoError(c, err) {
+					return
+				}
+
+				assert.Len(c, decisions, tc.expectedDecisionCount)
+			}, 10*time.Second, 20*time.Millisecond)
 		})
 	}
 }


### PR DESCRIPTION
TestAPICPull/test_pull was flaky on Windows runners: the test started api.Pull() in a
goroutine, slept 500ms, then asserted the decision was in the DB, meaning that on a slow runner (windows) the write could happen after the assertion.

Test now waits for the condition (require.EventuallyWithT) instead of a fixed sleep, and
shuts down + joins the pull routine in a cleanup, so it no longer leaks a goroutine that
kept pulling against a closed DB for the rest of the package run.

apic.go: Pull()'s "waiting for scenarios" loop used a bare time.Sleep and ignored the
tomb, so the routine could not be stopped until a machine registered a scenario. It now
selects on pullTomb.Dying(). This is what made the leaked goroutine unstoppable in the
test, and it also blocks shutdown in production.