### PR TITLE
appsec: release the listeners when one of them fails

### DIFF
--- a/pkg/acquisition/modules/appsec/run.go
+++ b/pkg/acquisition/modules/appsec/run.go
@@ -25,6 +25,13 @@ func (w *Source) listenAndServe(ctx context.Context, t *tomb.Tomb) error {
 	serverError := make(chan error, 2)
 
 	startServer := func(listener net.Listener, canTLS bool) {
+		// The listener is this goroutine's to close. http.Server closes the ones
+		// it tracks, but it never gets to track this one when the TLS config is
+		// rejected below or by ServeTLS itself (a cert that fails to load returns
+		// before the listener reaches Serve), and an untracked listener is one
+		// Shutdown cannot release either.
+		defer listener.Close()
+
 		var err error
 
 		if canTLS && (w.config.CertFilePath != "" || w.config.KeyFilePath != "") {
@@ -93,34 +100,45 @@ func (w *Source) listenAndServe(ctx context.Context, t *tomb.Tomb) error {
 		startServer(listener, true)
 	}(w.config.ListenAddr)
 
+	// Whichever way this returns, the server goes with it. One listener failing
+	// to bind used to return straight away and leave the other one serving: the
+	// port stayed held for the lifetime of the process, and because nothing
+	// rebinds, every later reload failed on an address that was still in use
+	// while the rest of the process carried on looking healthy.
+	defer w.shutdownServer(ctx)
+
 	select {
 	case err := <-serverError:
 		return err
 	case <-t.Dying():
-		w.logger.Info("Shutting down Appsec server")
-		// xx let's clean up the appsec runners :)
-		appsec.AppsecRulesDetails = make(map[int]appsec.RulesDetails)
+		return nil
+	}
+}
 
-		if err := w.server.Shutdown(ctx); err != nil {
-			w.logger.Errorf("Error shutting down Appsec server: %s", err.Error())
-		}
+// shutdownServer stops the HTTP server and releases what the listeners hold.
+func (w *Source) shutdownServer(ctx context.Context) {
+	w.logger.Info("Shutting down Appsec server")
 
-		if w.AppsecRuntime != nil && w.AppsecRuntime.ChallengeRuntime != nil {
-			if err := w.AppsecRuntime.ChallengeRuntime.Close(ctx); err != nil {
-				w.logger.Errorf("Error closing challenge runtime: %s", err)
-			}
-		}
+	// xx let's clean up the appsec runners :)
+	appsec.AppsecRulesDetails = make(map[int]appsec.RulesDetails)
 
-		if w.config.ListenSocket != "" {
-			if err := os.Remove(w.config.ListenSocket); err != nil {
-				if !errors.Is(err, fs.ErrNotExist) {
-					w.logger.Errorf("can't remove socket %s: %s", w.config.ListenSocket, err)
-				}
-			}
+	if err := w.server.Shutdown(ctx); err != nil {
+		w.logger.Errorf("Error shutting down Appsec server: %s", err.Error())
+	}
+
+	if w.AppsecRuntime != nil && w.AppsecRuntime.ChallengeRuntime != nil {
+		if err := w.AppsecRuntime.ChallengeRuntime.Close(ctx); err != nil {
+			w.logger.Errorf("Error closing challenge runtime: %s", err)
 		}
 	}
 
-	return nil
+	if w.config.ListenSocket != "" {
+		if err := os.Remove(w.config.ListenSocket); err != nil {
+			if !errors.Is(err, fs.ErrNotExist) {
+				w.logger.Errorf("can't remove socket %s: %s", w.config.ListenSocket, err)
+			}
+		}
+	}
 }
 
 func (w *Source) StreamingAcquisition(ctx context.Context, out chan pipeline.Event, t *tomb.Tomb) error {

--- a/pkg/acquisition/modules/appsec/run_test.go
+++ b/pkg/acquisition/modules/appsec/run_test.go
@@ -1,0 +1,190 @@
+package appsecacquisition
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/tomb.v2"
+)
+
+// freeAddr returns a loopback address that was bindable a moment ago.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	addr := l.Addr().String()
+	require.NoError(t, l.Close())
+
+	return addr
+}
+
+func newTestSource(t *testing.T, cfg Configuration) *Source {
+	t.Helper()
+
+	w := &Source{
+		logger: log.NewEntry(log.StandardLogger()),
+		mux:    http.NewServeMux(),
+		config: cfg,
+	}
+	w.server = &http.Server{Addr: cfg.ListenAddr, Handler: w.mux}
+
+	return w
+}
+
+// runListenAndServe runs listenAndServe to completion and returns its error.
+func runListenAndServe(t *testing.T, w *Source) error {
+	t.Helper()
+
+	var tb tomb.Tomb
+
+	done := make(chan error, 1)
+
+	tb.Go(func() error {
+		done <- w.listenAndServe(context.Background(), &tb)
+		return nil
+	})
+
+	defer func() {
+		tb.Kill(nil)
+		_ = tb.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(30 * time.Second):
+		t.Fatal("listenAndServe did not return")
+		return nil
+	}
+}
+
+// requireAddrFree fails unless addr can be bound again.
+func requireAddrFree(t *testing.T, addr string) {
+	t.Helper()
+
+	// the goroutine that owns the listener releases it as it unwinds
+	require.Eventually(t, func() bool {
+		l, err := net.Listen("tcp", addr)
+		if err != nil {
+			return false
+		}
+
+		l.Close()
+
+		return true
+	}, 10*time.Second, 50*time.Millisecond, "%s is still bound after listenAndServe returned", addr)
+}
+
+// A listener that fails to bind must not leave the other one holding its port.
+// Before this was fixed, listenAndServe returned the error without shutting the
+// server down, so the surviving listener kept the port for the lifetime of the
+// process and every later reload failed with "address already in use" while the
+// rest of CrowdSec carried on looking healthy.
+func TestListenAndServeReleasesTCPWhenTheSocketFails(t *testing.T) {
+	addr := freeAddr(t)
+
+	w := newTestSource(t, Configuration{
+		ListenAddr: addr,
+		// a directory that does not exist, so the bind fails
+		ListenSocket: filepath.Join(t.TempDir(), "absent", "appsec.sock"),
+	})
+
+	require.Error(t, runListenAndServe(t, w))
+	requireAddrFree(t, addr)
+}
+
+// The mirror of the above: the TCP bind fails and the socket must be released.
+func TestListenAndServeReleasesSocketWhenTCPFails(t *testing.T) {
+	// hold the address so the appsec listener cannot have it
+	blocker, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	defer blocker.Close()
+
+	socket := filepath.Join(t.TempDir(), "appsec.sock")
+
+	w := newTestSource(t, Configuration{
+		ListenAddr:   blocker.Addr().String(),
+		ListenSocket: socket,
+	})
+
+	require.Error(t, runListenAndServe(t, w))
+
+	// the socket file is removed on the way out, so it can be bound again
+	require.Eventually(t, func() bool {
+		l, err := net.Listen("unix", socket)
+		if err != nil {
+			return false
+		}
+
+		l.Close()
+
+		return true
+	}, 10*time.Second, 50*time.Millisecond, "%s was not released", socket)
+}
+
+// A TLS listener that never reaches Serve is one the server never tracks, so
+// Shutdown cannot release it either - the goroutine that opened it has to.
+func TestListenAndServeReleasesTCPWhenTLSIsMisconfigured(t *testing.T) {
+	for name, cfg := range map[string]Configuration{
+		"cert file that does not exist": {
+			CertFilePath: filepath.Join(t.TempDir(), "absent.pem"),
+			KeyFilePath:  filepath.Join(t.TempDir(), "absent.key"),
+		},
+		"key file not configured": {
+			CertFilePath: filepath.Join(t.TempDir(), "absent.pem"),
+		},
+		"cert file not configured": {
+			KeyFilePath: filepath.Join(t.TempDir(), "absent.key"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg.ListenAddr = freeAddr(t)
+			w := newTestSource(t, cfg)
+
+			require.Error(t, runListenAndServe(t, w))
+			requireAddrFree(t, cfg.ListenAddr)
+		})
+	}
+}
+
+// The ordinary path still works: a clean shutdown releases the port.
+func TestListenAndServeReleasesTCPOnShutdown(t *testing.T) {
+	addr := freeAddr(t)
+	w := newTestSource(t, Configuration{ListenAddr: addr})
+
+	var tb tomb.Tomb
+
+	done := make(chan error, 1)
+
+	tb.Go(func() error {
+		done <- w.listenAndServe(context.Background(), &tb)
+		return nil
+	})
+
+	// wait until it is actually serving
+	require.Eventually(t, func() bool {
+		c, err := net.Dial("tcp", addr)
+		if err != nil {
+			return false
+		}
+
+		c.Close()
+
+		return true
+	}, 10*time.Second, 50*time.Millisecond, "appsec never started listening on %s", addr)
+
+	tb.Kill(nil)
+	require.NoError(t, <-done)
+	require.NoError(t, tb.Wait())
+
+	requireAddrFree(t, addr)
+}


### PR DESCRIPTION
## What and why

`listenAndServe` returned as soon as either listener sent to `serverError`, which skipped the shutdown block. The other listener stayed inside `Serve`, so its port was held for the lifetime of the process — and since nothing rebinds, every later reload failed on an address still in use while LAPI kept answering and the process looked healthy. One bad reload poisons all the following ones, which is the permanent death in #4545.

The server is now shut down on the way out whichever branch returns.

Second hole in the same function: a listener that never reaches `Serve` is not one the server tracks, so `Shutdown` cannot release it either. `ServeTLS` returns before `Serve` when `tls.LoadX509KeyPair` fails, and the missing key/cert checks in `startServer` return earlier still. The goroutine that opens a listener now closes it.

No retry loop — per @blotus in #4545, the bind is not meant to retry; the assumption that the previous server was already shut down is what was wrong.

Fixes #4545

## How it was tested

`go test ./pkg/acquisition/modules/appsec/...` — the whole package, plus `-race` on the new tests:

```
ok  	github.com/crowdsecurity/crowdsec/pkg/acquisition/modules/appsec	4.254s
```

The four new tests are deterministic and need no race window: a socket path whose directory does not exist makes the UDS bind fail while TCP succeeds, and vice versa.

With `run.go` reverted and the tests kept, exactly the leak cases fail and the clean-shutdown case still passes:

```
--- FAIL: TestListenAndServeReleasesTCPWhenTheSocketFails (10.00s)
--- FAIL: TestListenAndServeReleasesSocketWhenTCPFails (10.00s)
--- FAIL: TestListenAndServeReleasesTCPWhenTLSIsMisconfigured (30.01s)
    --- FAIL: .../key_file_not_configured (10.00s)
    --- FAIL: .../cert_file_not_configured (10.00s)
    --- FAIL: .../cert_file_that_does_not_exist (10.00s)
FAIL
```

Before the fix, the leak is visible directly:

```
listenAndServe returned: listen unix .../no-such-dir/appsec.sock: bind: ...
LEAK: 127.0.0.1:59929 is still bound after listenAndServe returned
```

`go vet ./pkg/acquisition/modules/appsec/...` clean. `make test` and `make lint` were not run here (Windows, no containers); the pre-existing `pkg/acquisition` docker config failures and the `cloudwatch` vet finding reproduce on a pristine tree.

## Checklist

- [x] One concern only.
- [x] No break to LAPI/CAPI payloads, database schema, config keys, or `cscli -o json|raw` output.
- [x] A human has reviewed this diff line by line.
- [x] A human has tested this change, not only an agent.

AI assistance used: mostly

/kind fix
/area appsec
