### PR TITLE
Expand env vars in online_api_credentials.yaml

### DIFF
--- a/pkg/csconfig/api.go
+++ b/pkg/csconfig/api.go
@@ -1,7 +1,6 @@
 package csconfig
 
 import (
-	"bytes"
 	"cmp"
 	"crypto/tls"
 	"crypto/x509"
@@ -107,7 +106,9 @@ func (o *OnlineApiClientCfg) Load() error {
 		return err
 	}
 
-	dec := yaml.NewDecoder(bytes.NewReader(fcontent))
+	configData := csstring.StrictExpand(string(fcontent), os.LookupEnv)
+
+	dec := yaml.NewDecoder(strings.NewReader(configData))
 	dec.KnownFields(true)
 
 	err = dec.Decode(o.Credentials)

--- a/pkg/csconfig/api_test.go
+++ b/pkg/csconfig/api_test.go
@@ -118,7 +118,22 @@ func TestLoadOnlineApiClientCfg(t *testing.T) {
 			expected:    &ApiCredentialsCfg{},
 			expectedErr: "open ./testdata/nonexist_online-api-secrets.yaml: " + cstest.FileNotFoundMessage,
 		},
+		{
+			name: "configuration with env vars",
+			input: &OnlineApiClientCfg{
+				CredentialsFilePath: "./testdata/online-api-secrets-envvar.yaml",
+			},
+			expected: &ApiCredentialsCfg{
+				URL:      "http://crowdsec.api",
+				Login:    "test",
+				Password: "testpassword",
+				PapiURL:  PAPIBaseURL,
+			},
+		},
 	}
+
+	t.Setenv("TEST_ONLINE_API_LOGIN", "test")
+	t.Setenv("TEST_ONLINE_API_PASSWORD", "testpassword")
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/csconfig/testdata/online-api-secrets-envvar.yaml
+++ b/pkg/csconfig/testdata/online-api-secrets-envvar.yaml
@@ -1,0 +1,3 @@
+url: http://crowdsec.api
+login: ${TEST_ONLINE_API_LOGIN}
+password: ${TEST_ONLINE_API_PASSWORD}


### PR DESCRIPTION
## Summary
- `OnlineApiClientCfg.Load()` read `online_api_credentials.yaml` verbatim, so `${VAR}`/`$VAR` placeholders in `url`, `login`, or `password` were never substituted.
- Docker setups relying on env vars for CAPI credentials got the literal placeholder string instead of a value, and registration/authentication against CAPI failed.
- `local_api_credentials.yaml` and the main `config.yaml` already expand env vars through `csstring.StrictExpand`. This applies the same expansion to `OnlineApiClientCfg.Load()`; nothing else about that loader changes.

Fixes #4599.

Tested with `go test ./pkg/csconfig/...` and `go test ./pkg/apiserver/...` (`TEST_LOCAL_ONLY=1`), both pass, including a new case that reproduces the bug with env vars set via `t.Setenv`.

Reviewed the diff and the test results above before opening this PR.
