### PR TITLE
add HasValidChallengeCookie() helper

### DIFF
--- a/pkg/appsec/appsec.go
+++ b/pkg/appsec/appsec.go
@@ -245,6 +245,11 @@ type AppsecRequestState struct {
 	// the allowlist cookie itself, not by this flag.
 	ChallengeBypassed bool
 
+	// ChallengeCookieValid is set when the request presented a cookie that
+	// passed ValidCookie. Not cleared by ResetResponse: it stays true for
+	// the whole request, out-of-band included.
+	ChallengeCookieValid bool
+
 	// ChallengeExempt is set by the ExemptFromChallenge expr helper to exempt
 	// the current request from the bot challenge: SendChallenge becomes a no-op
 	// once it is set. It only affects the current request and doesn't mint a
@@ -300,6 +305,13 @@ func (s *AppsecRequestState) ResetResponse(cfg *AppsecConfig) {
 	s.SubmissionRejection = nil
 	s.ChallengeBypassed = false
 	s.HooksHalted = false
+}
+
+// HasValidChallengeCookie reports whether the request presented a valid
+// challenge cookie. A cookie minted during this request (submission,
+// GrantChallengeCookie) doesn't count — the visitor presents it on the next hop.
+func (s *AppsecRequestState) HasValidChallengeCookie() bool {
+	return s.ChallengeCookieValid
 }
 
 func (s *AppsecRequestState) DropInfo(request *ParsedRequest) *AppsecDropInfo {
@@ -1244,6 +1256,7 @@ func (w *AppsecRuntimeConfig) ProcessOnChallengeRules(ctx context.Context, state
 			fp.AllowlistReason = cookieData.AllowlistReason
 			state.Fingerprint = &fp
 			state.CookiePowDifficulty = cookieData.PowDifficulty
+			state.ChallengeCookieValid = true
 			// An allowlist cookie minted on a prior request must short-circuit
 			// SendChallenge on every replay, exactly like a GrantChallengeCookie
 			// call within the current request would. Without this, the visitor

--- a/pkg/appsec/appsec.go
+++ b/pkg/appsec/appsec.go
@@ -307,11 +307,12 @@ func (s *AppsecRequestState) ResetResponse(cfg *AppsecConfig) {
 	s.HooksHalted = false
 }
 
-// HasValidChallengeCookie reports whether the request presented a valid
-// challenge cookie. A cookie minted during this request (submission,
-// GrantChallengeCookie) doesn't count — the visitor presents it on the next hop.
+// HasValidChallengeCookie reports whether the request has cleared the
+// challenge: either it presented a valid cookie, or a hook exempted it. A
+// cookie minted during this request (submission, GrantChallengeCookie)
+// doesn't count — the visitor presents it on the next hop.
 func (s *AppsecRequestState) HasValidChallengeCookie() bool {
-	return s.ChallengeCookieValid
+	return s.ChallengeCookieValid || s.ChallengeExempt
 }
 
 func (s *AppsecRequestState) DropInfo(request *ParsedRequest) *AppsecDropInfo {

--- a/pkg/appsec/appsec_challenge_test.go
+++ b/pkg/appsec/appsec_challenge_test.go
@@ -473,6 +473,19 @@ func TestHasValidChallengeCookie(t *testing.T) {
 	}
 }
 
+func TestHasValidChallengeCookieOnExempt(t *testing.T) {
+	rt := newChallengeTestRuntime(t, nil)
+
+	state := &AppsecRequestState{}
+	state.ResetResponse(rt.Config)
+
+	req := newInBandRequest(http.MethodGet, "/protected", nil)
+
+	require.False(t, state.HasValidChallengeCookie())
+	require.NoError(t, rt.ExemptFromChallenge(state, req, "verified-bot"))
+	assert.True(t, state.HasValidChallengeCookie())
+}
+
 func TestHasValidChallengeCookieFalseOnGrant(t *testing.T) {
 	rt := newChallengeTestRuntime(t, nil)
 

--- a/pkg/appsec/appsec_challenge_test.go
+++ b/pkg/appsec/appsec_challenge_test.go
@@ -1,6 +1,7 @@
 package appsec
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"sync"
@@ -437,4 +438,80 @@ func TestGenerateResponseChallengeNilHeaders(t *testing.T) {
 		require.NotNil(t, body.UserHeaders)
 		assert.Equal(t, []string{challenge.DefaultChallengeCSP}, body.UserHeaders["Content-Security-Policy"])
 	})
+}
+
+func TestHasValidChallengeCookie(t *testing.T) {
+	rt := newChallengeTestRuntime(t, nil)
+
+	mintReq := newInBandRequest(http.MethodGet, "/", nil)
+	ck, err := rt.ChallengeRuntime.SealAllowlistCookie(mintReq.HTTPRequest, "has-valid-cookie", nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		cookie   string
+		expected bool
+	}{
+		{name: "no cookie", expected: false},
+		{name: "invalid cookie", cookie: "garbage", expected: false},
+		{name: "valid cookie", cookie: ck.Val, expected: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := newInBandRequest(http.MethodGet, "/protected", nil)
+			if tc.cookie != "" {
+				req.HTTPRequest.Header.Set("Cookie", challenge.ChallengeCookieName+"="+tc.cookie)
+			}
+
+			state := &AppsecRequestState{}
+			state.ResetResponse(rt.Config)
+
+			require.NoError(t, rt.ProcessOnChallengeRules(t.Context(), state, req))
+			assert.Equal(t, tc.expected, state.HasValidChallengeCookie())
+		})
+	}
+}
+
+func TestHasValidChallengeCookieFalseOnGrant(t *testing.T) {
+	rt := newChallengeTestRuntime(t, nil)
+
+	state := &AppsecRequestState{}
+	state.ResetResponse(rt.Config)
+
+	req := newInBandRequest(http.MethodGet, "/protected", nil)
+
+	require.NoError(t, rt.GrantChallengeCookie(state, req, "granted", nil))
+	assert.False(t, state.HasValidChallengeCookie())
+}
+
+func TestHasValidChallengeCookieInPreEval(t *testing.T) {
+	rt := newChallengeTestRuntime(t, nil)
+
+	compiled, err := buildHookList(t.Context(), []Hook{
+		{
+			Filter: "HasValidChallengeCookie()",
+			Apply:  []string{"SetRemediation('allow')"},
+		},
+	}, hookPreEval, &appsecExprPatcher{})
+	require.NoError(t, err)
+
+	for _, valid := range []bool{false, true} {
+		t.Run(fmt.Sprintf("valid=%t", valid), func(t *testing.T) {
+			state := &AppsecRequestState{HookVars: map[string]string{}}
+			state.ResetResponse(rt.Config)
+			state.ChallengeCookieValid = valid
+
+			req := newInBandRequest(http.MethodGet, "/protected", nil)
+
+			require.NoError(t, rt.processHooks(compiled, GetPreEvalEnv(t.Context(), rt, state, req), "pre_eval", state))
+
+			if valid {
+				require.NotNil(t, state.PendingAction)
+				assert.Equal(t, AllowRemediation, *state.PendingAction)
+			} else {
+				assert.Nil(t, state.PendingAction)
+			}
+		})
+	}
 }

--- a/pkg/appsec/patcher.go
+++ b/pkg/appsec/patcher.go
@@ -15,6 +15,8 @@ var challengeRuntimeCallees = map[string]struct{}{
 	"GrantChallengeCookie": {},
 	"RejectSubmission":     {},
 	"LogAccepted":          {},
+	// no runtime, no cookie validation: the helper would always return false
+	"HasValidChallengeCookie": {},
 }
 
 func (p *appsecExprPatcher) Visit(node *ast.Node) { //nolint:gocritic // signature fixed by expr-lang ast.Visitor interface

--- a/pkg/appsec/patcher_test.go
+++ b/pkg/appsec/patcher_test.go
@@ -46,3 +46,22 @@ func TestAppsecConfigBuildDoesNotDetectRequireValidChallengeWhenUnused(t *testin
 	require.NoError(t, err)
 	assert.False(t, runtimeCfg.NeedWASMVM)
 }
+
+func TestAppsecConfigBuildDetectsHasValidChallengeCookie(t *testing.T) {
+	logger := log.New()
+	logger.SetOutput(io.Discard)
+
+	cfg := AppsecConfig{
+		Logger: log.NewEntry(logger),
+		PreEval: []Hook{
+			{
+				Filter: "HasValidChallengeCookie()",
+				Apply:  []string{"SetRemediation(\"allow\")"},
+			},
+		},
+	}
+
+	runtimeCfg, err := cfg.Build(t.Context(), nil)
+	require.NoError(t, err)
+	assert.True(t, runtimeCfg.NeedWASMVM)
+}

--- a/pkg/appsec/waf_helpers.go
+++ b/pkg/appsec/waf_helpers.go
@@ -127,7 +127,8 @@ func GetPreEvalEnv(ctx context.Context, w *AppsecRuntimeConfig, state *AppsecReq
 			}
 			return w.GrantChallengeCookie(state, request, reason, ttlOverride)
 		},
-		"fingerprint": state.Fingerprint,
+		"fingerprint":             state.Fingerprint,
+		"HasValidChallengeCookie": state.HasValidChallengeCookie,
 		"ValidateRequestWithSchema": func(ref string) bool {
 			return w.ValidateRequestWithSchema(ctx, state, request, ref)
 		},
@@ -165,9 +166,10 @@ func GetPostEvalEnv(ctx context.Context, w *AppsecRuntimeConfig, state *AppsecRe
 		"DumpFingerprint": func(label string) string {
 			return DumpFingerprint(w.FingerprintDumpDir, label, state.Fingerprint, request)
 		},
-		"fingerprint":         state.Fingerprint,
-		"hook_vars":           state.HookVars,
-		"ExemptFromChallenge": func(reason string) error { return w.ExemptFromChallenge(state, request, reason) },
+		"fingerprint":             state.Fingerprint,
+		"hook_vars":               state.HookVars,
+		"HasValidChallengeCookie": state.HasValidChallengeCookie,
+		"ExemptFromChallenge":     func(reason string) error { return w.ExemptFromChallenge(state, request, reason) },
 		"AddRequestScore": func(points int, reason string) error {
 			return w.AddRequestScore(state, points, reason)
 		},
@@ -309,22 +311,23 @@ func GetOnChallengeSubmitEnv(w *AppsecRuntimeConfig, state *AppsecRequestState, 
 
 func GetOnMatchEnv(w *AppsecRuntimeConfig, state *AppsecRequestState, request *ParsedRequest, evt pipeline.Event) map[string]interface{} {
 	return map[string]interface{}{
-		"evt":                 evt,
-		"req":                 request.HTTPRequest,
-		"hook_vars":           state.HookVars,
-		"IsInBand":            request.IsInBand,
-		"IsOutBand":           request.IsOutBand,
-		"SetRemediation":      func(action string) error { return w.SetAction(state, action) },
-		"SetReturnCode":       func(code int) error { return w.SetHTTPCode(state, code) },
-		"CancelEvent":         func() error { return w.CancelEvent(state) },
-		"SendEvent":           func() error { return w.SendEvent(state) },
-		"CancelAlert":         func() error { return w.CancelAlert(state) },
-		"SendAlert":           func() error { return w.SendAlert(state) },
-		"DumpRequest":         request.DumpRequest,
-		"SetChallengeBody":    func(body string) error { return w.SetChallengeBody(state, body) },
-		"SetChallengeCookie":  func(cookie cookie.AppsecCookie) error { return w.SetChallengeCookie(state, cookie) },
-		"AppsecCookie":        cookie.NewAppsecCookie,
-		"ExemptFromChallenge": func(reason string) error { return w.ExemptFromChallenge(state, request, reason) },
+		"evt":                     evt,
+		"req":                     request.HTTPRequest,
+		"hook_vars":               state.HookVars,
+		"IsInBand":                request.IsInBand,
+		"IsOutBand":               request.IsOutBand,
+		"SetRemediation":          func(action string) error { return w.SetAction(state, action) },
+		"SetReturnCode":           func(code int) error { return w.SetHTTPCode(state, code) },
+		"CancelEvent":             func() error { return w.CancelEvent(state) },
+		"SendEvent":               func() error { return w.SendEvent(state) },
+		"CancelAlert":             func() error { return w.CancelAlert(state) },
+		"SendAlert":               func() error { return w.SendAlert(state) },
+		"DumpRequest":             request.DumpRequest,
+		"SetChallengeBody":        func(body string) error { return w.SetChallengeBody(state, body) },
+		"SetChallengeCookie":      func(cookie cookie.AppsecCookie) error { return w.SetChallengeCookie(state, cookie) },
+		"AppsecCookie":            cookie.NewAppsecCookie,
+		"ExemptFromChallenge":     func(reason string) error { return w.ExemptFromChallenge(state, request, reason) },
+		"HasValidChallengeCookie": state.HasValidChallengeCookie,
 		"AddRequestScore": func(points int, reason string) error {
 			return w.AddRequestScore(state, points, reason)
 		},


### PR DESCRIPTION
Add a new `HasValidChallengeCookie()` to check whether the request contains a valid challenge cookie.

Intended to  help protect access to API endpoints in applications that mostly acts as client for an API:
```yaml
pre_eval:
  - filter: "!HasValidChallengeCookie() && req.URL.Path startsWith '/api/'"
    apply:
      - DropRequest("need to solve challenge before hitting API")
```